### PR TITLE
Bug/i888 place holder element detection

### DIFF
--- a/src/EPPlus/ExcelXMLWriter/ExtLstHelper.cs
+++ b/src/EPPlus/ExcelXMLWriter/ExtLstHelper.cs
@@ -33,7 +33,7 @@ namespace OfficeOpenXml.ExcelXMLWriter
 
             bool isPlaceHolder = false;
 
-            if(!xml.Substring(start + 1, end-start).Contains("<"))
+            if(!xml.Substring(start + 1, end - start - 1).Contains("<"))
             {
                 isPlaceHolder = true;
             }

--- a/src/EPPlus/ExcelXMLWriter/ExtLstHelper.cs
+++ b/src/EPPlus/ExcelXMLWriter/ExtLstHelper.cs
@@ -31,8 +31,15 @@ namespace OfficeOpenXml.ExcelXMLWriter
             int start = 0, end = 0;
             GetBlock.Pos(xml, "extLst", ref start, ref end);
 
+            bool isPlaceHolder = false;
+
+            if(!xml.Substring(start + 1, end-start).Contains("<"))
+            {
+                isPlaceHolder = true;
+            }
+
             //If the node isn't just a placeholder
-            if (end - start > 10)
+            if (!isPlaceHolder)
             {
                 int contentStart = start + "<ExtLst>".Length;
                 string extNodesOnly = xml.Substring(contentStart, end - contentStart - "</ExtLst>".Length);

--- a/src/EPPlusTest/DataValidation/DataValidationTests.cs
+++ b/src/EPPlusTest/DataValidation/DataValidationTests.cs
@@ -67,6 +67,19 @@ namespace EPPlusTest.DataValidation
         }
 
         [TestMethod]
+        public void DataValidation_CanReadNoneValidation()
+        {
+            var pck = OpenTemplatePackage("i888.xlsx");
+
+            var validation = pck.Workbook.Worksheets[0].DataValidations[0];
+
+            Assert.IsNotNull(validation);
+            Assert.AreEqual("A1", validation.Address.ToString());
+            Assert.AreEqual("test", validation.PromptTitle);
+            Assert.AreEqual("message", validation.Prompt);
+        }
+
+        [TestMethod]
         public void DataValidations_ShouldWriteReadAllValidOperatorsOnAllTypes()
         {
 

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -4847,6 +4847,21 @@ namespace EPPlusTest
                 SaveAndCleanup(p);
             }
         }
+
+
+        [TestMethod]
+        public void Issue888()
+        {
+            using (var package = OpenPackage("i888.xlsx", true))
+            {
+                var ws1 = package.Workbook.Worksheets.Add("ws1");
+
+                ws1.DataValidations.AddAnyValidation("A1");
+
+                SaveAndCleanup(package);
+            }
+        }
+
         [TestMethod]
         public void s466()
         {

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -29,6 +29,8 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using OfficeOpenXml;
+using OfficeOpenXml.ConditionalFormatting;
+using OfficeOpenXml.DataValidation;
 using OfficeOpenXml.Drawing;
 using OfficeOpenXml.Drawing.Chart;
 using OfficeOpenXml.Drawing.Chart.Style;
@@ -4852,13 +4854,20 @@ namespace EPPlusTest
         [TestMethod]
         public void Issue888()
         {
-            using (var package = OpenPackage("i888.xlsx", true))
+            using (var package = OpenPackage("issue888.xlsx", true))
             {
                 var ws1 = package.Workbook.Worksheets.Add("ws1");
 
                 ws1.DataValidations.AddAnyValidation("A1");
 
                 SaveAndCleanup(package);
+
+                var readPackage = OpenPackage("issue888.xlsx");
+
+                var sheet = readPackage.Workbook.Worksheets[0];
+                var formatting = sheet.DataValidations[0];
+
+                Assert.AreEqual(eDataValidationType.Any, formatting.ValidationType.Type);
             }
         }
 


### PR DESCRIPTION
Previously detection of placeholder nodes was simply made by checking number of chars this prevented placeholders with attributes.

We now detect placeholders by checking if they contain the start of another node. Or a "<" symbol after the initial one. As no nodes being read this way should be a singular node unless it is a placeholder.