### PR TITLE
Attribute fixes in EPPlus 6 to develop7

### DIFF
--- a/src/EPPlus/Attributes/EpplusTableColumnAttributeBase.cs
+++ b/src/EPPlus/Attributes/EpplusTableColumnAttributeBase.cs
@@ -52,6 +52,15 @@ namespace OfficeOpenXml.Attributes
         }
 
         /// <summary>
+        /// If true, the entire column will be hidden.
+        /// </summary>
+        public bool Hidden
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// If not <see cref="RowFunctions.None"/> the last cell in the column (the totals row) will contain a formula of the specified type.
         /// </summary>
         public RowFunctions TotalsRowFunction

--- a/src/EPPlus/LoadFunctions/ColumnInfo.cs
+++ b/src/EPPlus/LoadFunctions/ColumnInfo.cs
@@ -41,6 +41,8 @@ namespace OfficeOpenXml.LoadFunctions
 
         public string Header { get; set; }
 
+        public bool Hidden { get; set; }
+
         public string NumberFormat { get; set; }
 
         public RowFunctions TotalsRowFunction { get; set; }

--- a/src/EPPlus/LoadFunctions/LoadFromCollection.cs
+++ b/src/EPPlus/LoadFunctions/LoadFromCollection.cs
@@ -51,6 +51,7 @@ namespace OfficeOpenXml.LoadFunctions
                 var cols = new LoadFromCollectionColumns<T>(parameters.BindingFlags, SortOrderProperties);
                 var columns = cols.Setup();
                 _columns = columns.ToArray();
