### PR TITLE
#492 - support for file paths as strings in constructor and SaveAs

### DIFF
--- a/src/EPPlus/ExcelPackage.cs
+++ b/src/EPPlus/ExcelPackage.cs
@@ -254,6 +254,13 @@ namespace OfficeOpenXml
             ConstructNewFile(null);
         }
         /// <summary>
+		/// Create a new instance of the ExcelPackage class based on a existing file or creates a new file. 
+		/// </summary>
+		/// <param name="path">If newFile exists, it is opened.  Otherwise it is created from scratch.</param>
+        public ExcelPackage(string path)
+            : this(new FileInfo(path))
+        { }
+        /// <summary>
         /// Create a new instance of the ExcelPackage class based on a existing file or creates a new file. 
         /// </summary>
         /// <param name="newFile">If newFile exists, it is opened.  Otherwise it is created from scratch.</param>
@@ -264,6 +271,14 @@ namespace OfficeOpenXml
             File = newFile;
             ConstructNewFile(password);
         }
+        /// <summary>
+        /// Create a new instance of the ExcelPackage class based on a existing file or creates a new file. 
+        /// </summary>
+        /// <param name="path">If newFile exists, it is opened.  Otherwise it is created from scratch.</param>
+        /// <param name="password">Password for an encrypted package</param>
+        public ExcelPackage(string path, string password)
+            : this(new FileInfo(path), password)
+        { }
 		/// <summary>
 		/// Create a new instance of the ExcelPackage class based on a existing template.
 		/// If newFile exists, it will be overwritten when the Save method is called
@@ -289,6 +304,16 @@ namespace OfficeOpenXml
             File = newFile;
             CreateFromTemplate(template, password);
         }
+        /// <summary>
+        /// Create a new instance of the ExcelPackage class based on a existing template.
+        /// If newFile exists, it will be overwritten when the Save method is called
+        /// </summary>
+        /// <param name="newFilePath">The name of the Excel file to be created</param>
+        /// <param name="templatePath">The name of the Excel template to use as the basis of the new Excel file</param>
+        /// <param name="password">Password to decrypted the template</param>
+        public ExcelPackage(string newFilePath, string templatePath, string password)
+            : this(new FileInfo(newFilePath), new FileInfo(templatePath), password)
+        { }
         /// <summary>
         /// Create a new instance of the ExcelPackage class based on a existing template.
         /// </summary>
@@ -950,6 +975,15 @@ namespace OfficeOpenXml
         }
         /// <summary>
         /// Saves the workbook to a new file
+        /// The package is closed after it has been saved        
+        /// </summary>
+        /// <param name="filePath">The file location</param>
+        public void SaveAs(string filePath)
+        {
+            SaveAs(new FileInfo(filePath));
+        }
+        /// <summary>
+        /// Saves the workbook to a new file
         /// The package is closed after it has been saved
         /// </summary>
         /// <param name="file">The file</param>
@@ -960,6 +994,17 @@ namespace OfficeOpenXml
             File = file;
             Encryption.Password = password;
             Save();
+        }
+        /// <summary>
+        /// Saves the workbook to a new file
+        /// The package is closed after it has been saved
+        /// </summary>
+        /// <param name="filePath">The file</param>
+        /// <param name="password">The password to encrypt the workbook with. 
+        /// This parameter overrides the Encryption.Password.</param>
+        public void SaveAs(string filePath, string password)
+        {
+            SaveAs(new FileInfo(filePath), password);
         }
         /// <summary>
         /// Copies the Package to the Outstream

--- a/src/EPPlus/ExcelPackageAsync.cs
+++ b/src/EPPlus/ExcelPackageAsync.cs
@@ -36,6 +36,15 @@ namespace OfficeOpenXml
             var stream = fileInfo.OpenRead();
             await LoadAsync(stream, RecyclableMemory.GetStream(), null, cancellationToken).ConfigureAwait(false);
         }
+        /// <summary>
+        /// Loads the specified package data from a stream.
+        /// </summary>
+        /// <param name="filePath">The input file.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        public async Task LoadAsync(string filePath, CancellationToken cancellationToken = default)
+        {
+            await LoadAsync(new FileInfo(filePath), cancellationToken);
+        }
 
         /// <summary>
         /// Loads the specified package data from a stream.
@@ -47,6 +56,16 @@ namespace OfficeOpenXml
         {
             var stream = fileInfo.OpenRead();
             await LoadAsync(stream, RecyclableMemory.GetStream(), Password, cancellationToken).ConfigureAwait(false);
+        }
+        /// <summary>
+        /// Loads the specified package data from a stream.
+        /// </summary>
+        /// <param name="filePath">The input file.</param>
+        /// <param name="password">The password</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        public async Task LoadAsync(string filePath, string password, CancellationToken cancellationToken = default)
+        {
+            await LoadAsync(new FileInfo(filePath), password, cancellationToken);
         }
 
         /// <summary>
@@ -60,6 +79,17 @@ namespace OfficeOpenXml
         {
             var stream = fileInfo.OpenRead();
             await LoadAsync(stream, output, Password, cancellationToken).ConfigureAwait(false);
+        }
+        /// <summary>
+        /// Loads the specified package data from a stream.
+        /// </summary>
+        /// <param name="filePath">The input file.</param>
+        /// <param name="output">The out stream. Sets the Stream property</param>
+        /// <param name="password">The password</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        public async Task LoadAsync(string filePath, Stream output, string password, CancellationToken cancellationToken = default)
+        {
+            await LoadAsync(new FileInfo(filePath), output, password, cancellationToken);
         }
 
         /// <summary>
@@ -287,6 +317,16 @@ namespace OfficeOpenXml
             File = file;
             await SaveAsync(cancellationToken).ConfigureAwait(false); 
         }
+        /// <summary>
+        /// Saves the workbook to a new file
+        /// The package is closed after it has been saved        
+        /// </summary>
+        /// <param name="filePath">The file location</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        public async Task SaveAsAsync(string filePath, CancellationToken cancellationToken = default)
+        {
+            await SaveAsAsync(new FileInfo(filePath), cancellationToken);
+        }
 
         /// <summary>
         /// Saves the workbook to a new file
@@ -301,6 +341,18 @@ namespace OfficeOpenXml
             File = file;
             Encryption.Password = password;
             await SaveAsync(cancellationToken).ConfigureAwait(false);
+        }
+        /// <summary>
+        /// Saves the workbook to a new file
+        /// The package is closed after it has been saved
+        /// </summary>
+        /// <param name="filePath">The file</param>
+        /// <param name="password">The password to encrypt the workbook with. 
+        /// This parameter overrides the Encryption.Password.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        public async Task SaveAsAsync(string filePath, string password, CancellationToken cancellationToken = default)
+        {
+            await SaveAsAsync(new FileInfo(filePath), password, cancellationToken);
         }
 
         /// <summary>

--- a/src/EPPlusTest/ExcelPackageTests.cs
+++ b/src/EPPlusTest/ExcelPackageTests.cs
@@ -38,6 +38,24 @@ namespace EPPlusTest
     [TestClass]
     public class ExcelPackageTests
     {
-        
+        [TestMethod, Ignore]
+        public void ConstructorWithStringPath()
+        {
+            var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Test.xlsx");
+            using(var package = new ExcelPackage(path))
+            {
+
+            }
+        }
+
+        [TestMethod, Ignore]
+        public void ConstructorWithStringPathAndPassword()
+        {
+            var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Test.xlsx");
+            using (var package = new ExcelPackage(path, "pwd123"))
+            {
+
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #492 , support for file paths as strings in constructor and SaveAs