### PR TITLE
Bug/464 fix datavalidation address collision

### DIFF
--- a/src/EPPlus/Core/RangeCopyHelper.cs
+++ b/src/EPPlus/Core/RangeCopyHelper.cs
@@ -130,7 +130,7 @@ namespace OfficeOpenXml.Core
                         }
                         else
                         {
-                            _destination._worksheet.DataValidations.AddCopyOfDataValidation(dv, new ExcelAddressBase(newAddress).AddressSpaceSeparated);
+                            _destination._worksheet.DataValidations.AddCopyOfDataValidation(dv, _destination._worksheet, new ExcelAddressBase(newAddress).AddressSpaceSeparated);
                         }
                     }
                 }

--- a/src/EPPlus/Core/Worksheet/WorksheetCopyHelper.cs
+++ b/src/EPPlus/Core/Worksheet/WorksheetCopyHelper.cs
@@ -104,7 +104,7 @@ namespace OfficeOpenXml.Core.Worksheet
             {
                 foreach(ExcelDataValidation dv in copy.DataValidations)
                 {
-                    added.DataValidations.AddCopyOfDataValidation(dv);
+                    added.DataValidations.AddCopyOfDataValidation(dv, added);
                 }
             }
 

--- a/src/EPPlus/DataValidation/ExcelDataValidation.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidation.cs
@@ -30,20 +30,21 @@ namespace OfficeOpenXml.DataValidation
         /// </summary>
         /// <param name="uid">Id for validation</param>
         /// <param name="address">adress validation is applied to</param>
-        protected ExcelDataValidation(string uid, string address)
+        protected ExcelDataValidation(string uid, string address, ExcelWorksheet ws)
         {
             Require.Argument(uid).IsNotNullOrEmpty("uid");
             Require.Argument(address).IsNotNullOrEmpty("address");
 
             Uid = uid;
             Address = new ExcelAddress(CheckAndFixRangeAddress(address));
+            _ws = ws;
         }
 
         /// <summary>
         /// Read-File Constructor
         /// </summary>
         /// <param name="xr"></param>
-        protected ExcelDataValidation(XmlReader xr)
+        protected ExcelDataValidation(XmlReader xr, ExcelWorksheet ws)
         {
             LoadXML(xr);
         }
@@ -52,7 +53,7 @@ namespace OfficeOpenXml.DataValidation
         /// Copy-Constructor
         /// </summary>
         /// <param name="validation">Validation to copy from</param>
-        protected ExcelDataValidation(ExcelDataValidation validation)
+        protected ExcelDataValidation(ExcelDataValidation validation,ExcelWorksheet ws)
         {
             Uid = validation.Uid;
             Address = validation.Address;
@@ -66,7 +67,10 @@ namespace OfficeOpenXml.DataValidation
             PromptTitle = validation.PromptTitle;
             Prompt = validation.Prompt;
             operatorString = validation.operatorString;
+            _ws = ws;
         }
+
+        internal ExcelWorksheet _ws;
 
         /// <summary>
         /// Uid of the data validation
@@ -335,6 +339,7 @@ namespace OfficeOpenXml.DataValidation
         {
             var dvAddress = AddressUtility.ParseEntireColumnSelections(address);
             Address = new ExcelAddress(address);
+            _ws.DataValidations.UpdateRangeDictionary(this);
         }
 
         /// <summary>

--- a/src/EPPlus/DataValidation/ExcelDataValidationAny.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationAny.cs
@@ -57,13 +57,19 @@ namespace OfficeOpenXml.DataValidation
 
         internal override ExcelDataValidation GetClone()
         {
-            //TODO if to be cloneable to different worksheet ws must be changed here somehow...
             return new ExcelDataValidationAny(this, this._ws);
+        }
+
+        internal override ExcelDataValidation GetClone(ExcelWorksheet copy)
+        {
+            return new ExcelDataValidationAny(this, copy);
         }
 
         internal ExcelDataValidationAny Clone()
         {
             return (ExcelDataValidationAny)GetClone();
         }
+
+
     }
 }

--- a/src/EPPlus/DataValidation/ExcelDataValidationAny.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationAny.cs
@@ -25,7 +25,7 @@ namespace OfficeOpenXml.DataValidation
         /// </summary>
         /// <param name="uid">Uid of the data validation, format should be a Guid surrounded by curly braces.</param>
         /// <param name="address"></param>
-        internal ExcelDataValidationAny(string uid, string address) : base(uid, address)
+        internal ExcelDataValidationAny(string uid, string address, ExcelWorksheet ws) : base(uid, address, ws)
         {
         }
 
@@ -33,7 +33,7 @@ namespace OfficeOpenXml.DataValidation
         /// Constructor for reading data
         /// </summary>
         /// <param name="xr">The XmlReader to read from</param>
-        internal ExcelDataValidationAny(XmlReader xr) : base(xr)
+        internal ExcelDataValidationAny(XmlReader xr, ExcelWorksheet ws) : base(xr, ws)
         {
         }
 
@@ -41,7 +41,7 @@ namespace OfficeOpenXml.DataValidation
         /// Copy constructor
         /// </summary>
         /// <param name="copy"></param>
-        internal ExcelDataValidationAny(ExcelDataValidationAny copy) : base(copy)
+        internal ExcelDataValidationAny(ExcelDataValidationAny copy, ExcelWorksheet ws) : base(copy, ws)
         {
         }
 
@@ -57,7 +57,8 @@ namespace OfficeOpenXml.DataValidation
 
         internal override ExcelDataValidation GetClone()
         {
-            return new ExcelDataValidationAny(this);
+            //TODO if to be cloneable to different worksheet ws must be changed here somehow...
+            return new ExcelDataValidationAny(this, this._ws);
         }
 
         internal ExcelDataValidationAny Clone()

--- a/src/EPPlus/DataValidation/ExcelDataValidationCollection.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationCollection.cs
@@ -80,7 +80,7 @@ namespace OfficeOpenXml.DataValidation
 
                 if (xr.NodeType == XmlNodeType.Element)
                 {
-                    var validation = ExcelDataValidationFactory.Create(xr);
+                    var validation = ExcelDataValidationFactory.Create(xr, _worksheet);
 
                     if(validation.Address.Addresses != null)
                     {
@@ -97,6 +97,25 @@ namespace OfficeOpenXml.DataValidation
                     }
                     _validations.Add(validation);
                 }
