### PR TITLE
Bugfix Attribute xml encoding

### DIFF
--- a/src/EPPlus/ExcelXMLWriter/ExcelXmlWriter.cs
+++ b/src/EPPlus/ExcelXMLWriter/ExcelXmlWriter.cs
@@ -30,6 +30,7 @@ using System.Security;
 using System.Text;
 using System.Xml.Linq;
 using static OfficeOpenXml.ExcelWorksheet;
+using OfficeOpenXml.XMLWritingEncoder;
 
 namespace OfficeOpenXml.ExcelXMLWriter
 {
@@ -616,22 +617,22 @@ namespace OfficeOpenXml.ExcelXMLWriter
 
             if (string.IsNullOrEmpty(_ws.DataValidations[i].ErrorTitle) == false)
             {
-                cache.Append($"errorTitle=\"{_ws.DataValidations[i].ErrorTitle}\" ");
+                cache.Append($"errorTitle=\"{_ws.DataValidations[i].ErrorTitle.EncodeXMLAttribute()}\" ");
             }
 
             if (string.IsNullOrEmpty(_ws.DataValidations[i].Error) == false)
             {
-                cache.Append($"error=\"{_ws.DataValidations[i].Error}\" ");
+                cache.Append($"error=\"{_ws.DataValidations[i].Error.EncodeXMLAttribute()}\" ");
             }
 
             if (string.IsNullOrEmpty(_ws.DataValidations[i].PromptTitle) == false)
             {
-                cache.Append($"promptTitle=\"{_ws.DataValidations[i].PromptTitle}\" ");
+                cache.Append($"promptTitle=\"{_ws.DataValidations[i].PromptTitle.EncodeXMLAttribute()}\" ");
             }
 
             if (string.IsNullOrEmpty(_ws.DataValidations[i].Prompt) == false)
             {
-                cache.Append($"prompt=\"{_ws.DataValidations[i].Prompt}\" ");
+                cache.Append($"prompt=\"{_ws.DataValidations[i].Prompt.EncodeXMLAttribute()}\" ");
             }
 
             if (_ws.DataValidations.HasValidationType(InternalValidationType.DataValidation))

--- a/src/EPPlus/XMLWritingEncoder/AttributeEncoder.cs
+++ b/src/EPPlus/XMLWritingEncoder/AttributeEncoder.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OfficeOpenXml.XMLWritingEncoder
+{
+    internal static class AttributeEncoder
+    {
+        /// <summary>
+        /// Encode to XML (special characteres: &apos; &quot; &gt; &lt; &amp;)
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        internal static string EncodeXMLAttribute(this string s)
+        {
+            return s.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;").Replace("'", "&apos;");
+        }
+
+    }
+}


### PR DESCRIPTION
Files with quotation marks  ("")  in Prompt or prompt titles were not being encoded properly causing corrupt workbooks.