### PR TITLE
Memoize measurestring

### DIFF
--- a/src/EPPlus/ExcelRangeBase.cs
+++ b/src/EPPlus/ExcelRangeBase.cs
@@ -871,6 +871,9 @@ namespace OfficeOpenXml
                 return;
             }
 
+            // This will call GDI+, and the result isn't cached.
+            // Calling this in the tight loop below is very slow.
+            var stringFormat = StringFormat.GenericDefault;
             foreach (var cell in this)
             {
                 if (_worksheet.Column(cell.Start.Column).Hidden)    //Issue 15338
@@ -899,7 +902,7 @@ namespace OfficeOpenXml
                 var textForWidth = cell.TextForWidth;
                 var t = textForWidth + (ind > 0 && !string.IsNullOrEmpty(textForWidth) ? new string('_', ind) : "");
                 if (t.Length > 32000) t = t.Substring(0, 32000); //Issue
-                var size = g.MeasureString(t, f, 10000, StringFormat.GenericDefault);
+                var size = g.MeasureString(t, f, 10000, stringFormat);
 
                 double width;
                 double r = styles.CellXfs[cell.StyleID].TextRotation;

--- a/src/EPPlus/ExcelRangeBase.cs
+++ b/src/EPPlus/ExcelRangeBase.cs
@@ -871,9 +871,35 @@ namespace OfficeOpenXml
                 return;
             }
 
+            #region MeasureString memoization
             // This will call GDI+, and the result isn't cached.
             // Calling this in the tight loop below is very slow.
             var stringFormat = StringFormat.GenericDefault;
+
+            // Sheets usually contain plenty of duplicates
+            // Measurestring is very slow, so memoizing yields massive performance benefits.
+            // We use the string hash rather than the string to reduce memory load and lookup/compare cost.
+            // This means columns can be wrongly calculated on hash collisions. Hash collisions are rare,
+            // and they might not affect the size calculation anyway.
+
+            // To support implementations without Tuple/ValueTuple,
+            // as well as reduce som overhead, we combine our two
+            // 32-bit keys in a single 64-bit value
+            var measureCache = new Dictionary<ulong, SizeF>();
+
+            SizeF MeasureString(string t, int fntID)
+            {
+                ulong key = ((ulong)t.GetHashCode() << 32) | (ulong)fntID;
+                if (!measureCache.TryGetValue(key, out var size))
+                {
+                    size = g.MeasureString(t, fontCache[fntID], 10000, stringFormat);
+                    measureCache.Add(key, size);
+                }
+
+                return size;
+            }
+            #endregion
+
             foreach (var cell in this)
             {
                 if (_worksheet.Column(cell.Start.Column).Hidden)    //Issue 15338
@@ -902,7 +928,7 @@ namespace OfficeOpenXml
                 var textForWidth = cell.TextForWidth;
                 var t = textForWidth + (ind > 0 && !string.IsNullOrEmpty(textForWidth) ? new string('_', ind) : "");
                 if (t.Length > 32000) t = t.Substring(0, 32000); //Issue
-                var size = g.MeasureString(t, f, 10000, stringFormat);
+                var size = MeasureString(t, fntID);
 
                 double width;
                 double r = styles.CellXfs[cell.StyleID].TextRotation;


### PR DESCRIPTION
- Note that this builds on top of another PR I have added (see first commit).
- Note that string hash collisions might generate wrong result in some cases. Is this acceptable?
- I didn't implement this for net35 as it didn't include Tuple.
- Used Tuple rather than ValueTuple for netframework as the project doesn't reference ValueTuple (should it?)
- If ValueTuple is included, the implementation would be simpler (and faster for netframework)
