### PR TITLE
Fix #690: Preserve column/row ranges on row/column insert

### DIFF
--- a/src/EPPlus/ExcelNamedRangeCollection.cs
+++ b/src/EPPlus/ExcelNamedRangeCollection.cs
@@ -145,11 +145,11 @@ namespace OfficeOpenXml
             foreach(var namedRange in namedRanges)
             {
                 var address = new ExcelAddressBase(namedRange.Address);
-                if (rows > 0 && address._toCol<=upperLimit && address._fromCol>=lowerLimint)
+                if (rows > 0 && address._toCol<=upperLimit && address._fromCol>=lowerLimint && !(address._fromRow == 1 && address._toRow == ExcelPackage.MaxRows))
                 {
                     address = address.AddRow(rowFrom, rows);
                 }
-                if(cols > 0 && colFrom > 0 && address._toRow <= upperLimit && address._fromRow >= lowerLimint)
+                if(cols > 0 && colFrom > 0 && address._toRow <= upperLimit && address._fromRow >= lowerLimint && !(address._fromCol == 1 && address._toCol == ExcelPackage.MaxColumns))
                 {
                     address = address.AddColumn(colFrom, cols);
                 }

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -3534,5 +3534,37 @@ namespace EPPlusTest
                 Assert.IsTrue((bool)sheet1.Cells["C3"].Value);
             }
         }
+
+        [TestMethod]
+        public void I690InsertRow()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                pck.Workbook.Names.Add("ColumnRange", new ExcelRangeBase(sheet1, "Sheet1!$C:$C"));
+                
+                var rangeAddress = pck.Workbook.Names["ColumnRange"].Address;
+
+                sheet1.InsertRow(1, 1);
+
+                Assert.AreEqual(pck.Workbook.Names["ColumnRange"].Address, rangeAddress);
+            }
+        }
+
+        [TestMethod]
+        public void I690InsertColumn()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                pck.Workbook.Names.Add("RowRange", new ExcelRangeBase(sheet1, "Sheet1!$7:$7"));
+
+                var rangeAddress = pck.Workbook.Names["RowRange"].Address;
+
+                sheet1.InsertColumn(1, 1);
+
+                Assert.AreEqual(pck.Workbook.Names["RowRange"].Address, rangeAddress);
+            }
+        }
     }
 }


### PR DESCRIPTION
When there are defined names referencing a whole column (e.g. `Sheet1!$C:$C`), inserting rows fails to update the range: `Sheet1!Sheet1!$C1:#REF!`.

Same issue for named row ranges and inserting columns.

This fixes the issue (see https://github.com/EPPlusSoftware/EPPlus/issues/690)