### PR TITLE
VBA Project name from sheet allows module name to be longer than 31 characters and corrupts

### DIFF
--- a/src/EPPlus/Vba/ExcelVBAProject.cs
+++ b/src/EPPlus/Vba/ExcelVBAProject.cs
@@ -1060,17 +1060,13 @@ namespace OfficeOpenXml.VBA
 
         internal string GetModuleNameFromWorksheet(ExcelWorksheet sheet)
         {
-            var name = sheet.Name;
-            name = name.Substring(0, name.Length < 31 ? name.Length : 31);  //Maximum 31 charachters
-            if (this.Modules[name] != null || !ExcelVBAModule.IsValidModuleName(name)) //Check for valid chars, if not valid, set to sheetX.
+            var name = "Sheet" + i.ToString();
+
+            while (this.Modules[name] != null)
             {
-                int i = sheet.PositionId;
-                name = "Sheet" + i.ToString();
-                while (this.Modules[name] != null)
-                {
                     name = "Sheet" + (++i).ToString();
-                }
             }
+
             return name;
         }
 

--- a/src/EPPlus/Vba/ExcelVBAProject.cs
+++ b/src/EPPlus/Vba/ExcelVBAProject.cs
@@ -1060,6 +1060,8 @@ namespace OfficeOpenXml.VBA
 
         internal string GetModuleNameFromWorksheet(ExcelWorksheet sheet)
         {
+            int i = sheet.PositionId;
+            
             var name = "Sheet" + i.ToString();
 
             while (this.Modules[name] != null)


### PR DESCRIPTION
We have a complex issue we are running into. 

We take a sheet as a "repeater", and copy that sheet a dynamic number of times, based on the data. 
ie. 3 real estate properties, take a base sheet, copy it 3 times for each property, then hide the base sheet. 

This has worked for us on EPPlus 4... for a long time. We recently upgraded to the latest 5 branch and have encountered corrupted workbooks. 

It only happens on workbooks that use macros, so a VBA Project, and when the sheet names are longer. 

We limit the sheet name to 31 characters in our code, but for some reason, when the name for the VBA Module is set, it adds a "Worksheet" pre-fix to it. Which then in turn makes the module name longer than 31 characters. 

To get around this, we set a name limit in our code of 17 characters to not go over 31 when "Worksheet" is prepended, however, this is not a workable solution as 17 characters is not enough space for a name to read correctly. 

Going through the code, I was able to resolve all problems by simply naming any module with the "sheet{x} naming convention. It seems like there is no reason the module name would need to use the name of the sheet in the first place as when viewed in the Excel VBA editor, it will give you the actual full sheet name in parenthesis. ie. sheet8 (actual sheet name displays here)

Maybe there is a better way to accomplish this than the edit I made. Other ideas are welcome. But we need to get around this in some way as the module names in VBA projects are exceeding 31 characters and corrupting our Excel models. 

Some sheet names may also start with numbers, like a property address. If that makes any difference. 


