### PR TITLE
Invalid Cast

### DIFF
--- a/src/EPPlus/FormulaParsing/LexicalAnalysis/SourceCodeTokenizer.cs
+++ b/src/EPPlus/FormulaParsing/LexicalAnalysis/SourceCodeTokenizer.cs
@@ -50,11 +50,13 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
         {
             return Tokenize(input, null);
         }
+
+        private readonly static IList<Token> _emptyList = (new List<Token>()).AsReadOnly();
         public IEnumerable<Token> Tokenize(string input, string worksheet)
         {
             if (string.IsNullOrEmpty(input))
             {
-                return Enumerable.Empty<Token>();
+                return _emptyList;
             }
             // MA 1401: Ignore leading plus in formula.
             input = input.TrimStart('+');


### PR DESCRIPTION
`Enumerable.Empty<Token>()` is not a `List<Token>`.

But the calling functions are explicitly casting the result of `Tokenize` from `IEnumerable<Token>` to `List<Token>`, causing cast mismatch.

I have no confidence to clean up the callers, so it is better to harmonize this returning type. The caller's assumption must be `List<Token>` everywhere.