### PR TITLE
CustomFilter should be case insensitive by default

### DIFF
--- a/src/EPPlus/Filter/FilterWildCardMatcher.cs
+++ b/src/EPPlus/Filter/FilterWildCardMatcher.cs
@@ -86,7 +86,7 @@ namespace OfficeOpenXml.Filter
             stringPos += anyChars;
             if (stringPos > value.Length) return false;
 
-            int foundPos = value.ToLowerInvariant().IndexOf(tokens[tokenPos].ToLowerInvariant(), stringPos);
+            int foundPos = value.IndexOf(tokens[tokenPos], stringPos, StringComparison.CurrentCultureIgnoreCase);
             while (foundPos>=0)
             {
                 bool match;
@@ -100,7 +100,7 @@ namespace OfficeOpenXml.Filter
                     match = MatchTokenList(value, tokens, foundPos + tokens[tokenPos].Length, tokenPos + 1);
                     if (match) return true;
                 }
-                foundPos = value.ToLowerInvariant().IndexOf(tokens[tokenPos].ToLowerInvariant(), foundPos+1);
+                foundPos = value.IndexOf(tokens[tokenPos], foundPos+1, StringComparison.CurrentCultureIgnoreCase);
             }
             return false;
         }

--- a/src/EPPlus/Filter/FilterWildCardMatcher.cs
+++ b/src/EPPlus/Filter/FilterWildCardMatcher.cs
@@ -86,7 +86,7 @@ namespace OfficeOpenXml.Filter
             stringPos += anyChars;
             if (stringPos > value.Length) return false;
 
-            int foundPos = value.IndexOf(tokens[tokenPos], stringPos);
+            int foundPos = value.ToLowerInvariant().IndexOf(tokens[tokenPos].ToLowerInvariant(), stringPos);
             while (foundPos>=0)
             {
                 bool match;
@@ -100,7 +100,7 @@ namespace OfficeOpenXml.Filter
                     match = MatchTokenList(value, tokens, foundPos + tokens[tokenPos].Length, tokenPos + 1);
                     if (match) return true;
                 }
-                foundPos = value.IndexOf(tokens[tokenPos], foundPos+1);
+                foundPos = value.ToLowerInvariant().IndexOf(tokens[tokenPos].ToLowerInvariant(), foundPos+1);
             }
             return false;
         }

--- a/src/EPPlusTest/Filter/CustomFilterTest.cs
+++ b/src/EPPlusTest/Filter/CustomFilterTest.cs
@@ -84,6 +84,30 @@ namespace EPPlusTest.Filter
             Assert.AreEqual(false, ws.Row(33).Hidden);
         }
         [TestMethod]
+        public void CustomContains()
+        {
+            var ws = _pck.Workbook.Worksheets.Add("StartsWith");
+            LoadTestdata(ws);
+            for (int row = 2; row <= ws.Dimension.Rows; row++)
+            {
+                if (row % 10 == 0)
+                {
+                    ws.Cells[row, 3].Value = ws.Cells[row, 3].Value.ToString().Replace("Value", "value");
+                }
+            }
+
+            ws.AutoFilterAddress = ws.Cells["A1:D100"];
+            var col = ws.AutoFilter.Columns.AddCustomFilterColumn(2);
+            col.Filters.Add(new ExcelFilterCustomItem("*value*"));
+            col.And = false;
+            ws.AutoFilter.ApplyFilter();
+
+            for (int row = 2; row <= ws.Dimension.Rows; row++)
+            {
+                Assert.AreEqual(false, ws.Row(row).Hidden);
+            }
+        }
+        [TestMethod]
         public void CustomNumericEqualOrGreaterThanOrEqual()
         {
             var ws = _pck.Workbook.Worksheets.Add("NumberEqOrGrEq");


### PR DESCRIPTION
As it's stated here: https://support.microsoft.com/en-us/office/filter-by-using-advanced-criteria-4c9222fe-8529-4cd7-a898-3f16abdff32b
"When filtering text data, Excel doesn't distinguish between uppercase and lowercase characters. "