+            }
+        }
+
+        internal void UpdateRangeDictionary(ExcelDataValidation validation)
+        {
+            //_validationsRD
+
+            if (validation.Address.Addresses != null)
+            {
+                for (int i = 0; i < validation.Address.Addresses.Count; i++)
+                {
+                    _validationsRD.Merge(validation.Address.Addresses[i]._fromRow, validation.Address.Addresses[i]._fromCol,
+                        validation.Address.Addresses[i]._toRow, validation.Address.Addresses[i]._toCol, validation);
+                }
+            }
+            else
+            {
+                _validationsRD.Merge(validation.Address._fromRow, validation.Address._fromCol,
+                    validation.Address._toRow, validation.Address._toCol, validation);
             }
         }
 
@@ -215,7 +234,7 @@ namespace OfficeOpenXml.DataValidation
         /// <returns></returns>
         public IExcelDataValidationAny AddAnyValidation(string address)
         {
-            var validation = new ExcelDataValidationAny(ExcelDataValidation.NewId(), address);
+            var validation = new ExcelDataValidationAny(ExcelDataValidation.NewId(), address, _worksheet);
             return (IExcelDataValidationAny)AddValidation(address, validation);
         }
 
@@ -226,7 +245,7 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="address">the range/address to validate</param>
         public IExcelDataValidationInt AddIntegerValidation(string address)
         {
-            var validation = new ExcelDataValidationInt(ExcelDataValidation.NewId(), address, _worksheet.Name);
+            var validation = new ExcelDataValidationInt(ExcelDataValidation.NewId(), address, _worksheet);
             return (IExcelDataValidationInt)AddValidation(address, validation);
         }
 
@@ -236,7 +255,7 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="address">The range/address to validate</param>
         public IExcelDataValidationInt AddTextLengthValidation(string address)
         {
-            var validation = new ExcelDataValidationInt(ExcelDataValidation.NewId(), address, _worksheet.Name, true);
+            var validation = new ExcelDataValidationInt(ExcelDataValidation.NewId(), address, _worksheet, true);
             return (IExcelDataValidationInt)AddValidation(address, validation);
         }
 
@@ -247,7 +266,7 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="address">The range/address to validate</param>
         public IExcelDataValidationDecimal AddDecimalValidation(string address)
         {
-            var validation = new ExcelDataValidationDecimal(ExcelDataValidation.NewId(), address, _worksheet.Name);
+            var validation = new ExcelDataValidationDecimal(ExcelDataValidation.NewId(), address, _worksheet);
             return (IExcelDataValidationDecimal)AddValidation(address, validation);
         }
 
@@ -258,7 +277,7 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="address">The range/address to validate</param>
         public IExcelDataValidationList AddListValidation(string address)
         {
-            var validation = new ExcelDataValidationList(ExcelDataValidation.NewId(), address, _worksheet.Name);
+            var validation = new ExcelDataValidationList(ExcelDataValidation.NewId(), address, _worksheet);
             return (IExcelDataValidationList)AddValidation(address, validation);
         }
 
@@ -268,7 +287,7 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="address">The range/address to validate</param>
         public IExcelDataValidationDateTime AddDateTimeValidation(string address)
         {
-            var validation = new ExcelDataValidationDateTime(ExcelDataValidation.NewId(), address, _worksheet.Name);
+            var validation = new ExcelDataValidationDateTime(ExcelDataValidation.NewId(), address, _worksheet);
             return (IExcelDataValidationDateTime)AddValidation(address, validation);
         }
 
@@ -278,7 +297,7 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="address">The range/address to validate</param>
         public IExcelDataValidationTime AddTimeValidation(string address)
         {
-            var validation = new ExcelDataValidationTime(ExcelDataValidation.NewId(), address, _worksheet.Name);
+            var validation = new ExcelDataValidationTime(ExcelDataValidation.NewId(), address, _worksheet);
             return (IExcelDataValidationTime)AddValidation(address, validation);
         }
 
@@ -288,23 +307,20 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="address">The range/address to validate</param>
         public IExcelDataValidationCustom AddCustomValidation(string address)
         {
-            var validation = new ExcelDataValidationCustom(ExcelDataValidation.NewId(), address, _worksheet.Name);
+            var validation = new ExcelDataValidationCustom(ExcelDataValidation.NewId(), address, _worksheet);
             return (IExcelDataValidationCustom)AddValidation(address, validation);
         }
 
         private ExcelDataValidation AddValidation(string address, ExcelDataValidation validation)
         {
-            var internalAddress = new ExcelAddress(address);
 
-            // if(internalAddress.inter)
-
-            if (_validationsRD.Exists(internalAddress._fromRow, internalAddress._fromCol, internalAddress._toRow, internalAddress._toCol))
+            if (_validationsRD.Exists(validation.Address._fromRow, validation.Address._fromCol, validation.Address._toRow, validation.Address._toCol))
             {
                 throw new InvalidOperationException($"A DataValidation already exists at {address}");
             }
 
             _validations.Add(validation);
-            _validationsRD.Add(internalAddress._fromRow, internalAddress._fromCol, internalAddress._toRow, internalAddress._toCol, validation);
+            _validationsRD.Add(validation.Address._fromRow, validation.Address._fromCol, validation.Address._toRow, validation.Address._toCol, validation);
 
             return validation;
         }
@@ -454,6 +470,11 @@ namespace OfficeOpenXml.DataValidation
             {
                 _validationsRD.InsertRow(address._fromRow, address.Rows, address._fromCol, address._toCol);
             }
+        }
+
+        internal void ClearRangeDictionary()
+        {
+            //_validationsRD.del
         }
 
         internal void DeleteRangeDictionary(ExcelAddress address, bool shiftLeft)

--- a/src/EPPlus/DataValidation/ExcelDataValidationCollection.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationCollection.cs
@@ -215,15 +215,15 @@ namespace OfficeOpenXml.DataValidation
         /// </summary>
         /// <param name="dv"></param>
         /// <param name="address"></param>
