### PR TITLE
Feature/calc chain by depth

### DIFF
--- a/src/EPPlus/FormulaParsing/DependencyChain/DependenyChainFactory.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/DependenyChainFactory.cs
@@ -160,11 +160,9 @@ namespace OfficeOpenXml.FormulaParsing
         /// <param name="options">Calcultaiton options</param>
         private static void FollowChain(DependencyChain depChain, ILexer lexer, ExcelWorkbook wb, ExcelWorksheet ws, FormulaCell f, ExcelCalculationOption options)
         {
-            Stack<FormulaCell> stack = new Stack<FormulaCell>();
-            int depth = 0; // tracks the current depth during traversal
+            Stack<FormulaCell> stack = new Stack<FormulaCell>();            
             f.ChainDepth = 0; // set the initial chain depth while f is still the original f
         iterateToken:
-            depth = f.ChainDepth; // iterate from whatever depth FormulaCell f is at
             while (f.tokenIx < f.Tokens.Count)
             {
                 var t = f.Tokens[f.tokenIx];
@@ -286,7 +284,7 @@ namespace OfficeOpenXml.FormulaParsing
                                     rf.iteratorWs = wb.Worksheets._worksheets[rf.wsIndex];
                                 }
                                 rf.Tokens = rf.iteratorWs==null ? lexer.Tokenize(rf.Formula).ToList() : lexer.Tokenize(rf.Formula, rf.iteratorWs.Name).ToList();
-                                rf.ChainDepth = depth; // this new formula cell is at the current depth
+                                rf.ChainDepth = f.ChainDepth; // this new formula cell is at the current depth
                                 depChain.Add(rf);
                                 stack.Push(f);
                                 f = rf;
@@ -319,7 +317,6 @@ namespace OfficeOpenXml.FormulaParsing
             if (stack.Count > 0)
             {
                 f = stack.Pop();
-                depth = f.ChainDepth; // resume iterating cells with the popped formula cell's depth 
                 goto iterateCells;
             }
             return;
@@ -343,7 +340,7 @@ namespace OfficeOpenXml.FormulaParsing
                     rf.ws = f.iteratorWs;
                     rf.Tokens = lexer.Tokenize(rf.Formula, f.iteratorWs.Name).ToList();
                     ws._formulaTokens.SetValue(rf.Row, rf.Column, rf.Tokens);
-                    rf.ChainDepth = depth + 1; // this new formula cell is at the next depth
+                    rf.ChainDepth = f.ChainDepth + 1; // this new formula cell is at the next depth
                     depChain.Add(rf);
                     stack.Push(f);                    
                     f = rf;
@@ -370,7 +367,6 @@ namespace OfficeOpenXml.FormulaParsing
                                     {
                                         // TODO: Find out circular reference from and to cell
                                         f = stack.Pop();
-                                        depth = f.ChainDepth; // resume iterating with the popped formula cell's depth 
                                         goto iterateCells;
                                     }
                                 }
@@ -381,6 +377,6 @@ namespace OfficeOpenXml.FormulaParsing
             }
             f.tokenIx++;
             goto iterateToken;
-        }
+        }        
     }
 }

--- a/src/EPPlus/FormulaParsing/DependencyChain/FormulaCell.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/FormulaCell.cs
@@ -34,5 +34,9 @@ namespace OfficeOpenXml.FormulaParsing
         internal CellStoreEnumerator<object> iterator;
         internal ExcelWorksheet iteratorWs;
         internal ExcelWorksheet ws;
+        /// <summary>
+        /// stores the depth at which a cell was referenced during depth-first dependency chain traversal in in order to support a breadth-first precedent list
+        /// </summary>
+        internal int ChainDepth { get; set; } 
     }
 }

