### PR TITLE
Fix incorrect escaping of U+000F

### DIFF
--- a/src/EPPlus/Utils/ConvertUtil.cs
+++ b/src/EPPlus/Utils/ConvertUtil.cs
@@ -234,7 +234,7 @@ namespace OfficeOpenXml.Utils
             {
                 if (t[i] <= 0x1f && ((t[i] != '\t' && t[i] != '\n' && t[i] != '\r' && encodeTabCRLF == false) || encodeTabCRLF)) //Not Tab, CR or LF
                 {
-                    sb.AppendFormat("_x00{0}_", (t[i] < 0xf ? "0" : "") + ((int)t[i]).ToString("X"));
+                    sb.AppendFormat("_x00{0}_", (t[i] <= 0xf ? "0" : "") + ((int)t[i]).ToString("X"));
                 }
                 else
                 {


### PR DESCRIPTION
The `SHIFT IN` control character with Unicode code point `U+000F` is incorrectly encoded as `_00F_`, and not `_000F_` as expected.