-        internal void AddCopyOfDataValidation(ExcelDataValidation dv, string address = null)
+        internal void AddCopyOfDataValidation(ExcelDataValidation dv, ExcelWorksheet added, string address = null)
         {
             if(address == null)
             {
-                _validations.Add(dv.GetClone());
+                _validations.Add(dv.GetClone(added));
             }
             else
             {
-                _validations.Add(ExcelDataValidationFactory.CloneWithNewAdress(address, dv));
+                _validations.Add(ExcelDataValidationFactory.CloneWithNewAdress(address, dv, added));
             }
         }
 

--- a/src/EPPlus/DataValidation/ExcelDataValidationCustom.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationCustom.cs
@@ -67,6 +67,10 @@ namespace OfficeOpenXml.DataValidation
         {
             return new ExcelDataValidationCustom(this, _ws);
         }
+        internal override ExcelDataValidation GetClone(ExcelWorksheet copy)
+        {
+            return new ExcelDataValidationCustom(this, copy);
+        }
 
         ExcelDataValidationAny Clone()
         {

--- a/src/EPPlus/DataValidation/ExcelDataValidationCustom.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationCustom.cs
@@ -28,18 +28,18 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="worksheetName"></param>
         /// <param name="uid">Uid of the data validation, format should be a Guid surrounded by curly braces.</param>
         /// <param name="address"></param>
-        internal ExcelDataValidationCustom(string uid, string address, string worksheetName)
-            : base(uid, address, worksheetName)
+        internal ExcelDataValidationCustom(string uid, string address, ExcelWorksheet ws)
+            : base(uid, address, ws)
         {
-            Formula = new ExcelDataValidationFormulaCustom(null, Uid, worksheetName, OnFormulaChanged);
+            Formula = new ExcelDataValidationFormulaCustom(null, Uid, ws.Name, OnFormulaChanged);
         }
 
         /// <summary>
         /// Constructor for reading data
         /// </summary>
         /// <param name="xr">The XmlReader to read from</param>
-        internal ExcelDataValidationCustom(XmlReader xr)
-            : base(xr)
+        internal ExcelDataValidationCustom(XmlReader xr, ExcelWorksheet ws)
+            : base(xr, ws)
         {
         }
 
@@ -47,7 +47,7 @@ namespace OfficeOpenXml.DataValidation
         /// Copy constructor
         /// </summary>
         /// <param name="copy"></param>
-        internal ExcelDataValidationCustom(ExcelDataValidationCustom copy) : base(copy)
+        internal ExcelDataValidationCustom(ExcelDataValidationCustom copy, ExcelWorksheet ws) : base(copy, ws)
         {
             Formula = copy.Formula;
         }
@@ -65,7 +65,7 @@ namespace OfficeOpenXml.DataValidation
 
         internal override ExcelDataValidation GetClone()
         {
-            return new ExcelDataValidationCustom(this);
+            return new ExcelDataValidationCustom(this, _ws);
         }
 
         ExcelDataValidationAny Clone()

--- a/src/EPPlus/DataValidation/ExcelDataValidationDateTime.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationDateTime.cs
@@ -29,19 +29,19 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="worksheetName"></param>
         /// <param name="uid">Uid of the data validation, format should be a Guid surrounded by curly braces.</param>
         /// <param name="address"></param>
-        internal ExcelDataValidationDateTime(string uid, string address, string worksheetName)
-            : base(uid, address, worksheetName)
+        internal ExcelDataValidationDateTime(string uid, string address, ExcelWorksheet ws)
+            : base(uid, address, ws)
         {
-            Formula = new ExcelDataValidationFormulaDateTime(null, Uid, worksheetName, OnFormulaChanged);
-            Formula2 = new ExcelDataValidationFormulaDateTime(null, Uid, worksheetName, OnFormulaChanged);
+            Formula = new ExcelDataValidationFormulaDateTime(null, Uid, ws.Name, OnFormulaChanged);
+            Formula2 = new ExcelDataValidationFormulaDateTime(null, Uid, ws.Name, OnFormulaChanged);
         }
 
         /// <summary>
         /// Constructor for reading data
         /// </summary>
         /// <param name="xr">The XmlReader to read from</param>
-        internal ExcelDataValidationDateTime(XmlReader xr)
-            : base(xr)
+        internal ExcelDataValidationDateTime(XmlReader xr, ExcelWorksheet ws)
+            : base(xr, ws)
         {
         }
 
@@ -49,7 +49,7 @@ namespace OfficeOpenXml.DataValidation
         /// Copy constructor
         /// </summary>
         /// <param name="copy"></param>
-        internal ExcelDataValidationDateTime(ExcelDataValidationDateTime copy) : base(copy)
+        internal ExcelDataValidationDateTime(ExcelDataValidationDateTime copy, ExcelWorksheet ws) : base(copy, ws)
         {
             Formula = copy.Formula;
             Formula2 = copy.Formula;
@@ -67,7 +67,7 @@ namespace OfficeOpenXml.DataValidation
 
         internal override ExcelDataValidation GetClone()
         {
-            return new ExcelDataValidationDateTime(this);
+            return new ExcelDataValidationDateTime(this, _ws);
         }
 
         ExcelDataValidationDateTime Clone()

--- a/src/EPPlus/DataValidation/ExcelDataValidationDateTime.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationDateTime.cs
@@ -70,6 +70,11 @@ namespace OfficeOpenXml.DataValidation
             return new ExcelDataValidationDateTime(this, _ws);
         }
 
+        internal override ExcelDataValidation GetClone(ExcelWorksheet copy)
+        {
+            return new ExcelDataValidationDateTime(this, copy);
+        }
+
         ExcelDataValidationDateTime Clone()
         {
             return (ExcelDataValidationDateTime)GetClone();

--- a/src/EPPlus/DataValidation/ExcelDataValidationDecimal.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationDecimal.cs
@@ -28,19 +28,19 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="worksheetName"></param>
         /// <param name="uid">Uid of the data validation, format should be a Guid surrounded by curly braces.</param>
         /// <param name="address"></param>
-        internal ExcelDataValidationDecimal(string uid, string address, string worksheetName)
-            : base(uid, address, worksheetName)
+        internal ExcelDataValidationDecimal(string uid, string address, ExcelWorksheet ws)
+            : base(uid, address, ws)
         {
-            Formula = new ExcelDataValidationFormulaDecimal(null, uid, worksheetName, OnFormulaChanged);
-            Formula2 = new ExcelDataValidationFormulaDecimal(null, uid, worksheetName, OnFormulaChanged);
+            Formula = new ExcelDataValidationFormulaDecimal(null, uid, ws.Name, OnFormulaChanged);
+            Formula2 = new ExcelDataValidationFormulaDecimal(null, uid, ws.Name, OnFormulaChanged);
         }
 
         /// <summary>
         /// Constructor for reading data
         /// </summary>
         /// <param name="xr">The XmlReader to read from</param>
-        internal ExcelDataValidationDecimal(XmlReader xr)
-            : base(xr)
+        internal ExcelDataValidationDecimal(XmlReader xr, ExcelWorksheet ws)
+            : base(xr, ws)
         {
         }
 
@@ -48,7 +48,7 @@ namespace OfficeOpenXml.DataValidation
         /// Copy constructor
         /// </summary>
         /// <param name="copy"></param>
-        internal ExcelDataValidationDecimal(ExcelDataValidationDecimal copy) : base(copy)
+        internal ExcelDataValidationDecimal(ExcelDataValidationDecimal copy, ExcelWorksheet ws) : base(copy, ws)
         {
             Formula = copy.Formula;
             Formula2 = copy.Formula2;
@@ -66,7 +66,7 @@ namespace OfficeOpenXml.DataValidation
 
         internal override ExcelDataValidation GetClone()
         {
-            return new ExcelDataValidationDecimal(this);
+            return new ExcelDataValidationDecimal(this, _ws);
         }
 
         ExcelDataValidationDecimal Clone()

--- a/src/EPPlus/DataValidation/ExcelDataValidationDecimal.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationDecimal.cs
@@ -69,6 +69,11 @@ namespace OfficeOpenXml.DataValidation
             return new ExcelDataValidationDecimal(this, _ws);
         }
 
+        internal override ExcelDataValidation GetClone(ExcelWorksheet copy)
+        {
+            return new ExcelDataValidationDecimal(this, copy);
+        }
+
         ExcelDataValidationDecimal Clone()
         {
             return (ExcelDataValidationDecimal)GetClone();

--- a/src/EPPlus/DataValidation/ExcelDataValidationFactory.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationFactory.cs
@@ -26,28 +26,28 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="xr"></param>
         /// <returns>"</returns>
         /// <exception cref="InvalidOperationException"></exception>
-        internal static ExcelDataValidation Create(XmlReader xr)
+        internal static ExcelDataValidation Create(XmlReader xr, ExcelWorksheet ws)
         {
             string validationTypeName = xr.GetAttribute("type") == null ? "" : xr.GetAttribute("type");
 
             switch (validationTypeName)
             {
                 case "":
-                    return new ExcelDataValidationAny(xr);
+                    return new ExcelDataValidationAny(xr, ws);
                 case "textLength":
-                    return new ExcelDataValidationInt(xr, true);
+                    return new ExcelDataValidationInt(xr, ws, true);
                 case "whole":
-                    return new ExcelDataValidationInt(xr);
+                    return new ExcelDataValidationInt(xr, ws);
                 case "decimal":
-                    return new ExcelDataValidationDecimal(xr);
+                    return new ExcelDataValidationDecimal(xr, ws);
                 case "list":
-                    return new ExcelDataValidationList(xr);
+                    return new ExcelDataValidationList(xr, ws);
                 case "time":
-                    return new ExcelDataValidationTime(xr);
+                    return new ExcelDataValidationTime(xr, ws);
                 case "date":
-                    return new ExcelDataValidationDateTime(xr);
+                    return new ExcelDataValidationDateTime(xr, ws);
                 case "custom":
-                    return new ExcelDataValidationCustom(xr);
+                    return new ExcelDataValidationCustom(xr, ws);
                 default:
                     throw new InvalidOperationException($"Non supported validationtype: {validationTypeName}");
             }

--- a/src/EPPlus/DataValidation/ExcelDataValidationFactory.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationFactory.cs
@@ -53,10 +53,10 @@ namespace OfficeOpenXml.DataValidation
             }
         }
 
-        static internal ExcelDataValidation CloneWithNewAdress(string address, ExcelDataValidation oldValidation)
+        static internal ExcelDataValidation CloneWithNewAdress(string address, ExcelDataValidation oldValidation, ExcelWorksheet added)
         {
-            var validation = oldValidation.GetClone();
-            validation.Address = new ExcelAddress(address);
+            var validation = oldValidation.GetClone(added);
+            validation.Address = new ExcelDatavalidationAddress(address, validation);
             return validation;
         }
     }

--- a/src/EPPlus/DataValidation/ExcelDataValidationInt.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationInt.cs
@@ -78,6 +78,12 @@ namespace OfficeOpenXml.DataValidation
             return new ExcelDataValidationInt(this, _ws);
         }
 
