### PR TITLE
Bug/issue557

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/Logical/MaxIfs.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Logical/MaxIfs.cs
@@ -32,7 +32,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Logical
             var matches = GetMatches("MAXIFS", arguments, out CompileResult errorResult);
             if (errorResult != null)
                 return errorResult;
-            if (matches.Count() == 0) return CreateResult(eErrorType.NA);
+            if (matches.Count() == 0) return CreateResult(0d, DataType.Decimal);
             return CreateResult(matches.Max(), DataType.Decimal);
         }
     }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Logical/MinIfs.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Logical/MinIfs.cs
@@ -31,7 +31,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Logical
             var matches = GetMatches("MINIFS", arguments, out CompileResult errorResult);
             if (errorResult != null)
                 return errorResult;
-            if (matches.Count() == 0) return CreateResult(eErrorType.NA);
+            if (matches.Count() == 0) return CreateResult(0d, DataType.Decimal);
             return CreateResult(matches.Min(), DataType.Decimal);
         }
     }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MinAndMaxifsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MinAndMaxifsTests.cs
@@ -68,11 +68,11 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions
         }
 
         [TestMethod]
-        public void MaxIfsShouldReturnNaErrorIfNoMatch()
+        public void MaxIfsShouldReturnZeroIfNoMatch()
         {
             _worksheet.Cells["F1"].Formula = "MAXIFS(D3:D7,C3:C7,\"P\")";
             _worksheet.Calculate();
-            Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA).ToString(), _worksheet.Cells["F1"].Value.ToString());
+            Assert.AreEqual(0d, _worksheet.Cells["F1"].Value);
         }
 
         [TestMethod]
@@ -105,6 +105,14 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions
             _worksheet.Cells["F1"].Formula = "MINIFS(D3:D7,C3:C7,\"F\", B3:B7, \"Mi**nda\")";
             _worksheet.Calculate();
             Assert.AreEqual(82d, _worksheet.Cells["F1"].Value);
+        }
+
+        [TestMethod]
+        public void MinIfsShouldReturnZeroIfNoMatch()
+        {
+            _worksheet.Cells["F1"].Formula = "MINIFS(D3:D7,C3:C7,\"P\")";
+            _worksheet.Calculate();
+            Assert.AreEqual(0d, _worksheet.Cells["F1"].Value);
         }
     }
 }


### PR DESCRIPTION
I found a discrepancy between how Excel and EPPlus handle MINIFS or MAXIFS with no matches. I hope I have properly followed the contributing guidelines, so this is a no-brainer PR. Please find attached a sample workbook I made to verify the correctness of MS documentation at https://support.microsoft.com/en-us/office/minifs-function-6ca1ddaa-079b-4e74-80cc-72eef32e6599 and https://support.microsoft.com/en-us/office/maxifs-function-dfd611e6-da2c-488a-919b-9b6376b28883

[issue557.xlsx](https://github.com/EPPlusSoftware/EPPlus/files/7730139/issue557.xlsx)
 
Please let me know what else I can do to assist in getting this PR approved.