### PR TITLE
Allowed full address for dataValidation

### DIFF
--- a/src/EPPlus/DataValidation/ExcelDataValidation.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidation.cs
@@ -86,7 +86,7 @@ namespace OfficeOpenXml.DataValidation
         /// <summary>
         /// Address of data validation
         /// </summary>
-        public ExcelAddress Address { get { return _address; } internal set { _address = (ExcelDatavalidationAddress)value; } }
+        public ExcelAddress Address { get { return _address; } internal set { _address = new ExcelDatavalidationAddress(value.Address, this); } }
 
         /// <summary>
         /// Validation type
@@ -237,12 +237,24 @@ namespace OfficeOpenXml.DataValidation
                 throw new FormatException("Multiple addresses may not be commaseparated, use space instead");
             }
 
-            address = ConvertUtil._invariantTextInfo.ToUpper(new ExcelAddress(address).LocalAddress);
+            var tempAddress = new ExcelAddress(address);
+            string wsName = "";
+
+            if (!string.IsNullOrEmpty(tempAddress.WorkSheetName)) 
+            {
+                wsName = ExcelCellBase.GetQuotedWorksheetName(tempAddress.WorkSheetName) + "!";
+            }
+
+            if(tempAddress.Addresses.Count < 1)
+            {
+                address = wsName + ConvertUtil._invariantTextInfo.ToUpper(tempAddress.LocalAddress);
+            }
 
             if (IsEntireColumn(address))
             {
                 address = AddressUtility.ParseEntireColumnSelections(address);
             }
+
             return address;
         }
 

--- a/src/EPPlus/DataValidation/ExcelDataValidation.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidation.cs
@@ -237,16 +237,7 @@ namespace OfficeOpenXml.DataValidation
                 throw new FormatException("Multiple addresses may not be commaseparated, use space instead");
             }
 