+        internal override ExcelDataValidation GetClone(ExcelWorksheet copy)
+        {
+            return new ExcelDataValidationInt(this, copy);
+        }
+
+
         /// <summary>
         /// Return a deep-copy clone of validation
         /// </summary>

--- a/src/EPPlus/DataValidation/ExcelDataValidationInt.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationInt.cs
@@ -28,7 +28,8 @@ namespace OfficeOpenXml.DataValidation
         /// </summary>
         /// <param name="xr">The XmlReader to read from</param>
         ///  <param name="isTextLength">Bool to define type of int validation</param>
-        internal ExcelDataValidationInt(XmlReader xr, bool isTextLength = false) : base(xr)
+        internal ExcelDataValidationInt(XmlReader xr, ExcelWorksheet ws, bool isTextLength = false)
+            : base(xr, ws)
         {
             _isTextLength = isTextLength;
         }
@@ -40,12 +41,12 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="uid">Uid of the data validation, format should be a Guid surrounded by curly braces.</param>
         /// <param name="address"></param>
         /// <param name="isTextLength">Bool to define type of int validation</param>
-        internal ExcelDataValidationInt(string uid, string address, string worksheetName, bool isTextLength = false)
-            : base(uid, address, worksheetName)
+        internal ExcelDataValidationInt(string uid, string address, ExcelWorksheet ws, bool isTextLength = false)
+            : base(uid, address, ws)
         {
             //Initilization of forumlas so they don't cause nullref
-            Formula = new ExcelDataValidationFormulaInt(null, uid, worksheetName, OnFormulaChanged);
-            Formula2 = new ExcelDataValidationFormulaInt(null, uid, worksheetName, OnFormulaChanged);
+            Formula = new ExcelDataValidationFormulaInt(null, uid, ws.Name, OnFormulaChanged);
+            Formula2 = new ExcelDataValidationFormulaInt(null, uid, ws.Name, OnFormulaChanged);
             _isTextLength = isTextLength;
         }
 
