### PR TITLE
LoadFromArrays always returns null

### DIFF
--- a/src/EPPlus/ExcelRangeBase_Load.cs
+++ b/src/EPPlus/ExcelRangeBase_Load.cs
@@ -232,7 +232,7 @@ namespace OfficeOpenXml
         public ExcelRangeBase LoadFromArrays(IEnumerable<object[]> Data)
         {
             //thanx to Abdullin for the code contribution
-            if (!(Data?.Any() ?? false)) throw new ArgumentNullException(nameof(Data));
+            if (!(Data?.Any() ?? false)) return null;
 
             var maxColumn = 0;
             var row = _fromRow;

--- a/src/EPPlus/ExcelRangeBase_Load.cs
+++ b/src/EPPlus/ExcelRangeBase_Load.cs
@@ -232,19 +232,16 @@ namespace OfficeOpenXml
         public ExcelRangeBase LoadFromArrays(IEnumerable<object[]> Data)
         {
             //thanx to Abdullin for the code contribution
-            if (Data == null) throw new ArgumentNullException("data");
+            if (!(Data?.Any() ?? false)) throw new ArgumentNullException(nameof(Data));
 
-            var rowArray = new List<object[]>();
             var maxColumn = 0;
             var row = _fromRow;
             foreach (object[] item in Data)
             {
-                //rowArray.Add(item);
                 _worksheet._values.SetValueRow_Value(row, _fromCol, item);
                 if (maxColumn < item.Length) maxColumn = item.Length;
                 row++;
             }
-            if (rowArray.Count == 0) return null; //Issue #57
             //_worksheet._values.SetRangeValueSpecial(_fromRow, _fromCol, _fromRow + rowArray.Count - 1, _fromCol + maxColumn - 1,
             //    (List<ExcelCoreValue> list, int index, int rowIx, int columnIx, object value) =>
             //    {
@@ -263,7 +260,7 @@ namespace OfficeOpenXml
             //        }
             //    }, rowArray);
 
-            return _worksheet.Cells[_fromRow, _fromCol, _fromRow + rowArray.Count - 1, _fromCol + maxColumn - 1];
+            return _worksheet.Cells[_fromRow, _fromCol, row - 1, _fromCol + maxColumn - 1];
         }
 #endregion
 #region LoadFromCollection

--- a/src/EPPlusTest/WorkSheetTests.cs
+++ b/src/EPPlusTest/WorkSheetTests.cs
@@ -1520,8 +1520,9 @@ namespace EPPlusTest
         public void LoadArray()
         {
             var ws = _pck.Workbook.Worksheets.Add("Loaded Array");
-            List<object[]> testArray = new List<object[]>() { new object[] { 3, 4, 5, 6 }, new string[] { "Test1", "test", "5", "6" } };
-            ws.Cells["A1"].LoadFromArrays(testArray);
+            List<object[]> testArray = new List<object[]>() { new object[] { 3, 4, 5 }, new string[] { "Test1", "test", "5", "6" } };
+            var range = ws.Cells["A1"].LoadFromArrays(testArray);
+            Assert.AreEqual("A1:D2", range.Address);
         }
         [TestMethod]
         public void SetBackground()


### PR DESCRIPTION
LoadFromArrays always returned null caused by missing/annotated rowArray.Add line.

New implementation removes unnecessary rowArray.