### PR TITLE
Issue #649 handline color override

### DIFF
--- a/src/EPPlus/ExcelStyles.cs
+++ b/src/EPPlus/ExcelStyles.cs
@@ -35,6 +35,7 @@ namespace OfficeOpenXml
     /// </summary>
     public sealed class ExcelStyles : XmlHelper
     {
+        const string ColorsPath = "d:colors/d:indexedColors/d:rgbColor";
         const string NumberFormatsPath = "d:numFmts";
         const string FontsPath = "d:fonts";
         const string FillsPath = "d:fills";
@@ -66,6 +67,17 @@ namespace OfficeOpenXml
         /// </summary>
         private void LoadFromDocument()
         {
+            //colors
+            XmlNodeList colorNodes = GetNodes(ColorsPath);
+            if (colorNodes != null && colorNodes.Count > 0)
+            {
+                int index = 0;
+                foreach (XmlNode node in colorNodes)
+                {
+                    ExcelColor.indexedColors[index++] = "#" + node.Attributes["rgb"].InnerText;
+                }
+            }
+
             //NumberFormats
             ExcelNumberFormatXml.AddBuildIn(NameSpaceManager, NumberFormats);
             XmlNode numNode = GetNode(NumberFormatsPath);

--- a/src/EPPlus/Style/ExcelColor.cs
+++ b/src/EPPlus/Style/ExcelColor.cs
@@ -25,7 +25,7 @@ namespace OfficeOpenXml.Style
     /// </summary>
     public sealed class ExcelColor :  StyleBase, IColor
     {
-        internal static readonly string[] indexedColors =
+        internal static string[] indexedColors =
         {
                 "#FF000000", // 0
                 "#FFFFFFFF",


### PR DESCRIPTION
#649  this change overrides the default index color mappings with then ones contained in the worksheet style.