@@ -53,7 +54,8 @@ namespace OfficeOpenXml.DataValidation
         /// Copy constructor
         /// </summary>
         /// <param name="copy"></param>
-        internal ExcelDataValidationInt(ExcelDataValidationInt copy) : base(copy)
+        internal ExcelDataValidationInt(ExcelDataValidationInt copy, ExcelWorksheet ws) 
+            : base(copy, ws)
         {
             Formula = copy.Formula;
             Formula2 = copy.Formula2;
@@ -73,7 +75,7 @@ namespace OfficeOpenXml.DataValidation
 
         internal override ExcelDataValidation GetClone()
         {
-            return new ExcelDataValidationInt(this);
+            return new ExcelDataValidationInt(this, _ws);
         }
 
         /// <summary>

--- a/src/EPPlus/DataValidation/ExcelDataValidationList.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationList.cs
@@ -31,18 +31,18 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="uid">Uid of the data validation, format should be a Guid surrounded by curly braces.</param>
         /// <param name="address"></param>
         /// <param name="validationType"></param>
-        internal ExcelDataValidationList(string uid, string address, string worksheetName)
-            : base(uid, address, worksheetName)
+        internal ExcelDataValidationList(string uid, string address, ExcelWorksheet ws)
+            : base(uid, address, ws)
         {
-            Formula = new ExcelDataValidationFormulaList(null, uid, worksheetName, OnFormulaChanged);
+            Formula = new ExcelDataValidationFormulaList(null, uid, ws.Name, OnFormulaChanged);
         }
 
         /// <summary>
         /// Constructor for reading data
         /// </summary>
         /// <param name="xr">The XmlReader to read from</param>
-        internal ExcelDataValidationList(XmlReader xr)
-            : base(xr)
+        internal ExcelDataValidationList(XmlReader xr, ExcelWorksheet ws)
+            : base(xr, ws)
         {
         }
 
@@ -50,7 +50,8 @@ namespace OfficeOpenXml.DataValidation
         /// Copy constructor
         /// </summary>
         /// <param name="copy"></param>
-        internal ExcelDataValidationList(ExcelDataValidationList copy) : base(copy)
+        internal ExcelDataValidationList(ExcelDataValidationList copy, ExcelWorksheet ws)
+            : base(copy, ws)
         {
             Formula = copy.Formula;
         }
@@ -102,7 +103,7 @@ namespace OfficeOpenXml.DataValidation
 
         internal override ExcelDataValidation GetClone()
         {
-            return new ExcelDataValidationList(this);
+            return new ExcelDataValidationList(this, _ws);
         }
 
         ExcelDataValidationDecimal Clone()

--- a/src/EPPlus/DataValidation/ExcelDataValidationList.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationList.cs
@@ -106,6 +106,11 @@ namespace OfficeOpenXml.DataValidation
             return new ExcelDataValidationList(this, _ws);
         }
 
+        internal override ExcelDataValidation GetClone(ExcelWorksheet copy)
+        {
+            return new ExcelDataValidationList(this, copy);
+        }
+
         ExcelDataValidationDecimal Clone()
         {
             return (ExcelDataValidationDecimal)GetClone();

--- a/src/EPPlus/DataValidation/ExcelDataValidationTime.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationTime.cs
@@ -71,6 +71,11 @@ namespace OfficeOpenXml.DataValidation
             return new ExcelDataValidationTime(this, _ws);
         }
 
