### PR TITLE
Bug/i861 faulty row styles

### DIFF
--- a/src/EPPlus/ExcelStyles.cs
+++ b/src/EPPlus/ExcelStyles.cs
@@ -448,10 +448,11 @@ namespace OfficeOpenXml
                 {
                     //iterate all columns and set the row to the style of the last column
                     var cse = new CellStoreEnumerator<ExcelValue>(ws._values, 0, 1, 0, ExcelPackage.MaxColumns);
+                    var cs = 0;
                     while (cse.Next())
                     {
-                        s = cse.Value._styleId;
-                        if (s == 0) continue;
+                        cs = cse.Value._styleId;
+                        if (cs == 0) continue;
                         var c = ws.GetValueInner(cse.Row, cse.Column) as ExcelColumn;
                         if (c != null && c.ColumnMax < ExcelPackage.MaxColumns)
                         {
@@ -459,12 +460,12 @@ namespace OfficeOpenXml
                             {
                                 if (!ws.ExistsStyleInner(rowNum, col))
                                 {
-                                    ws.SetStyleInner(rowNum, col, s);
+                                    ws.SetStyleInner(rowNum, col, cs);
                                 }
                             }
                         }
                     }
-                    ws.SetStyleInner(rowNum, 0, s);
+                    ws.SetStyleInner(rowNum, 0, cs);
                     cse.Dispose();
                 }
                 if (styleCashe.ContainsKey(s))

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -4665,5 +4665,25 @@ namespace EPPlusTest
             }
         }
 
+        [TestMethod]
+        public void Issue861()
+        {
+            var ep = new ExcelPackage();
+            var ws = ep.Workbook.Worksheets.Add("Test");
+
+            for (int row = 1; row < 10; ++row)
+                for (int col = 1; col < 10; ++col)
+                    ws.Cells[row, col].Value = $"{row}:{col}";
+
+            var wsCol = ws.Column(3);
+            wsCol.Style.Border.Left.Style = wsCol.Style.Border.Right.Style = ExcelBorderStyle.Thick;
+            wsCol.Style.Fill.SetBackground(System.Drawing.Color.Black);
+
+            ws.Row(3).Style.Fill.SetBackground(System.Drawing.Color.Aqua);
+
+            Assert.AreNotEqual(ws.Row(3).Style.Border.Left.Style, wsCol.Style.Border.Left.Style);
+            Assert.AreNotEqual(ws.Row(3).Style.Border.Right.Style, wsCol.Style.Border.Right.Style);
+        }
+
     }
 }


### PR DESCRIPTION
RowStyle was being updated on every row instead of only on rows that overlapped with the appropriate column. Fixed by ensuring row style index wasn't updated when column style (cs) needed to be.