-            var addressAndSheet = address.Split('!');
-
-            if(addressAndSheet.Length > 1) 
-            {
-                address = addressAndSheet[0] + "!" + ConvertUtil._invariantTextInfo.ToUpper(addressAndSheet[1]);
-            }
-            else
-            {
-                address = ConvertUtil._invariantTextInfo.ToUpper(address);
-            }
+            address = ConvertUtil._invariantTextInfo.ToUpper(new ExcelAddress(address).LocalAddress);
 
             if (IsEntireColumn(address))
             {

--- a/src/EPPlus/DataValidation/ExcelDataValidation.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidation.cs
@@ -242,13 +242,11 @@ namespace OfficeOpenXml.DataValidation
 
             if (!string.IsNullOrEmpty(tempAddress.WorkSheetName)) 
             {
-                wsName = ExcelCellBase.GetQuotedWorksheetName(tempAddress.WorkSheetName) + "!";
+                wsName = tempAddress.WorkSheetName + "!";
+                address = address.Replace(wsName, "");
             }
 
-            if(tempAddress.Addresses.Count < 1)
-            {
-                address = wsName + ConvertUtil._invariantTextInfo.ToUpper(tempAddress.LocalAddress);
-            }
+            address = ConvertUtil._invariantTextInfo.ToUpper(address);
 
             if (IsEntireColumn(address))
             {

--- a/src/EPPlus/DataValidation/ExcelDataValidation.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidation.cs
@@ -242,6 +242,11 @@ namespace OfficeOpenXml.DataValidation
 
             if (!string.IsNullOrEmpty(tempAddress.WorkSheetName)) 
             {
+                //var tokens = SourceCodeTokenizer.Default.Tokenize(tempAddress.Address, wsName);
+                //address = address.Substring(address.LastIndexOf('!') + 1);
+
+                address = address.Replace("'", "");
+
                 wsName = tempAddress.WorkSheetName + "!";
                 address = address.Replace(wsName, "");
             }

--- a/src/EPPlus/DataValidation/ExcelDataValidation.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidation.cs
@@ -236,7 +236,17 @@ namespace OfficeOpenXml.DataValidation
             {
                 throw new FormatException("Multiple addresses may not be commaseparated, use space instead");
             }
-            address = ConvertUtil._invariantTextInfo.ToUpper(address);
+
+            var addressAndSheet = address.Split('!');
+
+            if(addressAndSheet.Length > 1) 
+            {
+                address = addressAndSheet[0] + "!" + ConvertUtil._invariantTextInfo.ToUpper(addressAndSheet[1]);
+            }
+            else
+            {
+                address = ConvertUtil._invariantTextInfo.ToUpper(address);
+            }
 
             if (IsEntireColumn(address))
             {

--- a/src/EPPlus/ExcelXMLWriter/ExcelXmlWriter.cs
+++ b/src/EPPlus/ExcelXMLWriter/ExcelXmlWriter.cs
@@ -639,19 +639,15 @@ namespace OfficeOpenXml.ExcelXMLWriter
 
             if (_ws.DataValidations[i].InternalValidationType == InternalValidationType.DataValidation)
             {
-                var wsNameAddress = _ws.DataValidations[i].Address.Address.Split('!');
 
-                if (wsNameAddress.Length > 1)
+                if (_ws.DataValidations[i].Address.WorkSheetName != null && _ws.DataValidations[i].Address.WorkSheetName != _ws.Name)
                 {
-                    if (wsNameAddress[0] != _ws.Name)
-                    {
-                        throw new InvalidOperationException(
-                            $"Cannot write to address {_ws.DataValidations[i].Address.Address}. As it does not exist on worksheet {_ws.Name}. " +
-                            $"Try {_ws.Name}!{wsNameAddress[1]} instead or add the dataValidation to {wsNameAddress[0]}");
-                    }
+                    throw new InvalidOperationException(
+                        $"Cannot write to address {_ws.DataValidations[i].Address.Address}. As it does not exist on worksheet {_ws.Name}. " +
+                        $"Try {_ws.Name}!{_ws.DataValidations[i].Address.LocalAddress} instead or add the dataValidation to {_ws.DataValidations[i].Address.WorkSheetName}");
                 }
 
-               cache.Append($"sqref=\"{_ws.DataValidations[i].Address.LocalAddress.ToString().Replace(",", " ")}\" ");
+               cache.Append($"sqref=\"{_ws.DataValidations[i].Address.LocalAddress.Replace(",", " ")}\" ");
 
             }
 

--- a/src/EPPlus/ExcelXMLWriter/ExcelXmlWriter.cs
+++ b/src/EPPlus/ExcelXMLWriter/ExcelXmlWriter.cs
@@ -639,7 +639,20 @@ namespace OfficeOpenXml.ExcelXMLWriter
 
             if (_ws.DataValidations[i].InternalValidationType == InternalValidationType.DataValidation)
             {
-                cache.Append($"sqref=\"{_ws.DataValidations[i].Address.ToString().Replace(",", " ")}\" ");
+                var wsNameAddress = _ws.DataValidations[i].Address.Address.Split('!');
+
+                if (wsNameAddress.Length > 1)
+                {
+                    if (wsNameAddress[0] != _ws.Name)
+                    {
+                        throw new InvalidOperationException(
+                            $"Cannot write to address {_ws.DataValidations[i].Address.Address}. As it does not exist on worksheet {_ws.Name}. " +
+                            $"Try {_ws.Name}!{wsNameAddress[1]} instead or add the dataValidation to {wsNameAddress[0]}");
+                    }
+                }
+
+               cache.Append($"sqref=\"{_ws.DataValidations[i].Address.LocalAddress.ToString().Replace(",", " ")}\" ");
+
             }
 
             cache.Append($"xr:uid=\"{_ws.DataValidations[i].Uid}\"");

--- a/src/EPPlus/ExcelXMLWriter/ExcelXmlWriter.cs
+++ b/src/EPPlus/ExcelXMLWriter/ExcelXmlWriter.cs
@@ -639,16 +639,7 @@ namespace OfficeOpenXml.ExcelXMLWriter
 
             if (_ws.DataValidations[i].InternalValidationType == InternalValidationType.DataValidation)
             {
-
-                if (_ws.DataValidations[i].Address.WorkSheetName != null && _ws.DataValidations[i].Address.WorkSheetName != _ws.Name)
-                {
-                    throw new InvalidOperationException(
-                        $"Cannot write to address {_ws.DataValidations[i].Address.Address}. As it does not exist on worksheet {_ws.Name}. " +
-                        $"Try {_ws.Name}!{_ws.DataValidations[i].Address.LocalAddress} instead or add the dataValidation to {_ws.DataValidations[i].Address.WorkSheetName}");
-                }
-
-               cache.Append($"sqref=\"{_ws.DataValidations[i].Address.LocalAddress.Replace(",", " ")}\" ");
-
+               cache.Append($"sqref=\"{_ws.DataValidations[i].Address.Address.Replace(",", " ")}\" ");
             }
 
             cache.Append($"xr:uid=\"{_ws.DataValidations[i].Uid}\"");

--- a/src/EPPlusTest/DataValidation/DataValidationTests.cs
+++ b/src/EPPlusTest/DataValidation/DataValidationTests.cs
@@ -1083,5 +1083,38 @@ namespace EPPlusTest.DataValidation
                 Assert.AreEqual("ExtTestSheet!$C$5", validation.As.IntegerValidation.Formula.ExcelFormula);
             }
         }
+
+        [TestMethod]
+        public void OwnSheetNameApostrophe_ShouldNotThrow()
+        {
+            using (var package = new ExcelPackage())
+            {
+                package.Workbook.Worksheets.Add("Test' She' et");
+                package.Workbook.Worksheets.Add("ExtTestSheet");
+
+                // add validation rules to ProblemMeta sheet
+                ExcelWorksheet testSheet = package.Workbook.Worksheets.GetByName("Test' She' et");
+                ExcelWorksheet extTest = package.Workbook.Worksheets.GetByName("ExtTestSheet");
+
+                if (testSheet != null)
+                {
+                    //We ignore the worksheet name and only apply the addresses
+                    var defaultValidation = testSheet.DataValidations.AddIntegerValidation("Test' She' et!$C$2 Test' She' et!$Z$5");
+                    defaultValidation.Operator = ExcelDataValidationOperator.equal;
+
+                    defaultValidation.Formula.ExcelFormula = "ExtTestSheet!$C$5";
+                }
+
+                Stream stream = new MemoryStream();
+                package.SaveAs(stream);
+
+                var readPck = new ExcelPackage(stream);
+
+                var validation = readPck.Workbook.Worksheets[0].DataValidations[0];
+                var address = readPck.Workbook.Worksheets[0].DataValidations[0].Address.Address;
+                Assert.AreEqual("$C$2,$Z$5", address);
+                Assert.AreEqual("ExtTestSheet!$C$5", validation.As.IntegerValidation.Formula.ExcelFormula);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/DataValidation/DataValidationTests.cs
+++ b/src/EPPlusTest/DataValidation/DataValidationTests.cs
@@ -992,5 +992,51 @@ namespace EPPlusTest.DataValidation
                 SaveAndCleanup(pck);
             }
         }
+
+
+        [TestMethod]
+        public void AddressContainingOwnSheetName_ShouldNotThrow()
+        {
+            using (var package = new ExcelPackage())
+            {
+                package.Workbook.Worksheets.Add("ProblemMetaSheet");
+                // add validation rules to ProblemMeta sheet
+                ExcelWorksheet metaSheet = package.Workbook.Worksheets.GetByName("ProblemMetaSheet");
+                if (metaSheet != null)
+                {
+                    var defaultValidation = metaSheet.DataValidations.AddIntegerValidation("ProblemMetaSheet!$C$2");
+                    defaultValidation.Operator = ExcelDataValidationOperator.equal;
+                }
+
+                Stream stream = new MemoryStream();
+                package.SaveAs(stream);
+
+                var readPck = new ExcelPackage(stream);
+
+                var address = readPck.Workbook.Worksheets[0].DataValidations[0].Address.Address;
+                Assert.AreEqual("$C$2", address);
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void AddressContainingOtherSheetName_ShouldThrow()
+        {
+            using (var package = new ExcelPackage())
+            {
+                package.Workbook.Worksheets.Add("ProblemMetaSheet");
+                // add validation rules to ProblemMeta sheet
+                ExcelWorksheet metaSheet = package.Workbook.Worksheets.GetByName("ProblemMetaSheet");
+                if (metaSheet != null)
+                {
+                    var defaultValidation = metaSheet.DataValidations.AddIntegerValidation("roblemMetaSheet!$C$2");
+                    defaultValidation.Operator = ExcelDataValidationOperator.equal;
+                }
+
+                Stream stream = new MemoryStream();
+                package.SaveAs(stream);
+            }
+
+        }
     }
 }

--- a/src/EPPlusTest/DataValidation/DataValidationTests.cs
+++ b/src/EPPlusTest/DataValidation/DataValidationTests.cs
@@ -999,13 +999,13 @@ namespace EPPlusTest.DataValidation
         {
             using (var package = new ExcelPackage())
             {
-                package.Workbook.Worksheets.Add("ProblemMetaSheet");
+                package.Workbook.Worksheets.Add("ExSheet");
                 // add validation rules to ProblemMeta sheet
-                ExcelWorksheet metaSheet = package.Workbook.Worksheets.GetByName("ProblemMetaSheet");
-                if (metaSheet != null)
+                ExcelWorksheet exSheet = package.Workbook.Worksheets.GetByName("ExSheet");
+                if (exSheet != null)
                 {
-                    var defaultValidation = metaSheet.DataValidations.AddIntegerValidation("ProblemMetaSheet!$C$2");
-                    defaultValidation.Operator = ExcelDataValidationOperator.equal;
+                    var intValidation = exSheet.DataValidations.AddIntegerValidation("ExSheet!$C$2");
+                    intValidation.Operator = ExcelDataValidationOperator.equal;
                 }
 
                 Stream stream = new MemoryStream();
@@ -1027,16 +1027,15 @@ namespace EPPlusTest.DataValidation
                 package.Workbook.Worksheets.Add("ExtTestSheet");
 
                 // add validation rules to ProblemMeta sheet
-                ExcelWorksheet metaSheet = package.Workbook.Worksheets.GetByName("TestSheet");
+                ExcelWorksheet testSheet = package.Workbook.Worksheets.GetByName("TestSheet");
                 ExcelWorksheet extTest = package.Workbook.Worksheets.GetByName("ExtTestSheet");
 
-                if (metaSheet != null)
+                if (testSheet != null)
                 {
-                    var defaultValidation = metaSheet.DataValidations.AddIntegerValidation("TestSheet!$C$2 TestSheet!$Z$2");
-                    defaultValidation.Operator = ExcelDataValidationOperator.equal;
+                    var intValidation = testSheet.DataValidations.AddIntegerValidation("TestSheet!$C$2 TestSheet!$Z$2");
+                    intValidation.Operator = ExcelDataValidationOperator.equal;
 
-                    defaultValidation.Formula.ExcelFormula = "ExtTestSheet!$C$5";
-
+                    intValidation.Formula.ExcelFormula = "ExtTestSheet!$C$5";
                 }
 
                 Stream stream = new MemoryStream();
@@ -1052,7 +1051,7 @@ namespace EPPlusTest.DataValidation
         }
 
         [TestMethod]
-        public void MultipleAddressContainingOtherSheetName_ShouldThrow()
+        public void MultipleAddressContainingOtherSheetName_ShouldNotThrow()
         {
             using (var package = new ExcelPackage())
             {
@@ -1060,12 +1059,13 @@ namespace EPPlusTest.DataValidation
                 package.Workbook.Worksheets.Add("ExtTestSheet");
 
                 // add validation rules to ProblemMeta sheet
-                ExcelWorksheet metaSheet = package.Workbook.Worksheets.GetByName("TestSheet");
+                ExcelWorksheet testSheet = package.Workbook.Worksheets.GetByName("TestSheet");
                 ExcelWorksheet extTest = package.Workbook.Worksheets.GetByName("ExtTestSheet");
 
-                if (metaSheet != null)
+                if (testSheet != null)
                 {
-                    var defaultValidation = metaSheet.DataValidations.AddIntegerValidation("ExtTestSheet!$C$2 ExtTestSheet!$Z$2");
+                    //We ignore the worksheet name and only apply the addresses
+                    var defaultValidation = testSheet.DataValidations.AddIntegerValidation("ExtTestSheet!$C$2 ExtTestSheet!$Z$2");
                     defaultValidation.Operator = ExcelDataValidationOperator.equal;
 
                     defaultValidation.Formula.ExcelFormula = "ExtTestSheet!$C$5";


### PR DESCRIPTION
Added ability to refer to a dataValidation address with the sheet name and exclamation point instead of generating corrupt workbook.

Also added check for not refering to other workbook throwing an error on save if address is a reference to another workbook than the one you're placing the validation on.