### PR TITLE
Improve placeholder element detection in `ExtLstHelper`

### DIFF
--- a/src/EPPlus/ExcelXMLWriter/ExtLstHelper.cs
+++ b/src/EPPlus/ExcelXMLWriter/ExtLstHelper.cs
@@ -29,10 +29,10 @@ namespace OfficeOpenXml.ExcelXMLWriter
         private void ParseIntialXmlToList(string xml)
         {
             int start = 0, end = 0;
-            GetBlock.Pos(xml, "extLst", ref start, ref end);
+            bool isPlaceholder = false;
+            GetBlock.Pos(xml, "extLst", ref start, ref end, ref isPlaceholder);
 
-            //If the node isn't just a placeholder
-            if (end - start > 10)
+            if (!isPlaceholder)
             {
                 int contentStart = start + "<ExtLst>".Length;
                 string extNodesOnly = xml.Substring(contentStart, end - contentStart - "</ExtLst>".Length);

--- a/src/EPPlus/ExcelXMLWriter/GetBlock.cs
+++ b/src/EPPlus/ExcelXMLWriter/GetBlock.cs
@@ -18,6 +18,12 @@ namespace OfficeOpenXml.ExcelXMLWriter
     {
         internal static void Pos(string xml, string tag, ref int start, ref int end)
         {
+            bool isPlaceholder = false;
+            Pos(xml, tag, ref start, ref end, ref isPlaceholder);
+        }
+
+        internal static void Pos(string xml, string tag, ref int start, ref int end, ref bool isPlaceholder)
+        {
             Match startmMatch, endMatch;
             startmMatch = Regex.Match(xml.Substring(start), string.Format("(<[^>]*{0}[^>]*>)", tag)); //"<[a-zA-Z:]*" + tag + "[?]*>");
 
@@ -30,6 +36,7 @@ namespace OfficeOpenXml.ExcelXMLWriter
             var startPos = startmMatch.Index + start;
             if (startmMatch.Value.Substring(startmMatch.Value.Length - 2, 1) == "/")
             {
+                isPlaceholder = true;
                 end = startPos + startmMatch.Length;
             }
             else


### PR DESCRIPTION
Original placeholder detection (`end - start > 10`) won't work if element contain attributes:
```xml
<d:extLst xmlns:d="http://schemas.openxmlformats.org/spreadsheetml/2006/main" />
```