### PR TITLE
Update ExcelWorksheetView.cs FreezePanes() method

### DIFF
--- a/src/EPPlus/ExcelWorksheetView.cs
+++ b/src/EPPlus/ExcelWorksheetView.cs
@@ -463,7 +463,7 @@ namespace OfficeOpenXml
         {
             //TODO:fix this method to handle splits as well.
             if (Row == 1 && Column == 1) UnFreezePanes();
-            string sqRef = SelectedRange, activeCell = ActiveCell;
+            string sqRef = SelectedRange, activeCell = "A1";
             
             XmlElement paneNode = TopNode.SelectSingleNode(_paneNodePath, NameSpaceManager) as XmlElement;
             if (paneNode == null)


### PR DESCRIPTION
When you try to open an .xlsx file as a template, then modify it with FreezePanes(int r, int c) method, then save as another .xlsx file
And it freezes r rows _after_ the active cell of template .xlsx file
