### PR TITLE
DataValidation extLst writing bugFix

### DIFF
--- a/src/EPPlus/ExcelXMLWriter/ExcelXmlWriter.cs
+++ b/src/EPPlus/ExcelXMLWriter/ExcelXmlWriter.cs
@@ -637,7 +637,7 @@ namespace OfficeOpenXml.ExcelXMLWriter
                 cache.Append($"prompt=\"{_ws.DataValidations[i].Prompt.EncodeXMLAttribute()}\" ");
             }
 
-            if (_ws.DataValidations.HasValidationType(InternalValidationType.DataValidation))
+            if (_ws.DataValidations[i].InternalValidationType == InternalValidationType.DataValidation)
             {
                 cache.Append($"sqref=\"{_ws.DataValidations[i].Address.ToString().Replace(",", " ")}\" ");
             }
@@ -705,7 +705,7 @@ namespace OfficeOpenXml.ExcelXMLWriter
                 if (extNode != "")
                 {
                     //write adress if extLst
-                    cache.Append($"<xm:sqref>{_ws.DataValidations[i].Address}</xm:sqref>");
+                    cache.Append($"<xm:sqref>{_ws.DataValidations[i].Address.ToString().Replace(",", " ")}</xm:sqref>");
                 }
             }
 
@@ -897,13 +897,12 @@ namespace OfficeOpenXml.ExcelXMLWriter
         {
             var cache = new StringBuilder();
 
-            cache.Append($"<ext uri=\"{ExtLstUris.DataValidationsUri}\">");
+            cache.Append($"<ext xmlns:x14=\"{ExcelPackage.schemaMainX14}\" uri=\"{ExtLstUris.DataValidationsUri}\">");
 
             prefix = "x14:";
             cache.Append
             (
-            UpdateDataValidation(prefix,
-                $"xmlns:x14=\"{ExcelPackage.schemaMainX14}\" uri=\"{{CCE6A557-97BC-4b89-ADB6-D9C93CAAB3DF}}\" " + $"xmlns:xm=\"{ExcelPackage.schemaMainXm}\"")
+            UpdateDataValidation(prefix, $"xmlns:xm=\"{ExcelPackage.schemaMainXm}\"")
             );
             cache.Append("</ext>");
 

--- a/src/EPPlusTest/DataValidation/ExtLstValidationTests.cs
+++ b/src/EPPlusTest/DataValidation/ExtLstValidationTests.cs
@@ -176,6 +176,121 @@ namespace EPPlusTest.DataValidation
             Assert.AreEqual(InternalValidationType.ExtLst, validations[4].InternalValidationType);
         }
 
+        internal void AddDataValidations(ref ExcelWorksheet ws, bool isExtLst = false, string extSheetName = "", bool many = false)
+        {
+            if (isExtLst)
+            {
+                var intValidation = ws.DataValidations.AddIntegerValidation("A1");
+                intValidation.Operator = ExcelDataValidationOperator.equal;
+                intValidation.Formula.ExcelFormula = extSheetName + "!A1";
+            }
+            else
+            {
+                var intValidation = ws.DataValidations.AddIntegerValidation("A2");
+                intValidation.Formula.Value = 1;
+                intValidation.Formula2.Value = 3;
+            }
+
+            if (many)
+            {
+
+                if (isExtLst)
+                {
+                    var timeValidation = ws.DataValidations.AddTimeValidation("B1");
+                    timeValidation.Operator = ExcelDataValidationOperator.between;
+
+                    timeValidation.Formula.ExcelFormula = extSheetName + "!B1";
+                    timeValidation.Formula2.ExcelFormula = extSheetName + "!B2";
+
+
+                }
+                else
+                {
+                    var timeValidation = ws.DataValidations.AddTimeValidation("B2");
+                    timeValidation.Operator = ExcelDataValidationOperator.between;
+
+                    timeValidation.Formula.ExcelFormula = "B1";
+                    timeValidation.Formula.ExcelFormula = "B2";
+                }
+            }
+        }
+
+        //Ensures no save or load errors
+        internal void SaveAndLoadAndSave(in ExcelPackage pck)
+        {
+            var file = pck.File;
+
+            var stream = new MemoryStream();
+            pck.SaveAs(stream);
+
+            var loadedPackage = new ExcelPackage(stream);
+
+            loadedPackage.File = file;
+
+            SaveAndCleanup(loadedPackage);
+        }
+
+        [TestMethod]
+        public void LocalDataValidationsShouldWorkWithExtLstValidation()
+        {
+            using (var pck = OpenPackage("DataValidationLocalExtLst.xlsx", true))
+            {
+                var ws = pck.Workbook.Worksheets.Add("extLstTest");
+                var extSheet = pck.Workbook.Worksheets.Add("extAddressSheet");
+
+                AddDataValidations(ref ws, false);
+                AddDataValidations(ref ws, true, "extAddressSheet");
+
+                SaveAndLoadAndSave(pck);
+            }
+        }
+
+        [TestMethod]
+        public void LocalDataValidationsShouldWorkWithManyExtLstValidations()
+        {
+            using (var pck = OpenPackage("DataValidationLocalExtLstMany.xlsx", true))
+            {
+                var ws = pck.Workbook.Worksheets.Add("extLstTest");
+                var extSheet = pck.Workbook.Worksheets.Add("extAddressSheet");
+
+                AddDataValidations(ref ws, false);
+                AddDataValidations(ref ws, true, "extAddressSheet", true);
+
+                SaveAndLoadAndSave(pck);
+            }
+        }
+
+        [TestMethod]
+        public void ManyLocalDataValidationsShouldWorkWithSingularExtLstValidations()
+        {
+            using (var pck = OpenPackage("DataValidationLocalManyExtLst.xlsx", true))
+            {
+                var ws = pck.Workbook.Worksheets.Add("extLstTest");
+                var extSheet = pck.Workbook.Worksheets.Add("extAddressSheet");
+
+                AddDataValidations(ref ws, false, "", true);
+                AddDataValidations(ref ws, true, "extAddressSheet");
+
+                SaveAndLoadAndSave(pck);
+            }
+
+        }
+
+        [TestMethod]
+        public void ManyLocalDataValidationsShouldWorkWithManyExtLstConditionalFormattings()
+        {
+            using (var pck = OpenPackage("DataValidationLocalManyExtLst.xlsx", true))
+            {
+                var ws = pck.Workbook.Worksheets.Add("extLstTest");
+                var extSheet = pck.Workbook.Worksheets.Add("extAddressSheet");
+
+                AddDataValidations(ref ws, false, "", true);
+                AddDataValidations(ref ws, true, "extAddressSheet", true);
+
+                SaveAndLoadAndSave(pck);
+            }
+        }
+
         [TestMethod]
         public void DataValidationExtLstShouldWorkWithConditionalFormatting()
         {

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -4684,6 +4684,7 @@ namespace EPPlusTest
             Assert.AreNotEqual(ws.Row(3).Style.Border.Left.Style, wsCol.Style.Border.Left.Style);
             Assert.AreNotEqual(ws.Row(3).Style.Border.Right.Style, wsCol.Style.Border.Right.Style);
         }
+
         [TestMethod]
         public void i863()
         {


### PR DESCRIPTION
Fixed following bugs:
- Adding sqref attribute to extLst DataValidations if there existed Any local data validations
- sqref on extLst dataValidations were comma seperated instead of by whitespace
- extLst uri for dataValidations was declared twice in a parent and child node in the xml