### PR TITLE
Bug/i923 cf range update incorrectly

### DIFF
--- a/src/EPPlus/Core/Worksheet/WorksheetRangeBaseHelper.cs
+++ b/src/EPPlus/Core/Worksheet/WorksheetRangeBaseHelper.cs
@@ -12,7 +12,10 @@
  *************************************************************************************************/
 using OfficeOpenXml.ConditionalFormatting;
 using OfficeOpenXml.DataValidation;
+using OfficeOpenXml.DataValidation.Contracts;
 using OfficeOpenXml.DataValidation.Formulas.Contracts;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace OfficeOpenXml.Core.Worksheet
 {
@@ -20,14 +23,16 @@ namespace OfficeOpenXml.Core.Worksheet
     {
         internal static void AdjustDvAndCfFormulasRow(ExcelWorksheet ws, int rowFrom, int rows)
         {
-            foreach (var dv in ws.DataValidations)
+            for (int i = 0; i < ws.DataValidations.Count; i++)
             {
-                if (dv is ExcelDataValidationWithFormula<IExcelDataValidationFormula> dvFormula)
+                var type = ws.DataValidations.GetFormulas(ws.DataValidations[i], out IExcelDataValidationFormula Formula, out IExcelDataValidationFormula Formula2);
+
+                if (Formula != null)
                 {
-                    dvFormula.Formula.ExcelFormula = ExcelCellBase.UpdateFormulaReferences(dvFormula.Formula.ExcelFormula, rows, 0, rowFrom, 0, ws.Name, ws.Name);
-                    if (dv is ExcelDataValidationWithFormula2<IExcelDataValidationFormula> dvFormula2)
+                    Formula.ExcelFormula = ExcelCellBase.UpdateFormulaReferences(Formula.ExcelFormula, rows, 0, rowFrom, 0, ws.Name, ws.Name);
+                    if (Formula2 != null)
                     {
-                        dvFormula2.Formula2.ExcelFormula = ExcelCellBase.UpdateFormulaReferences(dvFormula2.Formula2.ExcelFormula, rows, 0, rowFrom, 0, ws.Name, ws.Name);
+                        Formula2.ExcelFormula = ExcelCellBase.UpdateFormulaReferences(Formula2.ExcelFormula, rows, 0, rowFrom, 0, ws.Name, ws.Name);
                     }
                 }
             }
@@ -47,7 +52,7 @@ namespace OfficeOpenXml.Core.Worksheet
 
         internal static void AdjustDvAndCfFormulasColumn(ExcelWorksheet ws, int columnFrom, int columns)
         {
-            foreach (var dv in ws.DataValidations)
+            foreach (ExcelDataValidation dv in ws.DataValidations)
             {
                 if (dv is ExcelDataValidationWithFormula<IExcelDataValidationFormula> dvFormula)
                 {

--- a/src/EPPlus/Core/Worksheet/WorksheetRangeBaseHelper.cs
+++ b/src/EPPlus/Core/Worksheet/WorksheetRangeBaseHelper.cs
@@ -44,60 +44,6 @@ namespace OfficeOpenXml.Core.Worksheet
                 }
             }
         }
-        //internal static void AdjustDvAndCfFormulasDelete(ExcelRangeBase range, ExcelAddressBase affectedRange, eShiftTypeDelete shift)
-        //{
-        //    var ws=range.Worksheet;
-        //    foreach (var dv in ws.DataValidations)
-        //    {
-        //        if (dv is ExcelDataValidationWithFormula<IExcelDataValidationFormula> dvFormula)
-        //        {
-        //            dvFormula.Formula.ExcelFormula = ExcelCellBase.UpdateFormulaReferences(dvFormula.Formula.ExcelFormula, range, affectedRange, shift, ws.Name, ws.Name);
-        //            if (dv is ExcelDataValidationWithFormula2<IExcelDataValidationFormula> dvFormula2)
-        //            {
-        //                dvFormula2.Formula2.ExcelFormula = ExcelCellBase.UpdateFormulaReferences(dvFormula2.Formula2.ExcelFormula, range, affectedRange, shift, ws.Name, ws.Name);
-        //            }
-        //        }
-        //    }
-
-        //    foreach (ExcelConditionalFormattingRule cf in ws.ConditionalFormatting)
-        //    {
-        //        if (!string.IsNullOrEmpty(cf.Formula))
-        //        {
-        //            cf.Formula = ExcelCellBase.UpdateFormulaReferences(cf.Formula, range, affectedRange, shift, ws.Name, ws.Name);
-        //        }
-        //        if (!string.IsNullOrEmpty(cf.Formula2))
-        //        {
-        //            cf.Formula2 = ExcelCellBase.UpdateFormulaReferences(cf.Formula2, range, affectedRange, shift, ws.Name, ws.Name);
-        //        }
-        //    }
-        //}
-        //internal static void AdjustDvAndCfFormulasInsert(ExcelRangeBase range, ExcelAddressBase affectedRange, eShiftTypeInsert shift)
-        //{
-        //    var ws = range.Worksheet;
-        //    foreach (var dv in ws.DataValidations)
-        //    {
-        //        if (dv is ExcelDataValidationWithFormula<IExcelDataValidationFormula> dvFormula)
-        //        {
-        //            dvFormula.Formula.ExcelFormula = ExcelCellBase.UpdateFormulaReferences(dvFormula.Formula.ExcelFormula, range, affectedRange, shift, ws.Name, ws.Name);
-        //            if (dv is ExcelDataValidationWithFormula2<IExcelDataValidationFormula> dvFormula2)
-        //            {
-        //                dvFormula2.Formula2.ExcelFormula = ExcelCellBase.UpdateFormulaReferences(dvFormula2.Formula2.ExcelFormula, range, affectedRange, shift, ws.Name, ws.Name);
-        //            }
-        //        }
-        //    }
-
-        //    foreach (ExcelConditionalFormattingRule cf in ws.ConditionalFormatting)
-        //    {
-        //        if (!string.IsNullOrEmpty(cf.Formula))
-        //        {
-        //            cf.Formula = UpdateFirstCellInFormula(cf.Formula, range, affectedRange, shift);
-        //        }
-        //        if (!string.IsNullOrEmpty(cf.Formula2))
-        //        {
-        //            cf.Formula2 = ExcelCellBase.UpdateFormulaReferences(cf.Formula2, range, affectedRange, shift, ws.Name, ws.Name);
-        //        }
-        //    }
-        //}
 
         internal static void AdjustDvAndCfFormulasColumn(ExcelWorksheet ws, int columnFrom, int columns)
         {

--- a/src/EPPlus/Core/Worksheet/WorksheetRangeDeleteHelper.cs
+++ b/src/EPPlus/Core/Worksheet/WorksheetRangeDeleteHelper.cs
@@ -559,18 +559,7 @@ namespace OfficeOpenXml.Core.Worksheet
                 }
                 else
                 {
-                    if (cf.Address.Address != newAddress.Address)
-                    {
-                        if (cf.Address.FirstCellAddressRelative != newAddress.FirstCellAddressRelative)
-                        {
-                            var cfr = ((ExcelConditionalFormattingRule)cf);
-                            cfr.Formula = WorksheetRangeHelper.AdjustStartCellForFormula(cfr.Formula, cf.Address, newAddress);
-                            cfr.Formula2 = WorksheetRangeHelper.AdjustStartCellForFormula(cfr.Formula2, cf.Address, newAddress);
-                        }
-
-                        ((ExcelConditionalFormattingRule)cf).Address = new ExcelAddress(newAddress.Address);
-                    }
-
+                    ((ExcelConditionalFormattingRule)cf).Address = new ExcelAddress(newAddress.Address);
                 }
             }
             deletedCF.ForEach(cf => ws.ConditionalFormatting.Remove(cf));
@@ -589,13 +578,6 @@ namespace OfficeOpenXml.Core.Worksheet
                 }
                 else
                 {
-                    if (dv is ExcelDataValidationWithFormula<IExcelDataValidationFormula> dvFormula)
-                    {
-                        if (dv.Address.FirstCellAddressRelative != newAddress.FirstCellAddressRelative)
-                        {
-                            dvFormula.Formula.ExcelFormula = WorksheetRangeHelper.AdjustStartCellForFormula(dvFormula.Formula.ExcelFormula, dv.Address, newAddress);
-                        }
-                    }
                     dv.SetAddress(newAddress.Address);
                 }
             }

