### PR TITLE
MATCH function with MatchType of ExactMatch should return #N/A when there are no exact matches

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
@@ -73,6 +73,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
                 }
             }
             while (navigator.MoveNext());
+
+            if (matchType == MatchType.ExactMatch && !lastValidIndex.HasValue)
+                return CreateResult(eErrorType.NA);
+
             return CreateResult(lastValidIndex, DataType.Integer);
         }
 

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/MatchTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/MatchTests.cs
@@ -74,5 +74,20 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
 
             Assert.AreEqual(2, _worksheet.Cells["A4"].Value);
         }
+
+        [TestMethod]
+        public void Match_Without_ExactMatch()
+        {
+            _worksheet.Cells["A1"].Value = "test";
+            _worksheet.Cells["A2"].Value = "value_to_match";
+            _worksheet.Cells["A3"].Value = "test";
+
+            //_worksheet.Cells["A4"].Value 
+            _worksheet.Cells["A4"].Formula = "MATCH(\"no_match\", A1:A3, 0)";
+
+            _worksheet.Calculate();
+
+            Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), _worksheet.Cells["A4"].Value);
+        }
     }
 }


### PR DESCRIPTION
Hi there,

We found an issue while testing some Excel spreadsheets when using the MATCH function.

When using a MatchType value of 0 (ExactMatch), the MATCH function would return a NULL instead of #N/A when there were no exact matches.

We created a test to validate the issue existed and have altered the Execute function in the Match class so that the test now passes.

We've tried to follow your guidelines, but we're still pretty new to "gitting" so please let us know if we need to make any alterations.

Nick