### PR TITLE
Fix null reference exception on ClearFormulas

### DIFF
--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -174,6 +174,8 @@ namespace OfficeOpenXml
         /// </summary>
         public void ClearFormulas()
         {
+            if (Dimension == null) return;
+
             var formulaCells = new CellStoreEnumerator<object>(_formulas, Dimension.Start.Row, Dimension.Start.Column, Dimension.End.Row, Dimension.End.Column);
             while (formulaCells.Next())
             {

--- a/src/EPPlusTest/WorkSheetTests.cs
+++ b/src/EPPlusTest/WorkSheetTests.cs
@@ -1853,6 +1853,17 @@ namespace EPPlusTest
         }
 
         [TestMethod]
+        public void ClearFormulasOnEmptySheetTest()
+        {
+            using (ExcelPackage package = new ExcelPackage())
+            {
+                var worksheet = package.Workbook.Worksheets.Add("Sheet1");
+                // Should not throw an exception
+                worksheet.ClearFormulas();
+            }
+        }
+
+        [TestMethod]
         public void ClearFormulasTest()
         {
             using (ExcelPackage package = new ExcelPackage())


### PR DESCRIPTION
When calling `ClearFormulas` on an empty worksheet, it was throwing a null reference exception since the `Dimension` variable was null due to not having any cells.