--- a/src/EPPlus/Core/Worksheet/WorksheetRangeInsertHelper.cs
+++ b/src/EPPlus/Core/Worksheet/WorksheetRangeInsertHelper.cs
@@ -255,7 +255,6 @@ namespace OfficeOpenXml.Core.Worksheet
                     {
                         dv.SetAddress(newAddress.Address);
                     }
-                    
                 }
             }
             foreach (var dv in delDV)

--- a/src/EPPlus/Core/Worksheet/WorksheetRangeInsertHelper.cs
+++ b/src/EPPlus/Core/Worksheet/WorksheetRangeInsertHelper.cs
@@ -227,12 +227,6 @@ namespace OfficeOpenXml.Core.Worksheet
                     var cfr = ((ExcelConditionalFormattingRule)cf);
                     if (cfr.Address.Address != newAddress.Address)
                     {
-                        if (cfr.Address.FirstCellAddressRelative != newAddress.FirstCellAddressRelative)
-                        {
-                            cfr.Formula = WorksheetRangeHelper.AdjustStartCellForFormula(cfr.Formula, cfr.Address, newAddress);
-                            cfr.Formula2 = WorksheetRangeHelper.AdjustStartCellForFormula(cfr.Formula2, cfr.Address, newAddress);
-                        }
-                        
                         cfr.Address = new ExcelAddress(newAddress.Address);
                     }
                 }
