### PR TITLE
Made ExcelVBAReference's Constructor Public

### DIFF
--- a/src/EPPlus/Vba/ExcelVBAReference.cs
+++ b/src/EPPlus/Vba/ExcelVBAReference.cs
@@ -21,7 +21,7 @@ namespace OfficeOpenXml.VBA
         /// Constructor.
         /// Defaults ReferenceRecordID to 0xD
         /// </summary>
-        internal ExcelVbaReference()
+        public ExcelVbaReference()
         {
             ReferenceRecordID = 0xD;
         }


### PR DESCRIPTION
This Constructor was originally public in EPPlus Major Version 4.X, but appears to have been made internal in Version 5.X's initial commit.

I have written software for work (commercially, and paid for version 5.X) that uses the constructor to add a reference to the VBA Scripting Library, and as a part of upgrading from 4.X, which had the ExcelVBAReference's Constructor as public, I need to still be able to instantiate instances of this type for the VBA code my exported XLSM files use.

I can conceive of a workaround to use reflection to instantiate the ExcelVbaReference despite the constructor now being internal instead of public, but I would prefer not to resort to reflection when I could use the default constructor.

The workaround would be:
`ExcelVbaReference reference = typeof(ExcelVbaReference).GetConstructor(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.CreateInstance, null, Type.EmptyTypes, null).Invoke(new object[] { }) as ExcelVbaReference;
`

I note that ExcelVbaReferenceControl which inherits from ExcelVbaReference also has an internal default constructor, but ExcelVbaReferenceProject's default constructor is actually public, leaving me confused as to why they would have inconsistent access modifiers.

This pull request solely focuses on the access modifier for ExcelVbaReference because that is narrowly within the scope of my needs, but I do suggest reviewing ExcelVbaReferenceControl as well to make that constructor public as well.