### PR TITLE
fix: Flushing async in SaveAsAsync

### DIFF
--- a/src/EPPlus/ExcelPackageAsync.cs
+++ b/src/EPPlus/ExcelPackageAsync.cs
@@ -319,7 +319,7 @@ namespace OfficeOpenXml
                 await outputStream.WriteAsync(buffer, 0, bytesRead).ConfigureAwait(false);
                 bytesRead = await inputStream.ReadAsync(buffer, 0, bufferLength).ConfigureAwait(false);
             }
-            outputStream.Flush();
+            await outputStream.FlushAsync();
         }
         internal async Task<byte[]> GetAsByteArrayAsync(bool save)
         {


### PR DESCRIPTION
CopyStreamAsync is not fully async, so it couses exception,when writing into aspnetcore output stream.

![image](https://user-images.githubusercontent.com/3385495/77238065-d8aba880-6be6-11ea-82d8-f7ba30045de6.png)
