### PR TITLE
ParentNode can be null

### DIFF
--- a/src/EPPlus/Style/ExcelParagraphCollection.cs
+++ b/src/EPPlus/Style/ExcelParagraphCollection.cs
@@ -135,7 +135,7 @@ namespace OfficeOpenXml.Style
         {
             for (int ix = 0 ; ix < _paragraphs.Count; ix++)
             {
-                _paragraphs[ix].ParentNode.RemoveChild(_paragraphs[ix]);
+                _paragraphs[ix].ParentNode?.RemoveChild(_paragraphs[ix]);
             }
             _list.Clear();
             _paragraphs.Clear();


### PR DESCRIPTION
ParentNode can be null, i've hit a NullReferenceException here when trying to change the Text within an ExcelShape.

I have noticed alot of the code has simple null checks like this missing, would you be against a large pull request with alot of small changes like this one?