### PR TITLE
Invalid Cast

### DIFF
--- a/src/EPPlus/Core/Worksheet/WorksheetRangeInsertHelper.cs
+++ b/src/EPPlus/Core/Worksheet/WorksheetRangeInsertHelper.cs
@@ -775,7 +775,7 @@ namespace OfficeOpenXml.Core.Worksheet
             var tokens = ws._formulaTokens.GetValue(row, column);
             if(tokens==null)
             {
-                tokens = (List<Token>)_sct.Tokenize(formula, ws.Name);
+                tokens = _sct.Tokenize(formula, ws.Name).ToList();
                 ws._formulaTokens.SetValue(row, column, tokens);
             }
             return tokens;


### PR DESCRIPTION
The _sct.Tokenize(formula, ws.Name) is not a List<Token>, so the cast is failing. The root cause is the mismatch between all the types IEnumerable<>, IList<>, List<>

A quick fix would be to convert to a list.
This function seem to be pressure-sensitive, so merely converting to a list will not be memory-optimal.

The SourceCodeTokenizer.Tokenize needs to return a correct type to avoid list re-creation.