### PR TITLE
Add support of data validation type: none

### DIFF
--- a/src/EPPlus/DataValidation/ExcelDataValidationFactory.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationFactory.cs
@@ -33,6 +33,7 @@ namespace OfficeOpenXml.DataValidation
             switch (validationTypeName)
             {
                 case "":
+                case "none":
                     return new ExcelDataValidationAny(xr, ws);
                 case "textLength":
                     return new ExcelDataValidationInt(xr, ws, true);


### PR DESCRIPTION
I have an issue opening a file that has data validation type: `none`. OpenXml API supports the type (see [DataValidationValues Enum](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.datavalidationvalues?view=openxml-2.8.1)) but EPPlus does not.