### PR TITLE
Prevent rare infinite loop bug

### DIFF
--- a/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
+++ b/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
@@ -105,6 +105,12 @@ namespace OfficeOpenXml.ConditionalFormatting
             ExcelConditionalFormattingConstants.Paths.CfRule,
             _worksheet.NameSpaceManager);
 
+          // Checking the count of cfRuleNodes "materializes" the collection which prevents a rare infinite loop bug
+          if (cfRuleNodes.Count == 0)
+          {
+              continue;
+          }
+
           // Foreach <cfRule> inside the current <conditionalFormatting>
           foreach (XmlNode cfRuleNode in cfRuleNodes)
           {


### PR DESCRIPTION
It seems in some cases the 'XmlNodeList' returned by 'SelectNodes' on a Conditional Formatting Node can infinitely return the same nodes over and over.

Doing something as simple as merely accessing the Count property prevents this. 