### PR TITLE
Added two test cases for issue 1022

### DIFF
--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/VLookupTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/VLookupTests.cs
@@ -43,5 +43,24 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
                 Assert.AreEqual("e", sheet.Cells["C10"].Value);
             }
         }
+
+        [TestMethod]
+        [DataRow(null, 0)]
+        [DataRow(1, 1)]
+        public void VlookupCeilingSignificance(object significance, double expected)
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test");
+                string keyValue = "key";
+                sheet.Cells["A1"].Value = keyValue;
+                sheet.Cells["B1"].Value = significance;
+                sheet.Cells["C1"].Formula= $@"CEILING(0.5,VLOOKUP(""{keyValue}"",A1:B1,2))";
+                sheet.Calculate();
+                Assert.AreEqual(expected, sheet.Cells["C1"].Value);
+            }
+        }
+
+
     }
 }


### PR DESCRIPTION
Per the guidelines:

1. I searched but did not find this on StackOverflow.
2. I searched issues and did not find this reported, so I created #1022

The single commit adds a vlookup test method with 1 passing and 1 failing test case. The issue may be with the Ceiling function as `=Ceiling(.5,<blank>)` also returns `#Value!`, but I just wasn't certain, so I when with VLookupTests.cs

Hope this is helpful.