### PR TITLE
Fixed copy bug of table formulas

### DIFF
--- a/src/EPPlus/ExcelCellBase.cs
+++ b/src/EPPlus/ExcelCellBase.cs
@@ -915,7 +915,8 @@ namespace OfficeOpenXml
                     if (t.TokenTypeIsSet(TokenType.ExcelAddress))
                     {
                         var address = new ExcelAddressBase(t.Value);
-                        if ((!string.IsNullOrEmpty(address._wb) || !IsReferencesModifiedWorksheet(currentSheet, modifiedSheet, address)) && !setFixed)
+                        if ((!string.IsNullOrEmpty(address._wb) || (!IsReferencesModifiedWorksheet(currentSheet, modifiedSheet, address)) && !setFixed)
+                            || address.Table != null)
                         {
                             f += address.Address;
                             continue;

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -4877,5 +4877,77 @@ namespace EPPlusTest
                 SaveAndCleanup(package);
             }
         }
+        [TestMethod]
+        public void s473()
+        {
+            using (var p = OpenPackage("tableCopyTest.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("sheet1");
+                var tableSheet = p.Workbook.Worksheets.Add("tableSheet");
+
+                
+
+                tableSheet.Cells[1, 1].Value = "Country";
+                tableSheet.Cells[2, 1].Value = "England";
+                tableSheet.Cells[3, 1].Value = "Wales";
+                tableSheet.Cells[4, 1].Value = "Scotland";
+                tableSheet.Cells[5, 1].Value = "Isle of Man";
+                tableSheet.Cells[6, 1].Value = "France";
+
+                tableSheet.Cells[1, 2].Value = "City";
+                tableSheet.Cells[2, 2].Value = "London";
+                tableSheet.Cells[3, 2].Value = "Cardiff";
+                tableSheet.Cells[4, 2].Value = "Edinburgh";
+                tableSheet.Cells[5, 2].Value = "Douglas";
+                tableSheet.Cells[6, 2].Value = "Paris";
+
+                var table = tableSheet.Tables.Add(new ExcelAddress("A1:B11"), "Table1");
+                //table.ToDataTable
+
+                for (int i =  2; i < 7; i++)
+                {
+                    ws.Cells[i, 1].Value = tableSheet.Cells[i, 1].Value;
+                    //If column 2 row i has the correct city to the country in A/table
+                    ws.Cells[i, 3].Formula = $"IF(B{i}=\"\",\"\",IF(B{i}=INDEX(Table1[City],MATCH(Sheet1!A{i},Table1[Country],0),1),TRUE,FALSE))";
+                }
+
+                int additionalRows = 2;
+                int startRow = 2;
+                ws.InsertRow(3, additionalRows);
+
+                for (int i = 0; i < additionalRows; i++)
+                {
+                    int copyToRow = startRow + 1 + i;
+
+                    ws.Cells[startRow, 1, startRow, ws.Dimension.Columns].Copy(ws.Cells[copyToRow, 1, copyToRow, ws.Dimension.Columns]);
+                }
+
+                //Ensure inserted rows copied formula correctly
+                Assert.AreEqual($"IF(B{2}=\"\",\"\",IF(B{2}=INDEX(Table1[City],MATCH(Sheet1!A{2},Table1[Country],0),1),TRUE,FALSE))", ws.Cells[2, 3].Formula);
+                Assert.AreEqual($"IF(B{3}=\"\",\"\",IF(B{3}=INDEX(Table1[City],MATCH(Sheet1!A{3},Table1[Country],0),1),TRUE,FALSE))", ws.Cells[3, 3].Formula);
+
+                SaveAndCleanup(p);
+            }
+
+            //using (var p = OpenTemplatePackage("s473Workaround.xlsx"))
+            //{
+            //    int additionalRows = 2;
+            //    int startRow = 2;
+
+            //    var workbook = p.Workbook;
+            //    var worksheet = workbook.Worksheets[0];
+
+            //    worksheet.InsertRow(3, additionalRows);
+            //    for (int i = 0; i < additionalRows; i++)
+            //    {
+            //        int copyToRow = startRow + 1 + i;
+            //        var temp = worksheet.Cells[startRow, 1, startRow, worksheet.Dimension.Columns];
+
+            //        worksheet.Cells[startRow, 1, startRow, worksheet.Dimension.Columns].Copy(worksheet.Cells[copyToRow, 1, copyToRow, worksheet.Dimension.Columns]);
+            //    }
+
+            //    SaveAndCleanup(p);
+            //}
+        }
     }
 }

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -4928,26 +4928,6 @@ namespace EPPlusTest
 
                 SaveAndCleanup(p);
             }
-
-            //using (var p = OpenTemplatePackage("s473Workaround.xlsx"))
-            //{
-            //    int additionalRows = 2;
-            //    int startRow = 2;
-
-            //    var workbook = p.Workbook;
-            //    var worksheet = workbook.Worksheets[0];
-
-            //    worksheet.InsertRow(3, additionalRows);
-            //    for (int i = 0; i < additionalRows; i++)
-            //    {
-            //        int copyToRow = startRow + 1 + i;
-            //        var temp = worksheet.Cells[startRow, 1, startRow, worksheet.Dimension.Columns];
-
-            //        worksheet.Cells[startRow, 1, startRow, worksheet.Dimension.Columns].Copy(worksheet.Cells[copyToRow, 1, copyToRow, worksheet.Dimension.Columns]);
-            //    }
-
-            //    SaveAndCleanup(p);
-            //}
         }
     }
 }


### PR DESCRIPTION
Copying a formula containing a Table reference would cause invalid formulas.
Fixed by adding condition to ExcelCellBase