+                SetHiddenColumns();
             }
             else
             {
@@ -59,9 +60,15 @@ namespace OfficeOpenXml.LoadFunctions
                 {
                     throw (new ArgumentException("Parameter Members must have at least one property. Length is zero"));
                 }
+                var colIx = 0;
                 foreach (var columnInfo in _columns)
                 {
                     if (columnInfo.MemberInfo == null) continue;
+                    if (columnInfo.Hidden)
+                    {
+                        Range.Worksheet.Column(Range._fromCol + colIx).Hidden = true;
+                    }
+                    colIx++;
                     var member = columnInfo.MemberInfo;
                     if (member.DeclaringType != null && member.DeclaringType != type)
                     {
@@ -151,7 +158,19 @@ namespace OfficeOpenXml.LoadFunctions
             SetValuesAndFormulas(values, formulaCells, ref col, ref row);
         }
 
-        
+        private void SetHiddenColumns()
+        {
+            for (var colIx = 0; colIx < _columns.Length; colIx++)
+            {
+                var columnInfo = _columns[colIx];
+                if (columnInfo.Hidden)
+                {
+                    Range.Worksheet.Column(Range._fromCol + colIx).Hidden = true;
+                }
+            }
+        }
+
+
 
         private void SetValuesAndFormulas(object[,] values, Dictionary<int, FormulaCell> formulaCells, ref int col, ref int row)
         {

--- a/src/EPPlus/LoadFunctions/LoadFromCollectionColumns.cs
+++ b/src/EPPlus/LoadFunctions/LoadFromCollectionColumns.cs
@@ -125,6 +125,7 @@ namespace OfficeOpenXml.LoadFunctions
                     var header = default(string);
                     var sortOrderColumnsIndex = _sortOrderColumns != null ? _sortOrderColumns.IndexOf(memberPath) : -1;
                     var sortOrder = sortOrderColumnsIndex > -1 ? sortOrderColumnsIndex : SortOrderOffset;
+                    var hidden = false;
                     var numberFormat = string.Empty;
                     var rowFunction = RowFunctions.None;
                     var totalsRowNumberFormat = string.Empty;
@@ -134,6 +135,7 @@ namespace OfficeOpenXml.LoadFunctions
                     var epplusColumnAttr = member.GetFirstAttributeOfType<EpplusTableColumnAttribute>();
                     if (epplusColumnAttr != null)
                     {
+                        hidden = epplusColumnAttr.Hidden;
                         if(!string.IsNullOrEmpty(epplusColumnAttr.Header) && !string.IsNullOrEmpty(headerPrefix))
                         {
                             header = $"{headerPrefix} {epplusColumnAttr.Header}";
@@ -173,6 +175,7 @@ namespace OfficeOpenXml.LoadFunctions
                         Header = header,
                         SortOrder = sortOrder,
                         Index = index++,
+                        Hidden = hidden,
                         SortOrderLevels = colInfoSortOrderList,
                         MemberInfo = member,
                         NumberFormat = numberFormat,

--- a/src/EPPlus/LoadFunctions/LoadFromCollectionColumns.cs
+++ b/src/EPPlus/LoadFunctions/LoadFromCollectionColumns.cs
@@ -84,6 +84,10 @@ namespace OfficeOpenXml.LoadFunctions
                     var memberPath = path != null ? $"{path}.{member.Name}" : member.Name;
                     if (member.HasPropertyOfType<EpplusNestedTableColumnAttribute>())
                     {
+                        if (member.PropertyType == typeof(string) || (!member.PropertyType.IsClass && !member.PropertyType.IsInterface))
+                        {
+                            throw new InvalidOperationException($"EpplusNestedTableColumn attribute can only be used with complex types (member: {memberPath})");
+                        }
                         var nestedTableAttr = member.GetFirstAttributeOfType<EpplusNestedTableColumnAttribute>();
                         var attrOrder = nestedTableAttr.Order;
                         hPrefix = nestedTableAttr.HeaderPrefix;

--- a/src/EPPlusTest/LoadFunctions/LoadFromCollectionAttributesComplexTypeTests.cs
+++ b/src/EPPlusTest/LoadFunctions/LoadFromCollectionAttributesComplexTypeTests.cs
@@ -221,5 +221,41 @@ namespace EPPlusTest.LoadFunctions
                 Assert.AreEqual("Created (GMT)", sheet.Cells["L1"].Value);
             }
         }
+
+        [TestMethod]
+        public void HiddenTest1()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var items = new List<OuterWithHiddenColumn>
+                {
+                    new OuterWithHiddenColumn
+                    {
+                        Active = false,
+                        Number = 1,
+                        HiddenName = "Hidden 1",
+                        Name = "Name 1"
+                    },
+                    new OuterWithHiddenColumn
+                    {
+                        Active = true,
+                        Number = 2,
+                        HiddenName = "Hidden 2",
+                        Name = "Name 2"
+                    }
+                };
+                var sheet = package.Workbook.Worksheets.Add("test");
+                sheet.Cells["A1"].LoadFromCollection(items);
+
+                Assert.IsTrue(sheet.Column(1).Hidden);
+                Assert.IsFalse((bool)sheet.Cells[1, 1].Value);
+                Assert.IsFalse(sheet.Column(2).Hidden);
+                Assert.AreEqual(1, sheet.Cells[1, 2].Value);
+                Assert.IsTrue(sheet.Column(3).Hidden);
+                Assert.AreEqual("Hidden 1", sheet.Cells[1, 3].Value);
+                Assert.IsFalse(sheet.Column(4).Hidden);
+                Assert.AreEqual("Name 1", sheet.Cells[1, 4].Value);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/LoadFunctions/LoadFromCollectionAttributesErrorTests.cs
+++ b/src/EPPlusTest/LoadFunctions/LoadFromCollectionAttributesErrorTests.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using OfficeOpenXml.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EPPlusTest.LoadFunctions
+{
+    public class NestedAttrOnString
+    {
+        [EpplusTableColumn(Order = 1)]
+        public string Name { get; set; }
+
+        [EpplusNestedTableColumn(Order = 2)]
+        public string Value { get; set; }
+    }
+
+    [TestClass]
+    public class LoadFromCollectionAttributesErrorTests
+    {
+        [TestMethod, ExpectedException(typeof(InvalidOperationException))]
+        public void NestedTypeAttributeOnString()
+        {
+            var coll = new List<NestedAttrOnString>
+            {
+                new NestedAttrOnString
+                {
+                    Name = "foo",
+                    Value = "bar",
+                }
+            };
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test");
+                sheet.Cells["A1"].LoadFromCollection(coll);
+            }
+        }
+    }
+}

--- a/src/EPPlusTest/LoadFunctions/LoadFromCollectionWithAttributeTestClasses.cs
+++ b/src/EPPlusTest/LoadFunctions/LoadFromCollectionWithAttributeTestClasses.cs
@@ -122,4 +122,20 @@ namespace EPPlusTest.LoadFunctions
         [EpplusTableColumn(Header = "Acknowledged...", Order = 1)]
         public bool Acknowledged { get; set; }
     }
+
+    [EpplusTable]
+    public class OuterWithHiddenColumn
+    {
+        [EpplusTableColumn(Hidden = true, Order = 1)]
+        public bool Active { get; set; }
+
+        [EpplusTableColumn(Header = "Number", Order = 2)]
+        public int Number { get; set; }
+
+        [EpplusTableColumn(Hidden = true, Order = 3)]
+        public string HiddenName { get; set; }
+
+        [EpplusTableColumn(Header = "Name", Order = 4)]
+        public string Name { get; set; }
+    }
 }


### PR DESCRIPTION
#962 Added Hidden property on ExcelTableColumn attribute to EPPlus 7 branch
#970 better error message when setting NestedTableColumn attribute on scalar property