### PR TITLE
Bugfix for issue 780: skip merged cells that are null when adding a n…

### DIFF
--- a/src/EPPlus/Table/ExcelTableCollection.cs
+++ b/src/EPPlus/Table/ExcelTableCollection.cs
@@ -85,6 +85,7 @@ namespace OfficeOpenXml.Table
             }
             foreach (var mc in _ws.MergedCells)
             {
+                if (mc == null) continue; // Issue 780: this happens if a merged cell has been removed
                 if (new ExcelAddressBase(mc).Collide(Range) != ExcelAddressBase.eAddressCollition.No)
                 {
                     throw (new ArgumentException($"Table range collides with merged range {mc}"));

--- a/src/EPPlusTest/Table/TableTests.cs
+++ b/src/EPPlusTest/Table/TableTests.cs
@@ -653,5 +653,29 @@ namespace EPPlusTest.Table
                 SaveAndCleanup(p);
             }
         }
+        [TestMethod]
+        public void CreateTableAfterDeletingAMergedCell()
+        {
+            // Reproduce issue 780
+            using (var package = new ExcelPackage())
+            {
+                var worksheet = package.Workbook.Worksheets.Add("Sheet1");
+
+                // Prepare some data
+                worksheet.Cells["A1"].Value = "Column 1";
+                worksheet.Cells["A2"].Value = 1;
+                worksheet.Cells["B1"].Value = "Column 2";
+                worksheet.Cells["B2"].Value = 2;
+
+                // Merge cells in row 4 (not related to the data above)
+                worksheet.Cells["A4:B4"].Merge = true;
+                // Delete the row that has the merged cells
+                worksheet.DeleteRow(4);
+
+                // Create a table
+                var tableCells = worksheet.Cells["A1:B2"];
+                var table = worksheet.Tables.Add(tableCells, "table"); // --> This triggers a NullReferenceException
+            }
+        }
     }
 }


### PR DESCRIPTION
This is a one-line fix.

* Added a unit test to reproduce the issue
* ExcelTableCollection: skip MergedCells that are null

fixes #780 