### PR TITLE
Configure method on the ExcelPackage class

### DIFF
--- a/src/EPPlus/Configuration/ExcelPackageConfiguration.cs
+++ b/src/EPPlus/Configuration/ExcelPackageConfiguration.cs
@@ -1,0 +1,84 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  08/19/2022         EPPlus Software AB       Implementing handling of initialization errors in ExcelPackage class.
+ *************************************************************************************************/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace OfficeOpenXml.Configuration
+{
+    /// <summary>
+    /// Parameters for configuring the <see cref="ExcelPackage"/> class before usage
+    /// </summary>
+    public class ExcelPackageConfiguration
+    {
+        /// <summary>
+        /// If set to true errors/exceptions that occurs during initialization of the ExcelPackage class will
+        /// be suppressed and logged in <see cref="ExcelPackage.InitializationErrors"/>.
+        /// 
+        /// If set to false these Exceptions will be rethrown.
+        /// 
+        /// Default value of this property is false.
+        /// </summary>
+        public bool SuppressInitializationExceptions
+        {
+            get; set;
+        }
+
+        private string _basePath = Directory.GetCurrentDirectory();
+        /// <summary>
+        /// Path of the directory where the json configuration file is located.
+        /// Default value is the path returned from <see cref="System.IO.Directory.GetCurrentDirectory"/>
+        /// </summary>
+        public string BasePath
+        {
+            get { return _basePath; }
+            set { _basePath = value; }
+        }
+
+        private string _jsonConfigFileName = "appsettings.json";
+        /// <summary>
+        /// File name of the json configuration file.
+        /// Default value is appsettings.json
+        /// </summary>
+        public string JsonConfigFileName
+        {
+            get { return _jsonConfigFileName; }
+            set { _jsonConfigFileName = value; }
+        }
+
+        /// <summary>
+        /// Configuration with default values.
+        /// </summary>
+        internal static ExcelPackageConfiguration Default
+        {
+            get { return new ExcelPackageConfiguration(); }
+        }
+
+        internal void CopyFrom(ExcelPackageConfiguration other)
+        {
+            _basePath = other.BasePath;
+            _jsonConfigFileName = other.JsonConfigFileName;
+            SuppressInitializationExceptions = other.SuppressInitializationExceptions;
+        }
+
+        /// <summary>
+        /// Resets configuration to its default values
+        /// </summary>
+        public void Reset()
+        {
+            CopyFrom(Default);
+        }
+    }
+}

--- a/src/EPPlus/Configuration/ExcelPackageConfiguration.cs
+++ b/src/EPPlus/Configuration/ExcelPackageConfiguration.cs
@@ -36,15 +36,15 @@ namespace OfficeOpenXml.Configuration
             get; set;
         }
 
-        private string _basePath = Directory.GetCurrentDirectory();
+        private string _jsonConfigBasePath = Directory.GetCurrentDirectory();
         /// <summary>
         /// Path of the directory where the json configuration file is located.
         /// Default value is the path returned from <see cref="System.IO.Directory.GetCurrentDirectory"/>
         /// </summary>
-        public string BasePath
+        public string JsonConfigBasePath
         {
-            get { return _basePath; }
-            set { _basePath = value; }
+            get { return _jsonConfigBasePath; }
+            set { _jsonConfigBasePath = value; }
         }
 
         private string _jsonConfigFileName = "appsettings.json";
@@ -68,7 +68,7 @@ namespace OfficeOpenXml.Configuration
 
         internal void CopyFrom(ExcelPackageConfiguration other)
         {
-            _basePath = other.BasePath;
+            _jsonConfigBasePath = other.JsonConfigBasePath;
             _jsonConfigFileName = other.JsonConfigFileName;
             SuppressInitializationExceptions = other.SuppressInitializationExceptions;
         }

--- a/src/EPPlus/ExcelConfigurationReader.cs
+++ b/src/EPPlus/ExcelConfigurationReader.cs
@@ -13,6 +13,7 @@
 #if (Core)
 using Microsoft.Extensions.Configuration;
 #endif
