### PR TITLE
Fix bug on VALUE function

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Value.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Value.cs
@@ -66,7 +66,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
                     val = "-" + numCandidate;
                 }
             }
-            if (Regex.IsMatch(val, $"^[\\d]*({Regex.Escape(_groupSeparator)}?[\\d]*)?({Regex.Escape(_decimalSeparator)}[\\d]*)*?[ ?% ?]?$", RegexOptions.Compiled))
+            if (Regex.IsMatch(val, $"^[\\d]*({Regex.Escape(_groupSeparator)}?[\\d]*)*?({Regex.Escape(_decimalSeparator)}[\\d]*)?[ ?% ?]?$", RegexOptions.Compiled))
             {
                 result = double.Parse(val, _cultureInfo);
                 return CreateResult(isPercentage ? result/100 : result, DataType.Decimal);

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/TextFunctionsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/TextFunctionsTests.cs
@@ -403,5 +403,18 @@ namespace EPPlusTest.Excel.Functions.Text
                 Assert.AreEqual(expected, sheet.Cells["A2"].Value);
             }
         }
+
+        [TestMethod]
+        public void ValueShouldReturnCorrectResult()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test");
+                sheet.Cells["A1"].Value = "1,234,567.89";
+                sheet.Cells["A2"].Formula = "VALUE(A1)";
+                sheet.Calculate();
+                Assert.AreEqual(1234567.89, sheet.Cells["A2"].Value);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix bug that VALUE function return !VALUE error when the input string has multiple comma (ex. 1,234,567.89)

Need to adjust the Regex string in file Value.cs.

New TestMethod "ValueShouldReturnCorrectResult" is added to test for this case.