### PR TITLE
Update DataTableBuilder.cs

### DIFF
--- a/src/EPPlus/Export/ToDataTable/DataTableBuilder.cs
+++ b/src/EPPlus/Export/ToDataTable/DataTableBuilder.cs
@@ -78,7 +78,7 @@ namespace OfficeOpenXml.Export.ToDataTable
                     ;
                 var v = _sheet.GetValue(row, col);
                 if (row == _range.End.Row && v == null) throw new InvalidOperationException(string.Format("Column with index {0} does not contain any values", col));
-                var type = v.GetType();
+                var type = v == null ? typeof(Nullable) : v.GetType();
 
                 // check mapping
                 var mapping = _options.Mappings.GetByRangeIndex(columnIndex);


### PR DESCRIPTION
fix  ' object reference not set to an instance of an object ' if a middle column cell is null