### PR TITLE
Allowed for save of groups containing drawings with same name

### DIFF
--- a/src/EPPlus/Drawing/ExcelGroupShape.cs
+++ b/src/EPPlus/Drawing/ExcelGroupShape.cs
@@ -47,7 +47,10 @@ namespace OfficeOpenXml.Drawing
                 {
                     var grpDraw = ExcelDrawing.GetDrawingFromNode(_parent._drawings, node, (XmlElement)node, _parent);
                     _groupDrawings.Add(grpDraw);
-                    _drawingNames.Add(grpDraw.Name, _groupDrawings.Count - 1);
+                    if (_drawingNames.ContainsKey(grpDraw.Name) == false)
+                    {
+                        _drawingNames.Add(grpDraw.Name, _groupDrawings.Count - 1);
+                    }
                 }
             }
         }

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -4877,5 +4877,18 @@ namespace EPPlusTest
                 SaveAndCleanup(package);
             }
         }
+        [TestMethod]
+        public void i898()
+        {
+            using (var package = OpenTemplatePackage("i898DoubleGroup.xlsx"))
+            {
+                var sheet = package.Workbook.Worksheets[0];
+
+                sheet.Cells["A1"].Value = 1;
+
+                //Ensure saving of drawings with same name when read from file is possible
+                SaveAndCleanup(package);
+            }
+        }
     }
 }


### PR DESCRIPTION
Added condition which allows for saving groups of drawings that have items of the same name in them.