+        internal override ExcelDataValidation GetClone(ExcelWorksheet copy)
+        {
+            return new ExcelDataValidationTime(this, copy);
+        }
+
         ExcelDataValidationTime Clone()
         {
             return (ExcelDataValidationTime)GetClone();

--- a/src/EPPlus/DataValidation/ExcelDataValidationTime.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationTime.cs
@@ -29,18 +29,19 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="uid">Uid of the data validation, format should be a Guid surrounded by curly braces.</param>
         /// <param name="address"></param>
         /// <param name="validationType"></param>
-        internal ExcelDataValidationTime(string uid, string address, string worksheetName) : base(uid, address, worksheetName)
+        internal ExcelDataValidationTime(string uid, string address, ExcelWorksheet ws)
+            : base(uid, address, ws)
         {
-            Formula = new ExcelDataValidationFormulaTime(null, uid, worksheetName, OnFormulaChanged);
-            Formula2 = new ExcelDataValidationFormulaTime(null, uid, worksheetName, OnFormulaChanged);
+            Formula = new ExcelDataValidationFormulaTime(null, uid, ws.Name, OnFormulaChanged);
+            Formula2 = new ExcelDataValidationFormulaTime(null, uid, ws.Name, OnFormulaChanged);
         }
 
         /// <summary>
         /// Constructor for reading data
         /// </summary>
         /// <param name="xr">The XmlReader to read from</param>
-        internal ExcelDataValidationTime(XmlReader xr)
-            : base(xr)
+        internal ExcelDataValidationTime(XmlReader xr, ExcelWorksheet ws)
+            : base(xr, ws)
         {
         }
 
@@ -48,7 +49,8 @@ namespace OfficeOpenXml.DataValidation
         /// Copy constructor
         /// </summary>
         /// <param name="copy"></param>
-        internal ExcelDataValidationTime(ExcelDataValidationTime copy) : base(copy)
+        internal ExcelDataValidationTime(ExcelDataValidationTime copy, ExcelWorksheet ws) 
+            : base(copy, ws)
         {
             Formula = copy.Formula;
             Formula2 = copy.Formula2;
@@ -66,7 +68,7 @@ namespace OfficeOpenXml.DataValidation
 
         internal override ExcelDataValidation GetClone()
         {
-            return new ExcelDataValidationTime(this);
+            return new ExcelDataValidationTime(this, _ws);
         }
 
         ExcelDataValidationTime Clone()

--- a/src/EPPlus/DataValidation/ExcelDataValidationWithFormula.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationWithFormula.cs
@@ -35,18 +35,18 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="workSheetName"></param>
         /// <param name="uid">Uid of the data validation, format should be a Guid surrounded by curly braces.</param>
         /// <param name="address"></param>
-        internal ExcelDataValidationWithFormula(string uid, string address, string workSheetName)
-            : base(uid, address)
+        internal ExcelDataValidationWithFormula(string uid, string address, ExcelWorksheet ws)
+            : base(uid, address, ws)
         {
-            _workSheetName = workSheetName;
+            _workSheetName = ws.Name;
         }
 
         /// <summary>
         /// Constructor for reading data
         /// </summary>
         /// <param name="xr">The XmlReader to read from</param>
-        internal ExcelDataValidationWithFormula(XmlReader xr)
-            : base(xr)
+        internal ExcelDataValidationWithFormula(XmlReader xr, ExcelWorksheet ws)
+            : base(xr, ws)
         {
         }
 
@@ -54,8 +54,8 @@ namespace OfficeOpenXml.DataValidation
         /// Copy Constructor
         /// </summary>
         /// <param name="copy"></param>
-        internal ExcelDataValidationWithFormula(ExcelDataValidation copy)
-            : base(copy)
+        internal ExcelDataValidationWithFormula(ExcelDataValidation copy, ExcelWorksheet ws)
+            : base(copy, ws)
         {
         }
 

--- a/src/EPPlus/DataValidation/ExcelDataValidationWithFormula2.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationWithFormula2.cs
@@ -29,8 +29,8 @@ namespace OfficeOpenXml.DataValidation
         /// <param name="workSheetName"></param>
         /// <param name="uid">Uid of the data validation, format should be a Guid surrounded by curly braces.</param>
         /// <param name="address"></param>
-        internal ExcelDataValidationWithFormula2(string uid, string address, string workSheetName)
-            : base(uid, address, workSheetName)
+        internal ExcelDataValidationWithFormula2(string uid, string address, ExcelWorksheet ws)
+            : base(uid, address, ws)
         {
         }
 
@@ -38,8 +38,8 @@ namespace OfficeOpenXml.DataValidation
         /// Constructor for reading data
         /// </summary>
         /// <param name="xr">The XmlReader to read from</param>
-        internal ExcelDataValidationWithFormula2(XmlReader xr)
-            : base(xr)
+        internal ExcelDataValidationWithFormula2(XmlReader xr, ExcelWorksheet ws)
+            : base(xr, ws)
         {
         }
 
@@ -47,8 +47,8 @@ namespace OfficeOpenXml.DataValidation
         /// Copy Constructor
         /// </summary>
         /// <param name="copy"></param>
-        internal ExcelDataValidationWithFormula2(ExcelDataValidation copy)
-            : base(copy)
+        internal ExcelDataValidationWithFormula2(ExcelDataValidation copy, ExcelWorksheet ws)
+            : base(copy, ws)
         {
         }
 

--- a/src/EPPlus/DataValidation/ExcelDatavalidationAddress.cs
+++ b/src/EPPlus/DataValidation/ExcelDatavalidationAddress.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OfficeOpenXml.DataValidation
+{
+    internal class ExcelDatavalidationAddress : ExcelAddress
+    {
+        ExcelDataValidation _val;
+
+        public ExcelDatavalidationAddress(string address, ExcelDataValidation val) : base(address) 
+        {
+            _val = val;
+        }
+
+        internal protected override void BeforeChangeAddress()
+        {
+            _val._ws.DataValidations.DeleteRangeDictionary(_val.Address, false);
+        }
+
+        /// <summary>
+        /// Called when the address changes
+        /// </summary>
+        internal protected override void ChangeAddress()
+        {
+
+            _val._ws.DataValidations.UpdateRangeDictionary(_val);
+        }
+    }
+}

--- a/src/EPPlus/DataValidation/ExcelDatavalidationAddress.cs
+++ b/src/EPPlus/DataValidation/ExcelDatavalidationAddress.cs
@@ -1,21 +1,28 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace OfficeOpenXml.DataValidation
 {
-    internal class ExcelDatavalidationAddress : ExcelAddress
+    /// <summary>
+    /// Handling for ExcelAdress updates of DataValidations
+    /// </summary>
+    public class ExcelDatavalidationAddress : ExcelAddress
     {
         ExcelDataValidation _val;
 
-        public ExcelDatavalidationAddress(string address, ExcelDataValidation val) : base(address) 
+        internal ExcelDatavalidationAddress(string address, ExcelDataValidation val) : base(address) 
         {
             _val = val;
         }
 
+        /// <summary>
+        /// Called before the address changes
+        /// </summary>
         internal protected override void BeforeChangeAddress()
         {
             _val._ws.DataValidations.DeleteRangeDictionary(_val.Address, false);
@@ -26,7 +33,6 @@ namespace OfficeOpenXml.DataValidation
         /// </summary>
         internal protected override void ChangeAddress()
         {
-
             _val._ws.DataValidations.UpdateRangeDictionary(_val);
         }
     }

--- a/src/EPPlus/DataValidation/RangeDataValidation.cs
+++ b/src/EPPlus/DataValidation/RangeDataValidation.cs
@@ -12,6 +12,8 @@
  *************************************************************************************************/
 using OfficeOpenXml.DataValidation.Contracts;
 using OfficeOpenXml.Utils;
+using System;
+using System.Collections.Generic;
 
 namespace OfficeOpenXml.DataValidation
 {

--- a/src/EPPlus/ExcelAddress.cs
+++ b/src/EPPlus/ExcelAddress.cs
@@ -88,7 +88,8 @@ namespace OfficeOpenXml
                 return _address;
             }
             set
-            {                
+            {
+                BeforeChangeAddress();
                 SetAddress(value, null, null);
                 ChangeAddress();
             }

--- a/src/EPPlus/ExcelAddressBase.cs
+++ b/src/EPPlus/ExcelAddressBase.cs
@@ -422,6 +422,10 @@ namespace OfficeOpenXml
             }
         }
 
+        internal protected virtual void BeforeChangeAddress()
+        {
+        }
+
         /// <summary>
         /// Called when the address changes
         /// </summary>

--- a/src/EPPlusTest/DataValidation/DataValidationTests.cs
+++ b/src/EPPlusTest/DataValidation/DataValidationTests.cs
@@ -455,7 +455,7 @@ namespace EPPlusTest.DataValidation
                 var wks = pck.Workbook.Worksheets.Add("Sheet1");
                 var validation = wks.DataValidations.AddIntegerValidation("A1");
                 var clone = ((ExcelDataValidationInt)validation).GetClone();
-                clone.Address = new ExcelAddress("A2");
+                clone.Address = new ExcelDatavalidationAddress("A2", clone);
 
                 Assert.AreNotEqual(validation.Address, clone.Address);
             }
@@ -560,112 +560,58 @@ namespace EPPlusTest.DataValidation
 
                 var list = ws.DataValidations.AddListValidation("A2");
 
+                list.Formula.Values.Add("TestValue");
+
                 ////Ideally
                 //ws.Cells["A2"].DataValidation.AddListDataValidation();
                 ////ws.Cells["A2"].DataValidation.AddListDataValidation(bool replace = false);
 
-
-                //SaveAndCleanup(pck);
-
-                //var pck2 = OpenPackage("InsertTest.xlsx");
-                //var ws2 = pck2.Workbook.Worksheets[0];
-                //var validation = pck2.Workbook.Worksheets[0].DataValidations[0];
-
-                //var list = ws2.DataValidations.AddListValidation("A2");
-
-                //list.Formula.Values.Add("Value1");
-                //list.Formula.Values.Add("Value2");
-
-                //ws.DataValidations.Remove(rangeValidation);
-
-                //rangeValidation.Address.Address = "A1,A2";
-
-                //ws.Cells["A1,A2"].DataValidation = rangeValidation;
-
-                // ws.DataValidations.AddIntegerValidation()
-
-
-
-                //rangeValidation.Operator = ExcelDataValidationOperator.equal;
-                //rangeValidation.Formula.Value = 5;
-                //rangeValidation.
-                //ws.DataValidations.AddCopyOfDataValidation(rangeValidation, "A4,A6");
-
-                //var operatorvar = rangeValidation.Operator;
-                //var fomula = rangeValidation.Formula;
-
-
-
-                //rangeValidation.Address.Address = "A1,A3";
-
-                //var listValidation = ws.Cells["A2"].DataValidation.AddListDataValidation();
-
-                //listValidation.Formula.Values.Add("Value1");
-                //listValidation.Formula.Values.Add("Value2");
-
-                // // ws.DataValidations.Remove(rangeValidation);
-
-                //// ws.DataValidations.Remove(rangeValidation);
-
-                // ws.Cells["A1"].Insert(eShiftTypeInsert.Down);
-                //var listvalidation = ws.Cells["A2"].DataValidation.AddListDataValidation();
-
-                //ws.Cells["A4"].Delete(eShiftTypeDelete.Up);
-
-                ////var validation = ws.Cells["A2"].DataValidation.AddListDataValidation();
-
-                //listvalidation.Formula.Values.Add("Test1");
-                //listvalidation.Formula.Values.Add("Test2");
-
-                ////ws.Cells["A2"].Insert(eShiftTypeInsert.Down);
-
-                ////ws.DataValidations.AddIntegerValidation()
-                ///
-
                 SaveAndCleanup(pck);
             }
         }
 
