### PR TITLE
Use styles.CellXfs rather than Styles

### DIFF
--- a/src/EPPlus/ExcelRangeBase.cs
+++ b/src/EPPlus/ExcelRangeBase.cs
@@ -876,7 +876,7 @@ namespace OfficeOpenXml
                 if (_worksheet.Column(cell.Start.Column).Hidden)    //Issue 15338
                     continue;
 
-                if (cell.Merge == true || cell.Style.WrapText) continue;
+                if (cell.Merge == true || styles.CellXfs[cell.StyleID].WrapText) continue;
                 var fntID = styles.CellXfs[cell.StyleID].FontId;
                 Font f;
                 if (fontCache.ContainsKey(fntID))


### PR DESCRIPTION
This is faster than calling Styles, but I haven't verified it's correct. I see the same pattern was used in the next line, so I just cargo-culted the optimization.