### PR TITLE
Fix bugs when inserting and deleting column in ExcelTable

### DIFF
--- a/src/EPPlus/Table/ExcelTableColumnCollection.cs
+++ b/src/EPPlus/Table/ExcelTableColumnCollection.cs
@@ -172,7 +172,7 @@ namespace OfficeOpenXml.Table
                 {
                     _cols[i].Position = i;
                 }
-                _colNames = _cols.ToDictionary(x => x.Name, y => y.Id);
+                _colNames = _cols.ToDictionary(x => x.Name, y => y.Position);
                 return range;
             }
         }
@@ -199,7 +199,7 @@ namespace OfficeOpenXml.Table
                 {
                     _cols[i].Position = i;
                 }
-                _colNames = _cols.ToDictionary(x => x.Name, y => y.Id);
+                _colNames = _cols.ToDictionary(x => x.Name, y => y.Position);
 
                 return range;
             }


### PR DESCRIPTION
These 2 lines:
https://github.com/EPPlusSoftware/EPPlus/blob/eb24010f9ce5dd923262039cf6541d35b3dba1d4/src/EPPlus/Table/ExcelTableColumnCollection.cs#L175
https://github.com/EPPlusSoftware/EPPlus/blob/eb24010f9ce5dd923262039cf6541d35b3dba1d4/src/EPPlus/Table/ExcelTableColumnCollection.cs#L202
are wrong, because from the start, element value of _colNames is index in _cols:
https://github.com/EPPlusSoftware/EPPlus/blob/eb24010f9ce5dd923262039cf6541d35b3dba1d4/src/EPPlus/Table/ExcelTableColumnCollection.cs#L38
so that it can be used to access _cols:
https://github.com/EPPlusSoftware/EPPlus/blob/eb24010f9ce5dd923262039cf6541d35b3dba1d4/src/EPPlus/Table/ExcelTableColumnCollection.cs#L91

Also, I think there should be an overload of Insert method that allow to specify the new column's name:
https://github.com/EPPlusSoftware/EPPlus/blob/eb24010f9ce5dd923262039cf6541d35b3dba1d4/src/EPPlus/Table/ExcelTableColumnCollection.cs#L139