--- a/src/EPPlusTest/FormulaParsing/DependencyChainTests.cs
+++ b/src/EPPlusTest/FormulaParsing/DependencyChainTests.cs
@@ -14,8 +14,11 @@ namespace EPPlusTest.FormulaParsing
     [TestClass]
     public class DependencyChainTests
     {
+        /// <summary>
+        /// Verifies that the breadth-first chain for this tree is A1 
+        /// </summary>
         [TestMethod]
-        public void NoDepth()
+        public void ChainOrder_OneLink()
         {
             using (var package = new ExcelPackage())
             {
@@ -28,8 +31,11 @@ namespace EPPlusTest.FormulaParsing
             }
         }
 
+        /// <summary>
+        /// Verifies that the breadth-first chain for this tree is A1 > A2 
+        /// </summary>
         [TestMethod]
-        public void LowDepth()
+        public void ChainOrder_TwoLinks()
         {
             using (var package = new ExcelPackage())
             {
@@ -46,18 +52,27 @@ namespace EPPlusTest.FormulaParsing
             }
         }
 
+        /// <summary>
+        /// Verifies that the breadth-first chain for this tree is A1 > A2 > A3
+        /// 
+        ///  A1   depth=0
+        /// |  \
+        /// A2  A3  depth=1
+        /// |   |
+        /// B2  B3  depth=2
+        /// </summary>
         [TestMethod]
-        public void BranchAtDepth0()
+        public void ChainOrder_BranchAtOneDepth()
         {
             using (var package = new ExcelPackage())
             {
-                /*
-                 *   A1   depth=0
-                 *  |  \
-                 *  A2  A3  depth=1
-                 *  |   |
-                 *  B2  B3  depth=2
-                 */
+                ///
+                ///  A1   depth=0
+                /// |  \
+                /// A2  A3  depth=1
+                /// |   |
+                /// B2  B3  depth=2
+                ///
                 var sheet = package.Workbook.Worksheets.Add("test");
                 ExcelRangeBase cellA1 = sheet.Cells["A1"];
                 cellA1.Formula = "A2+A3";
@@ -74,19 +89,20 @@ namespace EPPlusTest.FormulaParsing
             }
         }
 
-
+        /// <summary>
+        /// Verifies that the breadth-first chain for this tree is A1 > A2 > A3
+        /// 
+        ///  A1   depth=0
+        /// |   \
+        /// A2   A3   depth=1
+        /// |  \   \ 
+        /// B2  B3  B4    depth=2
+        /// </summary>
         [TestMethod]
-        public void BranchAtDepth0And1()
+        public void ChainOrder_BranchAtTwoDepths()
         {
             using (var package = new ExcelPackage())
-            {
-                /*
-                 *   A1   depth=0
-                 *  |   \
-                 *  A2   A3   depth=1
-                 *  |  \   \ 
-                 *  B2  B3  B4    depth=2
-                 */
+            {               
                 var sheet = package.Workbook.Worksheets.Add("test");
                 ExcelRangeBase cellA1 = sheet.Cells["A1"];
                 cellA1.Formula = "A2+A3";
@@ -104,21 +120,23 @@ namespace EPPlusTest.FormulaParsing
             }
         }
 
+        /// <summary>
+        /// Verifies that the breadth-first chain for this tree is A1 > B1 > B2 > C1 > C2 > C3
+        /// 
+        ///            A1   depth=0
+        ///            |    
+        ///        B1  +  B2   depth=1
+        ///        |       \     
+        ///    C1  +  C2   C3    depth=2
+        ///    |      |     \
+        ///  D1+D2  D3+D4    D5   depth=3
+        ///
+        /// </summary>
         [TestMethod]
-        public void BranchAtDepths0And1And2()
+        public void ChainOrder_BranchAtThreeDepths()
         {
             using (var package = new ExcelPackage())
-            {
-                /*
-                 *             A1   depth=0
-                 *             |    
-                 *         B1  +  B2   depth=1
-                 *         |       \     
-                 *     C1  +  C2   C3    depth=2
-                 *     |      |     \
-                 *   D1+D2  D3+D4    D5   depth=3
-                 *  
-                 */
+            {                
                 var sheet = package.Workbook.Worksheets.Add("test");
                 ExcelRangeBase cellA1 = sheet.Cells["A1"];
                 cellA1.Formula = "B1+B2";
@@ -144,6 +162,52 @@ namespace EPPlusTest.FormulaParsing
                 Assert.AreEqual(depthTree.ToList()[5].Address, cellC3.Address); // C3 at last
             }
         }
+
+
+        /// <summary>
+        /// This test fails because breadth-first traversal is being simulated in a depth-first algorithm
+        /// Despite A1 referencing B2 "higher" than C1's reference to B2, C1's reference is encountered first, so B2 is treated as being "lower" than C1
+        /// Only truly breadth-first traversal can produce the true breadth-first ordered results
+        /// </summary>
+        [TestMethod]
+        public void ChainOrder_MultipleReferences()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test");
+                ExcelRangeBase A1 = sheet.Cells["A1"];
+                A1.Formula = "B1+B2";  //<--- this instance of a reference B2 will be found second during depth-first tree traversal
+                ExcelRangeBase B1 = sheet.Cells["B1"];
+                B1.Formula = "C1";
+                ExcelRangeBase B2 = sheet.Cells["B2"];
+                B2.Formula = "C2";
+                ExcelRangeBase C1 = sheet.Cells["C1"];
+                C1.Formula = "B2"; //<--- this instance of a reference B2 will be found first during depth-first tree traversal
+
+                IEnumerable<IFormulaCellInfo> depthTree = package.Workbook.FormulaParserManager.GetCalculationChainByDepth(A1);
+                Assert.AreEqual(depthTree.ToList()[0].Address, A1.Address);
+                Assert.AreEqual(depthTree.ToList()[1].Address, B1.Address);
+                Assert.AreEqual(depthTree.ToList()[2].Address, B2.Address); // B2 should come before C1 (but this is a result of simulating breadth-first traversal from a depth-first traversal)
+                Assert.AreEqual(depthTree.ToList()[3].Address, C1.Address); // C1 should be after B2
+            }
+        }
+
+
+        /// <summary>
+        /// This is a template for testing dependency chains from an excel doc
+        /// </summary>
+        [TestMethod]
+        public void ChainOrder_FromFile()
+        {
+            using (var package = new ExcelPackage(@"Dependency Chain Depth.xlsm"))
+            {
+                var sheet = package.Workbook.Worksheets["test"];
+                ExcelRangeBase A1 = sheet.Cells["A1"];
+                IEnumerable<IFormulaCellInfo> depthTree = package.Workbook.FormulaParserManager.GetCalculationChainByDepth(A1);
+            }
+        }
+
+
 
     }
 }

