### PR TITLE
Fix typo/grammatical error in exception message

### DIFF
--- a/src/EPPlus/Encryption/EncryptionHandler.cs
+++ b/src/EPPlus/Encryption/EncryptionHandler.cs
@@ -78,7 +78,7 @@ namespace OfficeOpenXml.Encryption
                 }
                 else
                 {
-                    throw (new InvalidDataException("The stream is not an valid/supported encrypted document."));
+                    throw (new InvalidDataException("The stream is not a valid/supported encrypted document."));
                 }
             }
             catch// (Exception ex)

--- a/src/EPPlus/Packaging/ZipPackage.cs
+++ b/src/EPPlus/Packaging/ZipPackage.cs
@@ -70,7 +70,7 @@ namespace OfficeOpenXml.Packaging
                     var e = zip.GetNextEntry();
                     if (e == null)
                     {
-                        throw (new InvalidDataException("The file is not an valid Package file. If the file is encrypted, please supply the password in the constructor."));
+                        throw (new InvalidDataException("The file is not a valid Package file. If the file is encrypted, please supply the password in the constructor."));
                     }
 
                     while (e != null)
@@ -127,11 +127,11 @@ namespace OfficeOpenXml.Packaging
                     }
                     if (!hasContentTypeXml)
                     {
-                        throw (new InvalidDataException("The file is not an valid Package file. If the file is encrypted, please supply the password in the constructor."));
+                        throw (new InvalidDataException("The file is not a valid Package file. If the file is encrypted, please supply the password in the constructor."));
                     }
                     if (!hasContentTypeXml)
                     {
-                        throw (new InvalidDataException("The file is not an valid Package file. If the file is encrypted, please supply the password in the constructor."));
+                        throw (new InvalidDataException("The file is not a valid Package file. If the file is encrypted, please supply the password in the constructor."));
                     }
                     zip.Close();
                     zip.Dispose();


### PR DESCRIPTION
Change " **an** valid" to " **a** valid"