-        [TestMethod]
-        public void DataValidations_Insert_Test2()
-        {
-            using (var pck = OpenPackage("InsertTest2.xlsx", true))
-            {
-                var ws = pck.Workbook.Worksheets.Add("InsertTest2");
-                var rangeValidation = ws.DataValidations.AddIntegerValidation("A1:A3");
+        //[TestMethod]
+        //public void DataValidations_Insert_Test2()
+        //{
+        //    using (var pck = OpenPackage("InsertTest2.xlsx", true))
+        //    {
+        //        var ws = pck.Workbook.Worksheets.Add("InsertTest2");
+        //        var rangeValidation = ws.DataValidations.AddIntegerValidation("A1:A3");
 
-                rangeValidation.Operator = ExcelDataValidationOperator.equal;
-                rangeValidation.Formula.Value = 5;
+        //        rangeValidation.Operator = ExcelDataValidationOperator.equal;
+        //        rangeValidation.Formula.Value = 5;
 
-                //rangeValidation.Address.Address = "A1,A3";
+        //        //rangeValidation.Address.Address = "A1,A3";
 
-                //ws.Cells["A2"].Insert(eShiftTypeInsert.Down);
-                ws.Cells["A2"].Clear();
+        //        //ws.Cells["A2"].Insert(eShiftTypeInsert.Down);
+        //        //ws.Cells["A2"].Clear();
 
-                //ws.Cells["A3"].Insert(eShiftTypeInsert.Down);
+        //        ws.Cells["A2:A4"].DataValidation.ClearDataValidation();
 
-                //ws.Cells["A2"].Delete(eShiftTypeDelete.Up);
+        //        //ws.Cells["A3"].Insert(eShiftTypeInsert.Down);
 
-                var list = ws.DataValidations.AddListValidation("A2");
+        //        //ws.Cells["A2"].Delete(eShiftTypeDelete.Up);
 
-                list.Formula.Values.Add("Value1");
-                list.Formula.Values.Add("Value2");
+        //        var list = ws.DataValidations.AddListValidation("A2");
 
-                //rangeValidation.Address.Address = "A1,A3";
+        //        list.Formula.Values.Add("Value1");
+        //        list.Formula.Values.Add("Value2");
 
-                //SaveAndCleanup(pck);
+        //        //rangeValidation.Address.Address = "A1,A3";
 
-                //var pck2 = OpenPackage("InsertTest.xlsx");
-                //var ws2 = pck2.Workbook.Worksheets[0];
-                //var validation = pck2.Workbook.Worksheets[0].DataValidations[0];
+        //        //SaveAndCleanup(pck);
 
-                //var list = ws2.DataValidations.AddListValidation("A2");
+        //        //var pck2 = OpenPackage("InsertTest.xlsx");
+        //        //var ws2 = pck2.Workbook.Worksheets[0];
+        //        //var validation = pck2.Workbook.Worksheets[0].DataValidations[0];
 
-                //list.Formula.Values.Add("Value1");
-                //list.Formula.Values.Add("Value2");
+        //        //var list = ws2.DataValidations.AddListValidation("A2");
 
-                SaveAndCleanup(pck);
-            }
-        }
+        //        //list.Formula.Values.Add("Value1");
+        //        //list.Formula.Values.Add("Value2");
+
+        //        SaveAndCleanup(pck);
+        //    }
+        //}
     }
 }