@@ -259,13 +253,6 @@ namespace OfficeOpenXml.Core.Worksheet
                 {
                     if (dv.Address.Address != newAddress.Address)
                     {
-                        if (dv is ExcelDataValidationWithFormula<IExcelDataValidationFormula> dvFormula)
-                        {
-                            if (dv.Address.FirstCellAddressRelative != newAddress.FirstCellAddressRelative)
-                            {
-                                dvFormula.Formula.ExcelFormula = WorksheetRangeHelper.AdjustStartCellForFormula(dvFormula.Formula.ExcelFormula, dv.Address, newAddress);
-                            }
-                        }
                         dv.SetAddress(newAddress.Address);
                     }
                     

--- a/src/EPPlus/DataValidation/ExcelDataValidationCollection.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationCollection.cs
@@ -12,6 +12,9 @@
  *************************************************************************************************/
 using OfficeOpenXml.Core.CellStore;
 using OfficeOpenXml.DataValidation.Contracts;
+using OfficeOpenXml.DataValidation.Formulas;
+using OfficeOpenXml.DataValidation.Formulas.Contracts;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Math;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
 using OfficeOpenXml.Utils;
 using System;
@@ -21,6 +24,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Xml;
+using System.Xml.Linq;
 
 namespace OfficeOpenXml.DataValidation
 {
@@ -434,6 +438,62 @@ namespace OfficeOpenXml.DataValidation
         public void Clear()
         {
             _validations.Clear();
+        }
+
+        internal IExcelDataValidation GetFormulas(ExcelDataValidation dv, out IExcelDataValidationFormula Formula, out IExcelDataValidationFormula Formula2)
+        {
+            switch (dv.ValidationType.Type)
+            {
+                case eDataValidationType.TextLength:
+                case eDataValidationType.Whole:
+                    var intType = dv as ExcelDataValidationWithFormula2<IExcelDataValidationFormulaInt>;
+
+                    var form = (IExcelDataValidationFormula)intType.Formula;
+
+                    Formula = intType.Formula;
+                    Formula2 = intType.Formula2;
+
+                    return intType;
+
+                case eDataValidationType.Decimal:
+                    var decimalType = dv as ExcelDataValidationWithFormula2<IExcelDataValidationFormulaDecimal>;
+                    Formula = decimalType.Formula;
+                    Formula2 = decimalType.Formula2;
+
+                    return decimalType;
+
+                case eDataValidationType.List:
+                    var listType = dv as ExcelDataValidationWithFormula<IExcelDataValidationFormulaList>;
+                    Formula = listType.Formula;
+                    Formula2 = null;
+                    return listType;
+
+                case eDataValidationType.Time:
+                    var timeType = dv as ExcelDataValidationWithFormula2<IExcelDataValidationFormulaTime>;
+                    Formula = timeType.Formula;
+                    Formula2 = timeType.Formula2;
+                    return timeType;
+
+                case eDataValidationType.DateTime:
+                    var dateTimeType = dv as ExcelDataValidationWithFormula2<IExcelDataValidationFormulaDateTime>;
+                    Formula = dateTimeType.Formula;
+                    Formula2 = dateTimeType.Formula2;
+                    return dateTimeType;    
+
+                case eDataValidationType.Custom:
+                    var customType = dv as ExcelDataValidationWithFormula<IExcelDataValidationFormula>;
+                    Formula = customType.Formula;
+                    Formula2 = null;
+                    return customType;
+
+                case eDataValidationType.Any:
+                    Formula = null;
+                    Formula2 = null;
+                    return null;
+
+                default:
+                    throw new Exception("UNKNOWN TYPE IN GetFormulas");
+            }
         }
 
         /// <summary>

--- a/src/EPPlusTest/DataValidation/DataValidationTests.cs
+++ b/src/EPPlusTest/DataValidation/DataValidationTests.cs
@@ -932,17 +932,29 @@ namespace EPPlusTest.DataValidation
                 midValidation2.Operator = ExcelDataValidationOperator.equal;
                 bottomValidation.Operator = ExcelDataValidationOperator.equal;
 
+                topValidation.Formula.ExcelFormula = "B1";
+                midValidation.Formula.ExcelFormula = "H9";
+                bottomValidation.Formula.ExcelFormula = "D11";
+
                 sheet.InsertRow(9, 5);
 
                 Assert.AreEqual(topValidation, sheet.DataValidations._validationsRD.GetValuesFromRange(5, 8, 5, 8)[0]);
                 Assert.AreEqual(midValidation, sheet.DataValidations._validationsRD.GetValuesFromRange(15, 8, 15, 8)[0]);
                 Assert.AreEqual(midValidation2, sheet.DataValidations._validationsRD.GetValuesFromRange(15, 7,15, 7)[0]);
                 Assert.AreEqual(bottomValidation, sheet.DataValidations._validationsRD.GetValuesFromRange(25, 8, 25, 8)[0]);
+                
+                Assert.AreEqual("B1", topValidation.Formula.ExcelFormula);
+                Assert.AreEqual("H14", midValidation.Formula.ExcelFormula);
+                Assert.AreEqual("D16", bottomValidation.Formula.ExcelFormula);
 
                 sheet.InsertRow(16, 50);
                 Assert.AreEqual(midValidation, sheet.DataValidations._validationsRD.GetValuesFromRange(15, 8, 15, 8)[0]);
                 Assert.AreEqual(midValidation2, sheet.DataValidations._validationsRD.GetValuesFromRange(15, 7, 15, 7)[0]);
                 Assert.AreEqual(bottomValidation, sheet.DataValidations._validationsRD.GetValuesFromRange(75, 8, 75, 8)[0]);
+
+                Assert.AreEqual("B1", topValidation.Formula.ExcelFormula);
+                Assert.AreEqual("H14", midValidation.Formula.ExcelFormula);
+                Assert.AreEqual("D66", bottomValidation.Formula.ExcelFormula);
 
                 sheet.DeleteRow(9);
 
@@ -951,7 +963,15 @@ namespace EPPlusTest.DataValidation
                 Assert.AreEqual(midValidation2, sheet.DataValidations._validationsRD.GetValuesFromRange(14, 7, 14, 7)[0]);
                 Assert.AreEqual(bottomValidation, sheet.DataValidations._validationsRD.GetValuesFromRange(74, 8, 74, 8)[0]);
 
+                Assert.AreEqual("B1", topValidation.Formula.ExcelFormula);
+                Assert.AreEqual("H13", midValidation.Formula.ExcelFormula);
+                Assert.AreEqual("D65", bottomValidation.Formula.ExcelFormula);
+
                 sheet.DeleteRow(14);
+
+                Assert.AreEqual("B1", topValidation.Formula.ExcelFormula);
+                Assert.AreEqual("H13", midValidation.Formula.ExcelFormula);
+                Assert.AreEqual("D64", bottomValidation.Formula.ExcelFormula);
 
                 Assert.IsFalse(sheet.DataValidations._validationsRD.Exists(midValidation.Address._fromRow,midValidation.Address._fromCol,
                                                                            midValidation.Address._toRow,midValidation.Address._toCol));
@@ -965,29 +985,35 @@ namespace EPPlusTest.DataValidation
         [TestMethod]
         public void InsertDeleteTestRanges()
         {
-            using (var pck = OpenPackage("DV_InsertDelete.xlsx", true))
+            using (var pck = OpenPackage("DV_InsertDeleteRanges.xlsx", true))
             {
                 var sheet = pck.Workbook.Worksheets.Add("insertDel");
-                var topValidation = sheet.DataValidations.AddDecimalValidation("G5:G50");
-                var midValidation = sheet.DataValidations.AddDecimalValidation("H10:H25");
+                var topValidation = sheet.DataValidations.AddListValidation("G5:G50");
+                var midValidation = sheet.DataValidations.AddListValidation("H10:H25");
 
-                topValidation.Operator = ExcelDataValidationOperator.equal;
-                midValidation.Operator = ExcelDataValidationOperator.equal;
-
+                topValidation.Formula.ExcelFormula = "G4:G50";
+                midValidation.Formula.ExcelFormula = "H10:H25";
 
                 sheet.InsertRow(9, 5);
 
-                Assert.AreEqual(topValidation, sheet.DataValidations._validationsRD.GetValuesFromRange(10, 7, 12, 7)[0]);
-                Assert.AreEqual(0, sheet.DataValidations._validationsRD.GetValuesFromRange(10, 8, 14, 8).Count);
+                Assert.AreEqual("G4:G55", topValidation.Formula.ExcelFormula);
+                Assert.AreEqual("H15:H30", midValidation.Formula.ExcelFormula);
 
                 sheet.InsertRow(16, 50);
+
                 Assert.AreEqual(topValidation, sheet.DataValidations._validationsRD.GetValuesFromRange(16, 7, 20, 7)[0]);
                 Assert.AreEqual(midValidation, sheet.DataValidations._validationsRD.GetValuesFromRange(16, 8, 25, 8)[0]);
+
+                Assert.AreEqual("G4:G105", topValidation.Formula.ExcelFormula);
+                Assert.AreEqual("H15:H80", midValidation.Formula.ExcelFormula);
 
                 sheet.DeleteRow(9);
 
                 Assert.AreEqual(topValidation, sheet.DataValidations._validationsRD.GetValuesFromRange(104, 7, 104, 7)[0]);
                 Assert.AreEqual(0, sheet.DataValidations._validationsRD.GetValuesFromRange(80, 8, 80, 8).Count);
+
+                Assert.AreEqual("G4:G104", topValidation.Formula.ExcelFormula);
+                Assert.AreEqual("H14:H79", midValidation.Formula.ExcelFormula);
 
                 SaveAndCleanup(pck);
             }

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -5043,5 +5043,42 @@ namespace EPPlusTest
                 SaveAndCleanup(package);
             }
         }
+
+        [TestMethod]
+        public void i923()
+        {
+            using (ExcelPackage package = OpenPackage("cf_i923.xlsx", true))
+            {
+                // add a new worksheet to the empty workbook
+                ExcelWorksheet worksheet = package.Workbook.Worksheets.Add("Conditional Formatting");
+
+                // Create 4 columns of samples data
+                for (int col = 1; col < 10; col++)
+                {
+                    // Add the headers
+                    worksheet.Cells[1, col].Value = "Sample " + col;
+
+                    for (int row = 2; row < 21; row++)
+                    {
+                        // Add some items...
+                        worksheet.Cells[row, col].Value = "Me";
+                    }
+                }
+
+                var range = worksheet.Cells["C:Z"];
+
+                // -------------------------------------------------------------------
+                // Create a ContainsText rule
+                // -------------------------------------------------------------------
+                var cfRule28 = range.ConditionalFormatting.AddContainsText();
+                cfRule28.Text = "Me";
+                cfRule28.Style.Fill.BackgroundColor.Color = Color.FromArgb(198, 239, 206);
+
+                worksheet.DeleteColumn(1); // <--- THIS LINE CAUSES THE BUG
+
+                // save our new workbook and we are done!
+                package.Save();
+            }
+        }
     }
 }

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -5058,17 +5058,19 @@ namespace EPPlusTest
 
                     for (int row = 2; row < 21; row++)
                     {
-                        worksheet.Cells[row, col].Value = "ValueItem";
+                        worksheet.Cells[row, col].Value = "Value";
                     }
                 }
 
                 var range = worksheet.Cells["C:Z"];
 
                 var cfRule = range.ConditionalFormatting.AddContainsText();
-                cfRule.Text = "ValueItem";
+                cfRule.Text = "Value";
                 cfRule.Style.Fill.BackgroundColor.Color = Color.FromArgb(198, 239, 206);
 
                 worksheet.DeleteColumn(1);
+
+                Assert.AreEqual("NOT(ISERROR(SEARCH(\"Value\",B1)))", ((ExcelConditionalFormattingRule)cfRule).Formula);
 
                 package.Save();
             }


### PR DESCRIPTION
ConditionalFormatting text types would fail to function correctly after deleting column1 as the inital address was updated twice

A related bug was also found on all dataValidations. This fixes both.