### PR TITLE
Formulas containing worksheet name only to reference entire sheet

### DIFF
--- a/src/EPPlus/ExcelAddress.cs
+++ b/src/EPPlus/ExcelAddress.cs
@@ -383,11 +383,18 @@ namespace OfficeOpenXml
                 }
                 if (pos>0)
                 {
-                    if (_ws[pos+1]!='!')
+                    if(_ws.Length-1==pos)
+                    {
+                        _address = "A:XFD";
+                    }
+                    else if (_ws[pos+1]!='!')
                     {
                         throw new InvalidOperationException($"Address is not valid {address}. Missing ! after sheet name.");
                     }
-                    _address = _ws.Substring(pos+2);
+                    else
+                    {
+                        _address = _ws.Substring(pos + 2);
+                    }
                     _ws = _ws.Substring(1, pos-1);
                     pos = _address.IndexOf(":'");
                     if(pos>0)
@@ -419,6 +426,10 @@ namespace OfficeOpenXml
             else
             {
                 _address = address;
+            }
+            if(string.IsNullOrEmpty(_address))
+            {
+                _address = "A:XFD";
             }
         }
         internal void ChangeWorksheet(string wsName, string newWs)
@@ -1634,9 +1645,12 @@ namespace OfficeOpenXml
             }
             else
             {
-                var cells = address.Split(':');
-                GetFixed(cells[0], out _fromRowFixed, out _fromColFixed);
-                GetFixed(cells[1], out _toRowFixed, out _toColFixed);
+                var cells = address.Split(':');                
+                if(cells.Length>1) //If 1 then the address is the entire worksheet
+                {
+                    GetFixed(cells[0], out _fromRowFixed, out _fromColFixed);
+                    GetFixed(cells[1], out _toRowFixed, out _toColFixed);
+                }
             }
         }
 

--- a/src/EPPlus/FormulaParsing/EpplusExcelDataProvider.cs
+++ b/src/EPPlus/FormulaParsing/EpplusExcelDataProvider.cs
@@ -369,7 +369,12 @@ namespace OfficeOpenXml.FormulaParsing
                 }
                 else
                 {
-                    return null;
+                    var wsName = _package.Workbook.Worksheets[name];
+                    if(wsName == null)
+                    {
+                        return null;
+                    }
+                    nameItem = new ExcelNamedRange(name, ws,wsName, "A:XFD", -1);
                 }
             }
             id = ExcelAddressBase.GetCellID(nameItem.LocalSheetId, nameItem.Index, 0);
@@ -384,7 +389,7 @@ namespace OfficeOpenXml.FormulaParsing
                 {
                     Id = id,
                     Name = name,
-                    Worksheet = nameItem.Worksheet==null ? nameItem._ws : nameItem.Worksheet.Name, 
+                    Worksheet = string.IsNullOrEmpty(worksheet) ? (nameItem.Worksheet==null ? nameItem._ws : nameItem.Worksheet.Name) : worksheet, 
                     Formula = nameItem.Formula
                 };
                 if (nameItem._fromRow > 0)

--- a/src/EPPlus/FormulaParsing/LexicalAnalysis/PostProcessing/TokenizerPostProcessor.cs
+++ b/src/EPPlus/FormulaParsing/LexicalAnalysis/PostProcessing/TokenizerPostProcessor.cs
@@ -187,7 +187,8 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis.PostProcessing
         private void HandleWorksheetNameToken()
         {
             // use this and the following three tokens
-            var tokenType = _navigator.GetTokenAtRelativePosition(3).GetTokenTypeFlags();
+            var relativeToken = _navigator.GetTokenAtRelativePosition(3);
+            var tokenType = relativeToken.GetTokenTypeFlags();
             ChangeTokenTypeOnCurrentToken(tokenType);
             var sb = new StringBuilder();
             var nToRemove = 3;
@@ -196,12 +197,22 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis.PostProcessing
                 ChangeTokenTypeOnCurrentToken(TokenType.InvalidReference);
                 nToRemove = _navigator.NbrOfRemainingTokens;
             }
-            else if (!_navigator.GetTokenAtRelativePosition(3).TokenTypeIsSet(TokenType.ExcelAddress) &&
-                    !_navigator.GetTokenAtRelativePosition(3).TokenTypeIsSet(TokenType.ExcelAddressR1C1))
+            if (relativeToken.TokenTypeIsSet(TokenType.Comma) ||
+               relativeToken.TokenTypeIsSet(TokenType.ClosingParenthesis))
+            {
+                for (var ix = 0; ix < 3; ix++)
+                {
+                    sb.Append(_navigator.GetTokenAtRelativePosition(ix).Value);
+                }
+                ChangeTokenTypeOnCurrentToken(TokenType.ExcelAddress);
+                nToRemove = 2;
+            }
+            else if (!relativeToken.TokenTypeIsSet(TokenType.ExcelAddress) &&
+                     !relativeToken.TokenTypeIsSet(TokenType.ExcelAddressR1C1))
             {
                 ChangeTokenTypeOnCurrentToken(TokenType.InvalidReference);
                 nToRemove--;
-            }
+            }            
             else
             {
                 for (var ix = 0; ix < 4; ix++)

--- a/src/EPPlusTest/Core/Range/RangeAddressTests.cs
+++ b/src/EPPlusTest/Core/Range/RangeAddressTests.cs
@@ -414,5 +414,30 @@ namespace EPPlusTest.Core.Range
             }
 
         }
-}
+        [TestMethod]
+        public void VerifyFullWorksheetAddress()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var ws1 = pck.Workbook.Worksheets.Add("FullSheet");
+                ws1.SetValue("A1", "Col1");
+                ws1.SetValue("B1", "Col2");
+                ws1.SetValue("A2", 1);
+                ws1.SetValue("B2", "Row 1");
+                ws1.SetValue("A3", 2);
+                ws1.SetValue("B3", "Row 2");
+                ws1.SetValue("A4", 3);
+                ws1.SetValue("B4", "Row 3");
+
+                var ws2 = pck.Workbook.Worksheets.Add("Formula");
+                ws2.SetFormula(1, 1, "VLOOKUP(2,FullSheet,2,FALSE)");
+                ws2.SetFormula(2, 1, "VLOOKUP(3,'FullSheet',2,FALSE)");
+                ws2.Calculate();
+                Assert.AreEqual("Row 2", ws2.Cells["A1"].Value);
+                Assert.AreEqual("Row 3", ws2.Cells["A2"].Value);
+            }
+
+        }
+
+    }
 }

--- a/src/EPPlusTest/FormulaParsing/FormulaParserTests.cs
+++ b/src/EPPlusTest/FormulaParsing/FormulaParserTests.cs
@@ -132,5 +132,6 @@ namespace EPPlusTest.FormulaParsing
         {
             _parser.ParseAt(null);
         }
+
     }
 }


### PR DESCRIPTION
Formulas can now reference the sheet name only to address the whole worksheet