### PR TITLE
Fixed xml formatting issue on SaveDrawings

### DIFF
--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -2366,7 +2366,12 @@ namespace OfficeOpenXml
                         HandleSaveForIndividualDrawings(d);
                     }
                     Packaging.ZipPackagePart partPack = Drawings.Part;
-                    Drawings.DrawingXml.Save(partPack.GetStream(FileMode.Create, FileAccess.Write));
+
+                    var stream      = partPack.GetStream(FileMode.Create, FileAccess.Write);
+                    var xr          = new XmlTextWriter(stream, Encoding.UTF8);
+                    xr.Formatting   = Formatting.None;
+
+                    Drawings.DrawingXml.Save(xr);
                 }
             }
         }


### PR DESCRIPTION
Bug with formatted text in a TextBox drawing object (#270). 
I've read the contributing guidelines and apologies but I don't know exactly how to create a unit test for this. 