### PR TITLE
Fix finding worksheets with invalid chars in name

### DIFF
--- a/src/EPPlus/ExcelWorksheets.cs
+++ b/src/EPPlus/ExcelWorksheets.cs
@@ -577,13 +577,14 @@ namespace OfficeOpenXml
             }
             return null;
         }
-        internal ExcelWorksheet GetByName(string Name)
+        internal ExcelWorksheet GetByName(string name)
         {
-            if (string.IsNullOrEmpty(Name)) return null;
+            name = ValidateFixSheetName(name);
+            if (string.IsNullOrEmpty(name)) return null;
             ExcelWorksheet ws = null;
             foreach (ExcelWorksheet worksheet in _worksheets)
             {
-                if (worksheet.Name.Equals(Name, StringComparison.OrdinalIgnoreCase))
+                if (worksheet.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
                     ws = worksheet;
             }
             return (ws);

--- a/src/EPPlusTest/WorksheetsTests.cs
+++ b/src/EPPlusTest/WorksheetsTests.cs
@@ -179,7 +179,16 @@ namespace EPPlusTest
 			Assert.AreEqual("NEW8", workbook.Worksheets.First().Name);
 			Assert.AreEqual("NEW1", workbook.Worksheets[1].Name);
 		}
-		private static void CompareOrderOfWorksheetsAfterSaving(ExcelPackage editedPackage)
+        [TestMethod]
+        public void GetOrAddWorksheets()
+        {
+			if (workbook.Worksheets["[NEW2]"] == null)
+                workbook.Worksheets.Add("[NEW2]");
+
+            if (workbook.Worksheets["[NEW2]"] == null)
+                workbook.Worksheets.Add("[NEW2]");
+        }
+        private static void CompareOrderOfWorksheetsAfterSaving(ExcelPackage editedPackage)
 		{
 			var packageStream = new MemoryStream();
 			editedPackage.SaveAs(packageStream);


### PR DESCRIPTION
I was trying to write my own GetOrAdd method in my project and got test fails because of "[" and "]" symbols. I think that lib should have same behavior for "Add(name)" and "[name]". So i just add validator from "Add" method.

If we do not want to change indexer, i can add method GetOrAdd. For now, i cannot do this with public API (ValidateFixSheetName is internal).