+using OfficeOpenXml.Configuration;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -24,15 +25,16 @@ namespace OfficeOpenXml
     internal static class ExcelConfigurationReader
     {
         /// <summary>
-        /// Reads an environment variable from the o/s. If an error occors it will rethrow the <see cref="Exception"/> unless <paramref name="supressInitExceptions"/> is set to true.
+        /// Reads an environment variable from the o/s. If an error occors it will rethrow the <see cref="Exception"/> unless SuppressInitializationExceptions of the <paramref name="config"/> is set to true.
         /// </summary>
         /// <param name="key">The key of the requested variable</param>
         /// <param name="target">The <see cref="EnvironmentVariableTarget"/></param>
-        /// <param name="supressInitExceptions">If true any Exception will be supressed and logged.</param>
+        /// <param name="config">Configuration of the package</param>
         /// <param name="initErrors">A list of logged <see cref="ExcelInitializationError"/> objects.</param>
         /// <returns>The value of the environment variable</returns>
-        internal static string GetEnvironmentVariable(string key, EnvironmentVariableTarget target, bool supressInitExceptions, List<ExcelInitializationError> initErrors)
+        internal static string GetEnvironmentVariable(string key, EnvironmentVariableTarget target, ExcelPackageConfiguration config, List<ExcelInitializationError> initErrors)
         {
+            var supressInitExceptions = config.SuppressInitializationExceptions;
             try
             {
                 return Environment.GetEnvironmentVariable(key, target);
@@ -54,21 +56,25 @@ namespace OfficeOpenXml
         }
 
 #if (Core)
-        internal static string GetJsonConfigValue(string key, bool supressInitExceptions, List<ExcelInitializationError> initErrors)
+        internal static string GetJsonConfigValue(string key, ExcelPackageConfiguration config, List<ExcelInitializationError> initErrors)
         {
+            var supressInitExceptions = config.SuppressInitializationExceptions;
+            var basePath = config.BasePath;
+            var configFileName = config.JsonConfigFileName;
             var configRoot = default(IConfigurationRoot);
             try
             {
+                
                 var build = new ConfigurationBuilder()
-                       .SetBasePath(Directory.GetCurrentDirectory())
-                       .AddJsonFile("appsettings.json", true, false);
+                       .SetBasePath(basePath)
+                       .AddJsonFile(configFileName, true, false);
                 configRoot = build.Build();
             }
             catch (Exception ex)
             {
                 if (supressInitExceptions)
                 {
-                    var errorMessage = "Could not load configuration file \"appsettings.json\"";
+                    var errorMessage = $"Could not load configuration file \"{configFileName}\"";
                     var error = new ExcelInitializationError(errorMessage, ex);
                     initErrors.Add(error);
                 }

--- a/src/EPPlus/ExcelConfigurationReader.cs
+++ b/src/EPPlus/ExcelConfigurationReader.cs
@@ -1,0 +1,103 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  08/19/2022         EPPlus Software AB       Implementing handling of initialization errors in ExcelPackage class.
+ *************************************************************************************************/
+#if (Core)
+using Microsoft.Extensions.Configuration;
+#endif
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace OfficeOpenXml
+{
+    internal static class ExcelConfigurationReader
+    {
+        /// <summary>
+        /// Reads an environment variable from the o/s. If an error occors it will rethrow the <see cref="Exception"/> unless <paramref name="supressInitExceptions"/> is set to true.
+        /// </summary>
+        /// <param name="key">The key of the requested variable</param>
+        /// <param name="target">The <see cref="EnvironmentVariableTarget"/></param>
+        /// <param name="supressInitExceptions">If true any Exception will be supressed and logged.</param>
+        /// <param name="initErrors">A list of logged <see cref="ExcelInitializationError"/> objects.</param>
+        /// <returns>The value of the environment variable</returns>
+        internal static string GetEnvironmentVariable(string key, EnvironmentVariableTarget target, bool supressInitExceptions, List<ExcelInitializationError> initErrors)
+        {
+            try
+            {
+                return Environment.GetEnvironmentVariable(key, target);
+            }
+            catch (Exception ex)
+            {
+                if (supressInitExceptions)
+                {
+                    var errorMessage = $"Could not read environment variable \"{key}\"";
+                    var error = new ExcelInitializationError(errorMessage, ex);
+                    initErrors.Add(error);
+                }
+                else
+                {
+                    throw;
+                }
+            }
+            return default;
+        }
+
+#if (Core)
+        internal static string GetJsonConfigValue(string key, bool supressInitExceptions, List<ExcelInitializationError> initErrors)
+        {
+            var configRoot = default(IConfigurationRoot);
+            try
+            {
+                var build = new ConfigurationBuilder()
+                       .SetBasePath(Directory.GetCurrentDirectory())
+                       .AddJsonFile("appsettings.json", true, false);
+                configRoot = build.Build();
+            }
+            catch (Exception ex)
+            {
+                if (supressInitExceptions)
+                {
+                    var errorMessage = "Could not load configuration file \"appsettings.json\"";
+                    var error = new ExcelInitializationError(errorMessage, ex);
+                    initErrors.Add(error);
+                }
+                else
+                {
+                    throw;
+                }
+            }
+            if (configRoot != null)
+            {
+                try
+                {
+                    var v = configRoot[key];
+                    return v;
+                }
+                catch (Exception ex)
+                {
+                    if (supressInitExceptions)
+                    {
+                        var errorMessage = $"Could read key \"{key}\" from appsettings.json";
+                        var error = new ExcelInitializationError(errorMessage, ex);
+                        initErrors.Add(error);
+                        return null;
+                    }
+                    throw;
+                }
+            }
+            return null;
+        }
+#endif
+    }
+}

--- a/src/EPPlus/ExcelConfigurationReader.cs
+++ b/src/EPPlus/ExcelConfigurationReader.cs
@@ -59,7 +59,7 @@ namespace OfficeOpenXml
         internal static string GetJsonConfigValue(string key, ExcelPackageConfiguration config, List<ExcelInitializationError> initErrors)
         {
             var supressInitExceptions = config.SuppressInitializationExceptions;
-            var basePath = config.BasePath;
+            var basePath = config.JsonConfigBasePath;
             var configFileName = config.JsonConfigFileName;
             var configRoot = default(IConfigurationRoot);
             try

--- a/src/EPPlus/ExcelInitializationError.cs
+++ b/src/EPPlus/ExcelInitializationError.cs
@@ -1,0 +1,60 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  08/19/2022         EPPlus Software AB       Implementing handling of initialization errors in ExcelPackage class.
+ *************************************************************************************************/
+using OfficeOpenXml.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OfficeOpenXml
+{
+    /// <summary>
+    /// This class represents an error/Exception that has occured during initalization.
+    /// </summary>
+    public class ExcelInitializationError
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="errorMessage"></param>
+        /// <param name="e"></param>
+        internal ExcelInitializationError(string errorMessage, Exception e)
+        {
+            Require.Argument(errorMessage).IsNotNullOrEmpty("errorMessage");
+            Require.Argument(e).IsNotNull("e");
+            ErrorMessage = errorMessage;
+            Exception = e;
+            TimestampUtc = DateTime.UtcNow;
+        }
+
+        private ExcelInitializationError()
+        {
+
+        }
+
+        /// <summary>
+        /// Error message describing the initialization error
+        /// </summary>
+        public string ErrorMessage { get; private set; }
+
+        /// <summary>
+        /// Timestamp representing when the error occurred
+        /// </summary>
+        public DateTime TimestampUtc { get; private set; }
+
+        /// <summary>
+        /// The <see cref="Exception"/>
+        /// </summary>
+        public Exception Exception { get; private set; }
+    }
+}

--- a/src/EPPlus/ExcelPackage.cs
+++ b/src/EPPlus/ExcelPackage.cs
@@ -730,7 +730,7 @@ namespace OfficeOpenXml
         {
             _configuration.SuppressInitializationExceptions = config.SuppressInitializationExceptions;
             _configuration.JsonConfigFileName = config.JsonConfigFileName;
-            _configuration.BasePath = config.BasePath;
+            _configuration.JsonConfigBasePath = config.JsonConfigBasePath;
         }
 
         /// <summary>

--- a/src/EPPlus/FormulaParsing/ExcelCalculationOption.cs
+++ b/src/EPPlus/FormulaParsing/ExcelCalculationOption.cs
@@ -34,7 +34,7 @@ namespace OfficeOpenXml.FormulaParsing
             AllowCircularReferences = false;
             PrecisionAndRoundingStrategy = PrecisionAndRoundingStrategy.DotNet;
 #if (Core)
-            var basePath = ExcelPackage.GlobalConfiguration.BasePath;
+            var basePath = ExcelPackage.GlobalConfiguration.JsonConfigBasePath;
             var configFileName = ExcelPackage.GlobalConfiguration.JsonConfigFileName;
             var build = new ConfigurationBuilder()
                 .SetBasePath(basePath)

--- a/src/EPPlus/FormulaParsing/ExcelCalculationOption.cs
+++ b/src/EPPlus/FormulaParsing/ExcelCalculationOption.cs
@@ -26,14 +26,19 @@ namespace OfficeOpenXml.FormulaParsing
     /// </summary>
     public class ExcelCalculationOption
     {
+        /// <summary>
+        /// Constructor
+        /// </summary>
         public ExcelCalculationOption()
         {
             AllowCircularReferences = false;
             PrecisionAndRoundingStrategy = PrecisionAndRoundingStrategy.DotNet;
 #if (Core)
+            var basePath = ExcelPackage.GlobalConfiguration.BasePath;
+            var configFileName = ExcelPackage.GlobalConfiguration.JsonConfigFileName;
             var build = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", true, false);
+                .SetBasePath(basePath)
+                .AddJsonFile(configFileName, true, false);
             var c = build.Build();
 
             var configValue = c["EPPlus:ExcelPackage:AllowCircularReferences"];

--- a/src/EPPlusTest/GlobalConfiguration/ConfigurePackageTests.cs
+++ b/src/EPPlusTest/GlobalConfiguration/ConfigurePackageTests.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using OfficeOpenXml.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EPPlusTest.GlobalConfiguration
+{
+#if (Core)
+    [TestClass]
+    public class ConfigurePackageTests
+    {
+        [TestMethod]
+        public void ShouldSetSuppressInitExceptions()
+        {
+            lock(typeof(ExcelPackage))
+            {
+
+                try
+                {
+                    ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+                    ExcelPackage.Configure(x => { 
+                        x.SuppressInitializationExceptions = true;
+                        x.JsonConfigFileName = "asdf";
+                        x.BasePath = "JKLÖ";
+                    });
+                    using(var package = new ExcelPackage())
+                    {
+                        Assert.IsTrue(package.InitializationErrors.Count() > 0);
+                        Assert.AreEqual(1, package.InitializationErrors.Count());
+                    }
+                }
+                finally
+                {
+                    ExcelPackage.Configure(x => x.Reset());
+                }
+            }
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentException))]
+        public void ShouldThrowArgumentExceptionIfErrorsAreNotSuppressed()
+        {
+            lock(typeof(ExcelPackage))
+            {
+                ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+                ExcelPackage.Configure(x => { 
+                    x.SuppressInitializationExceptions = false;
+                    x.JsonConfigFileName = "asdf";
+                    x.BasePath = "JKLÖ";
+                });
+                try
+                {
+                    using(var package = new ExcelPackage())
+                    {
+                        Assert.IsTrue(package.InitializationErrors.Count() > 0);
+                        Assert.AreEqual(1, package.InitializationErrors.Count());
+                    }
+                }
+                finally
+                {
+                    ExcelPackage.Configure(x => x.Reset());
+                }
+            
+            }
+        }
+    }
+#endif
+}

--- a/src/EPPlusTest/GlobalConfiguration/ConfigurePackageTests.cs
+++ b/src/EPPlusTest/GlobalConfiguration/ConfigurePackageTests.cs
@@ -25,7 +25,7 @@ namespace EPPlusTest.GlobalConfiguration
                     ExcelPackage.Configure(x => { 
                         x.SuppressInitializationExceptions = true;
                         x.JsonConfigFileName = "asdf";
-                        x.BasePath = "JKLÖ";
+                        x.JsonConfigBasePath = "JKLÖ";
                     });
                     using(var package = new ExcelPackage())
                     {
@@ -49,7 +49,7 @@ namespace EPPlusTest.GlobalConfiguration
                 ExcelPackage.Configure(x => { 
                     x.SuppressInitializationExceptions = false;
                     x.JsonConfigFileName = "asdf";
-                    x.BasePath = "JKLÖ";
+                    x.JsonConfigBasePath = "JKLÖ";
                 });
                 try
                 {


### PR DESCRIPTION
There is a new static method on ExcelPackage - `Configure(Action<ExcelPackageConfiguration> configHandler)`

With this new method the following values can be set:
- `SuppressInitializationExceptions` - Exceptions that occurs during the constructor due to failures to read configuration values from config file and/or environment variables will be suppressed and logged.
- `BasePath` - the folder where the json configuration file will be read from
- `JsonConfigFileName` - file name of the json configuration file.

There is also a new property on the ExcelPackage class called `InitializationErrors`, which is an enumerable of ExcelInitializationError. This property will contain errors that has ben logged if `SuppressInitializationException` is set to true.

### Example
```csharp
ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
// The values set for the configuration file below will cause
// an Exception to be thrown since they are not a valid file path.
ExcelPackage.Configure(x => { 
    x.SuppressInitializationExceptions = false;
    x.JsonConfigFileName = "asdf";
    x.BasePath = "JKLÖ";
});
try
{
    using(var package = new ExcelPackage())
    {
        Assert.IsTrue(package.InitializationErrors.Count() > 0);
        Assert.AreEqual(1, package.InitializationErrors.Count());
    }
}
finally
{
    ExcelPackage.Configure(x => x.Reset());
}
```