### PR TITLE
Range insert and delete fix

### DIFF
--- a/src/EPPlus/Core/CellStore/RangeDictionary.cs
+++ b/src/EPPlus/Core/CellStore/RangeDictionary.cs
@@ -234,15 +234,18 @@ namespace OfficeOpenXml.Core.CellStore
                         var fr = (int)(ri.RowSpan >> 20) + 1;
                         var tr = (int)(ri.RowSpan & 0xFFFFF) + 1;
 
-                        if(fr>=fromRow)
+                        if(tr >= fromRow) 
                         {
-                            ri.RowSpan = ((fr + noRows - 1) << 20) | (tr + noRows - 1);
+                            if (fr >= fromRow)
+                            {
+                                ri.RowSpan = ((fr + noRows - 1) << 20) | (tr + noRows - 1);
+                            }
+                            else
+                            {
+                                ri.RowSpan = ((fr - 1) << 20) | (tr + noRows - 1);
+                            }
+                            rows[ix] = ri;
                         }
-                        else
-                        {
-                            ri.RowSpan = ((fr - 1) << 20) | (tr + noRows - 1);
-                        }
-                        rows[ix] = ri;
                     }
                     var add = (noRows << 20) | (noRows);
                     for (int i=ix+1;i<rows.Count;i++)

--- a/src/EPPlus/Core/RangeCopyHelper.cs
+++ b/src/EPPlus/Core/RangeCopyHelper.cs
@@ -127,6 +127,7 @@ namespace OfficeOpenXml.Core
                         if (_sourceRange._worksheet == _destination._worksheet)
                         {
                             dv.SetAddress(dv.Address + "," + newAddress);
+                            dv._ws.DataValidations.UpdateRangeDictionary(dv);
                         }
                         else
                         {

--- a/src/EPPlus/Core/Worksheet/WorksheetRangeDeleteHelper.cs
+++ b/src/EPPlus/Core/Worksheet/WorksheetRangeDeleteHelper.cs
@@ -598,9 +598,9 @@ namespace OfficeOpenXml.Core.Worksheet
                     }
                     dv.SetAddress(newAddress.Address);
                 }
-                ws.DataValidations.DeleteRangeDictionary(range, shift == eShiftTypeDelete.Left || shift == eShiftTypeDelete.EntireColumn);
             }
             deletedDV.ForEach(dv => ws.DataValidations.Remove(dv));
+            ws.DataValidations.DeleteRangeDictionary(range, shift == eShiftTypeDelete.Left || shift == eShiftTypeDelete.EntireColumn);
         }
 
         private static ExcelAddressBase DeleteSplitAddress(ExcelAddressBase address, ExcelAddressBase range, ExcelAddressBase effectedAddress, eShiftTypeDelete shift)

--- a/src/EPPlus/Core/Worksheet/WorksheetRangeInsertHelper.cs
+++ b/src/EPPlus/Core/Worksheet/WorksheetRangeInsertHelper.cs
@@ -270,12 +270,12 @@ namespace OfficeOpenXml.Core.Worksheet
                     }
                     
                 }
-                ws.DataValidations.InsertRangeDictionary(range, shift == eShiftTypeInsert.Right || shift == eShiftTypeInsert.EntireColumn);
             }
             foreach (var dv in delDV)
             {
                 ws.DataValidations.Remove(dv);
             }
+            ws.DataValidations.InsertRangeDictionary(range, shift == eShiftTypeInsert.Right || shift == eShiftTypeInsert.EntireColumn);
         }
 
         private static void InsertFilterAddress(ExcelRangeBase range, ExcelAddressBase effectedAddress, eShiftTypeInsert shift)

--- a/src/EPPlus/DataValidation/ExcelDataValidation.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidation.cs
@@ -345,7 +345,6 @@ namespace OfficeOpenXml.DataValidation
         {
             var dvAddress = AddressUtility.ParseEntireColumnSelections(address);
             _address = new ExcelDatavalidationAddress(address, this);
-            _ws.DataValidations.UpdateRangeDictionary(this);
         }
 
         /// <summary>

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -4953,5 +4953,46 @@ namespace EPPlusTest
                 SaveAndCleanup(p);
             }
         }
+
+        [TestMethod]
+        public void s474()
+        {
+            using (var p = OpenPackage("dataValidationInsertTest.xlsx", true))
+            {
+
+                int CustomTemplateRowsOffset = 0, START_ROW = 5, START_COLUMN = 8;
+
+                var sheet = p.Workbook.Worksheets.Add("dataValidationsInsert");
+
+                var validation = sheet.DataValidations.AddDecimalValidation("H3");
+                var rangeValidation = sheet.DataValidations.AddDecimalValidation("H4");
+                var rangeValidationH2 = sheet.DataValidations.AddDecimalValidation("H5");
+
+                var rangeValidation2 = sheet.DataValidations.AddDecimalValidation("G10");
+
+                validation.Operator = ExcelDataValidationOperator.equal;
+                rangeValidation.Operator = ExcelDataValidationOperator.equal;
+                rangeValidation2.Operator = ExcelDataValidationOperator.equal;
+                rangeValidationH2.Operator = ExcelDataValidationOperator.equal;
+
+
+                int rowCnt = START_ROW + CustomTemplateRowsOffset;
+                int startRow = rowCnt;
+                int startColumn = START_COLUMN;
+                int sheetRows = 30;
+
+
+                sheet.SetValue("A" + (2 + CustomTemplateRowsOffset), "Code");
+                sheet.SetValue("A" + (4 + CustomTemplateRowsOffset), "Description");
+
+                int columnCount = startColumn;
+                sheet.InsertRow(5, sheetRows - 1);
+
+                OfficeOpenXml.DataValidation.Contracts.IExcelDataValidationList validationList = 
+                    sheet.DataValidations.AddListValidation(sheet.Cells[startRow, columnCount, sheetRows - 1, columnCount].Address);
+
+                SaveAndCleanup(p);
+            }
+        }
     }
 }


### PR DESCRIPTION
Inserting and deleting rows connected to dataValidation caused RangeDictionary to be wildly wrong.
Those issues have been ammended and tests added.