--- a/src/EPPlusTest/DataValidation/DataValidationTests.cs
+++ b/src/EPPlusTest/DataValidation/DataValidationTests.cs
@@ -542,5 +542,130 @@ namespace EPPlusTest.DataValidation
                 SaveAndCleanup(pck);
             }
         }
+
+        [TestMethod]
+        public void DataValidations_Insert_Test()
+        {
+            using (var pck = OpenPackage("InsertTest.xlsx", true))
+            {
+                var ws = pck.Workbook.Worksheets.Add("InsertTest");
+                var rangeValidation = ws.DataValidations.AddIntegerValidation("A1:A3");
+
+                rangeValidation.Operator = ExcelDataValidationOperator.equal;
+                rangeValidation.Formula.Value = 5;
+
+                //ws.DataValidations.InsertRangeDictionary
+
+                rangeValidation.Address.Address = "A1,A3";
+
+                var list = ws.DataValidations.AddListValidation("A2");
+
+                ////Ideally
+                //ws.Cells["A2"].DataValidation.AddListDataValidation();
+                ////ws.Cells["A2"].DataValidation.AddListDataValidation(bool replace = false);
+
+
+                //SaveAndCleanup(pck);
+
+                //var pck2 = OpenPackage("InsertTest.xlsx");
+                //var ws2 = pck2.Workbook.Worksheets[0];
+                //var validation = pck2.Workbook.Worksheets[0].DataValidations[0];
+
+                //var list = ws2.DataValidations.AddListValidation("A2");
+
+                //list.Formula.Values.Add("Value1");
+                //list.Formula.Values.Add("Value2");
+
+                //ws.DataValidations.Remove(rangeValidation);
+
+                //rangeValidation.Address.Address = "A1,A2";
+
+                //ws.Cells["A1,A2"].DataValidation = rangeValidation;
+
+                // ws.DataValidations.AddIntegerValidation()
+
+
+
+                //rangeValidation.Operator = ExcelDataValidationOperator.equal;
+                //rangeValidation.Formula.Value = 5;
+                //rangeValidation.
+                //ws.DataValidations.AddCopyOfDataValidation(rangeValidation, "A4,A6");
+
+                //var operatorvar = rangeValidation.Operator;
+                //var fomula = rangeValidation.Formula;
+
+
+
+                //rangeValidation.Address.Address = "A1,A3";
+
+                //var listValidation = ws.Cells["A2"].DataValidation.AddListDataValidation();
+
+                //listValidation.Formula.Values.Add("Value1");
+                //listValidation.Formula.Values.Add("Value2");
+
+                // // ws.DataValidations.Remove(rangeValidation);
+
+                //// ws.DataValidations.Remove(rangeValidation);
+
+                // ws.Cells["A1"].Insert(eShiftTypeInsert.Down);
+                //var listvalidation = ws.Cells["A2"].DataValidation.AddListDataValidation();
+
+                //ws.Cells["A4"].Delete(eShiftTypeDelete.Up);
+
+                ////var validation = ws.Cells["A2"].DataValidation.AddListDataValidation();
+
+                //listvalidation.Formula.Values.Add("Test1");
+                //listvalidation.Formula.Values.Add("Test2");
+
+                ////ws.Cells["A2"].Insert(eShiftTypeInsert.Down);
+
+                ////ws.DataValidations.AddIntegerValidation()
+                ///
+
+                SaveAndCleanup(pck);
+            }
+        }
+
+        [TestMethod]
+        public void DataValidations_Insert_Test2()
+        {
+            using (var pck = OpenPackage("InsertTest2.xlsx", true))
+            {
+                var ws = pck.Workbook.Worksheets.Add("InsertTest2");
+                var rangeValidation = ws.DataValidations.AddIntegerValidation("A1:A3");
+
+                rangeValidation.Operator = ExcelDataValidationOperator.equal;
+                rangeValidation.Formula.Value = 5;
+
+                //rangeValidation.Address.Address = "A1,A3";
+
+                //ws.Cells["A2"].Insert(eShiftTypeInsert.Down);
+                ws.Cells["A2"].Clear();
+
+                //ws.Cells["A3"].Insert(eShiftTypeInsert.Down);
+
+                //ws.Cells["A2"].Delete(eShiftTypeDelete.Up);
+
+                var list = ws.DataValidations.AddListValidation("A2");
+
+                list.Formula.Values.Add("Value1");
+                list.Formula.Values.Add("Value2");
+
+                //rangeValidation.Address.Address = "A1,A3";
+
+                //SaveAndCleanup(pck);
+
+                //var pck2 = OpenPackage("InsertTest.xlsx");
+                //var ws2 = pck2.Workbook.Worksheets[0];
+                //var validation = pck2.Workbook.Worksheets[0].DataValidations[0];
+
+                //var list = ws2.DataValidations.AddListValidation("A2");
+
+                //list.Formula.Values.Add("Value1");
+                //list.Formula.Values.Add("Value2");
+
+                SaveAndCleanup(pck);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/DataValidation/UidTests.cs
+++ b/src/EPPlusTest/DataValidation/UidTests.cs
@@ -26,7 +26,7 @@ namespace EPPlusTest.DataValidation
             LoadXmlTestData("A1", "decimal", "1.3");
             var id = ExcelDataValidation.NewId();
             // Act
-            var validation = new ExcelDataValidationDecimal(id, "A1", _sheet.Name);
+            var validation = new ExcelDataValidationDecimal(id, "A1", _sheet);
             // Assert
             Assert.AreEqual(id, validation.Uid);
         }


### PR DESCRIPTION
Made changing Address.Address on a dataValidation update ValidationsRD by including worksheet in all dataValidations and adding a new class.

This was throwing
```
                var pck = new ExcelPackage();
                var ws = pck.Workbook.Worksheets.Add("InsertTest");
                var rangeValidation = ws.DataValidations.AddIntegerValidation("A1:A3");

                rangeValidation.Operator = ExcelDataValidationOperator.equal;
                rangeValidation.Formula.Value = 5;

                rangeValidation.Address.Address = "A1,A3";

                var list = ws.DataValidations.AddListValidation("A2");

                list.Formula.Values.Add("TestValue");
```