--- a/src/EPPlusTest/FormulaParsing/DependencyChainTests.cs
+++ b/src/EPPlusTest/FormulaParsing/DependencyChainTests.cs
@@ -1,0 +1,149 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using OfficeOpenXml.FormulaParsing;
+using OfficeOpenXml.FormulaParsing.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EPPlusTest.FormulaParsing
+{
+    [TestClass]
+    public class DependencyChainTests
+    {
+        [TestMethod]
+        public void NoDepth()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test");
+                ExcelRangeBase cellA1 = sheet.Cells["A1"];
+                cellA1.Formula = "A2";
+                IEnumerable<IFormulaCellInfo> depthTree = package.Workbook.FormulaParserManager.GetCalculationChainByDepth(cellA1);
+
+                Assert.AreEqual(depthTree.ToList()[0].Address, cellA1.Address);
+            }
+        }
+
+        [TestMethod]
+        public void LowDepth()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test");
+                ExcelRangeBase cellA1 = sheet.Cells["A1"];
+                cellA1.Formula = "A2";
+                ExcelRangeBase cellA2 = sheet.Cells["A2"];
+                cellA2.Formula = "A3";
+
+                IEnumerable<IFormulaCellInfo> depthTree = package.Workbook.FormulaParserManager.GetCalculationChainByDepth(cellA1);
+
+                Assert.AreEqual(depthTree.ToList()[0].Address, cellA1.Address); // A1 must come before A2
+                Assert.AreEqual(depthTree.ToList()[1].Address, cellA2.Address); // A2 must be included
+            }
+        }
+
+        [TestMethod]
+        public void BranchAtDepth0()
+        {
+            using (var package = new ExcelPackage())
+            {
+                /*
+                 *   A1   depth=0
+                 *  |  \
+                 *  A2  A3  depth=1
+                 *  |   |
+                 *  B2  B3  depth=2
+                 */
+                var sheet = package.Workbook.Worksheets.Add("test");
+                ExcelRangeBase cellA1 = sheet.Cells["A1"];
+                cellA1.Formula = "A2+A3";
+                ExcelRangeBase cellA2 = sheet.Cells["A2"];
+                cellA2.Formula = "B2";
+                ExcelRangeBase cellA3 = sheet.Cells["A3"];
+                cellA3.Formula = "B3";
+
+                IEnumerable<IFormulaCellInfo> depthTree = package.Workbook.FormulaParserManager.GetCalculationChainByDepth(cellA1);
+
+                Assert.AreEqual(depthTree.ToList()[0].Address, cellA1.Address);
+                Assert.AreEqual(depthTree.ToList()[1].Address, cellA2.Address);
+                Assert.AreEqual(depthTree.ToList()[2].Address, cellA3.Address);// B2 and B3 cannot come before A3 in a depth-first traversal
+            }
+        }
+
+
+        [TestMethod]
+        public void BranchAtDepth0And1()
+        {
+            using (var package = new ExcelPackage())
+            {
+                /*
+                 *   A1   depth=0
+                 *  |   \
+                 *  A2   A3   depth=1
+                 *  |  \   \ 
+                 *  B2  B3  B4    depth=2
+                 */
+                var sheet = package.Workbook.Worksheets.Add("test");
+                ExcelRangeBase cellA1 = sheet.Cells["A1"];
+                cellA1.Formula = "A2+A3";
+                ExcelRangeBase cellA2 = sheet.Cells["A2"];
+                cellA2.Formula = "B2+B3";
+                ExcelRangeBase cellA3 = sheet.Cells["A3"];
+                cellA3.Formula = "B4";
+                
+
+                IEnumerable<IFormulaCellInfo> depthTree = package.Workbook.FormulaParserManager.GetCalculationChainByDepth(cellA1);
+
+                Assert.AreEqual(depthTree.ToList()[0].Address, cellA1.Address);
+                Assert.AreEqual(depthTree.ToList()[1].Address, cellA2.Address);
+                Assert.AreEqual(depthTree.ToList()[2].Address, cellA3.Address); // B2 and B3 should not come before A3 in a depth-first traversal
+            }
+        }
+
+        [TestMethod]
+        public void BranchAtDepths0And1And2()
+        {
+            using (var package = new ExcelPackage())
+            {
+                /*
+                 *             A1   depth=0
+                 *             |    
+                 *         B1  +  B2   depth=1
+                 *         |       \     
+                 *     C1  +  C2   C3    depth=2
+                 *     |      |     \
+                 *   D1+D2  D3+D4    D5   depth=3
+                 *  
+                 */
+                var sheet = package.Workbook.Worksheets.Add("test");
+                ExcelRangeBase cellA1 = sheet.Cells["A1"];
+                cellA1.Formula = "B1+B2";
+                ExcelRangeBase cellB1 = sheet.Cells["B1"];
+                cellB1.Formula = "C1+C2";
+                ExcelRangeBase cellB2 = sheet.Cells["B2"];
+                cellB2.Formula = "C3";
+
+                ExcelRangeBase cellC1 = sheet.Cells["C1"];
+                cellC1.Formula = "D1+D2";
+                ExcelRangeBase cellC2 = sheet.Cells["C2"];
+                cellC2.Formula = "D3+D4";
+                ExcelRangeBase cellC3 = sheet.Cells["C3"];
+                cellC3.Formula = "D5";
+
+                IEnumerable<IFormulaCellInfo> depthTree = package.Workbook.FormulaParserManager.GetCalculationChainByDepth(cellA1);
+
+                Assert.AreEqual(depthTree.ToList()[0].Address, cellA1.Address);
+                Assert.AreEqual(depthTree.ToList()[1].Address, cellB1.Address); 
+                Assert.AreEqual(depthTree.ToList()[2].Address, cellB2.Address); // C1, C2, and C3 should not come before B2 in a depth-first traversal
+                Assert.AreEqual(depthTree.ToList()[3].Address, cellC1.Address); // C1 before C2
+                Assert.AreEqual(depthTree.ToList()[4].Address, cellC2.Address); // C2 before C3
+                Assert.AreEqual(depthTree.ToList()[5].Address, cellC3.Address); // C3 at last
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Hey there, I use EPPlus with a spreadsheet that's very challenging to follow and debug due to these factors 

- its size (number of tabs and formulas), 
- the complexity of those formulas (very lengthy, highly branching, compound formulas), and 
- the presence of many cells that return #Value! if they're not in use (red herrings everywhere) 

The dependency chain for some outputs from this spreadsheet are 10000+ links long. Because `DependencyChainFactory.FollowChain()` does a _depth-first_ tree traversal, even cells referenced in the same formula (at the top of the formula tree) can end up hundreds or thousands of links apart in the dependency chain. Figuring out what's causing a given formula to return `#Value!` with that dependency chain means outputting the chain in text and manually tracing the formulas while trying to ignore all the red herring `#Value!`s. Having access to the links in the dependency chain ordered by their "ascending precedent distance from the start of the chain" would speed up debugging tremendously because I think humans naturally think about the formulas breadth-first.

This PR is not intended to change any existing functionality. It adds depth tracking to `FormulaCell` so that a breadth-first dependency chain can be _simulated_ from the depth-first tree traversal. It works perfectly for smaller/simpler formula trees. It adds similar overloads to those present for the depth-first dependency chain retrieval. It also adds a few tests for the breadth-first dependency chain results.

However, there is definitely a catch where the simulation breaks down, and that is multiple references to the same cell. The first of multiple references to a cell determines that cell's depth. Really, the "depth" of the "highest" instance should determine the cell's "precedent distance" from the start of the chain. I have purposefully added a test that fails for this reason. The only way to correct that is with true breadth-first tree traversal, which I have purposefully not included in this PR. I may attempt to add that (and not change the existing depth-first `FollowChain()` method) in a subsequent PR, especially if I have your blessing to pursue that.

Thank you!
-Colby