### PR TITLE
#1038 Fix for INDEX function handling row_no as col_no when only one row

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Index.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Index.cs
@@ -52,14 +52,22 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             if (arg1.IsExcelRange)
             {
                 var row = ArgToInt(arguments, 1, RoundingMethod.Floor);                 
-                var col = arguments.Count()>2 ? ArgToInt(arguments, 2, RoundingMethod.Floor) : 1;
+                var col = arguments.Count()>2 ? ArgToInt(arguments, 2, RoundingMethod.Floor) : 0;
                 var ri=arg1.ValueAsRangeInfo;
-                if (row > ri.Address._toRow - ri.Address._fromRow + 1 ||
-                    col > ri.Address._toCol - ri.Address._fromCol + 1)
+                var nRows = ri.Address._toRow - ri.Address._fromRow + 1;
+                var nCols = ri.Address._toCol - ri.Address._fromCol + 1;
+                var rowIx = row - 1;
+                var colIx = col - 1;
+                if(nRows == 1 && row <= nCols && col == 0)
                 {
-                    ThrowExcelErrorValueException(eErrorType.Ref);
+                    colIx = rowIx;
+                    rowIx = 0;
                 }
-                var candidate = ri.GetOffset(row-1, col-1);
+                else if (row >  nRows ||  col > nCols || (col == 0 && nRows > 1 && nCols > 1))
+                {
+                    return CreateResult(eErrorType.Ref);
+                }
+                var candidate = ri.GetOffset(rowIx, colIx < 0 ? 0 : colIx);
                 //Commented JK-Can be any data type
                 //if (!IsNumber(candidate.Value))   
                 //{

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/IndexTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/IndexTests.cs
@@ -75,11 +75,28 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
             _worksheet.Cells["A2"].Value = 3d;
             _worksheet.Cells["A3"].Value = 5d;
 
-            _worksheet.Cells["A4"].Formula = "INDEX(A1:A3;3)";
+            _worksheet.Cells["A4"].Formula = "INDEX(A1:A3,3)";
 
             _worksheet.Calculate();
 
             Assert.AreEqual(5d, _worksheet.Cells["A4"].Value);
+        }
+
+        [TestMethod]
+        public void Index_Should_Handle_MultiRowColRange()
+        {
+            _worksheet.Cells["A1"].Value = 1d;
+            _worksheet.Cells["A2"].Value = 3d;
+            _worksheet.Cells["A3"].Value = 5d;
+            _worksheet.Cells["B1"].Value = 2d;
+            _worksheet.Cells["B2"].Value = 4d;
+            _worksheet.Cells["B3"].Value = 6d;
+
+            _worksheet.Cells["A4"].Formula = "INDEX(A1:B3,3,2)";
+
+            _worksheet.Calculate();
+
+            Assert.AreEqual(6d, _worksheet.Cells["A4"].Value);
         }
 
         [TestMethod]
@@ -104,6 +121,28 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
             _worksheet.Calculate();
 
             Assert.AreEqual("value_to_match", _worksheet.Cells["B2"].Value);
+        }
+
+        [TestMethod]
+        public void ShouldUseRowIxAsColIxIfOnlyOneRow()
+        {
+            _worksheet.Cells["A1"].Value = 1;
+            _worksheet.Cells["B1"].Value = 2;
+            _worksheet.Cells["A2"].Formula = "INDEX(A1:B1,2)";
+            _worksheet.Calculate();
+            Assert.AreEqual(2, _worksheet.Cells["A2"].Value);
+        }
+
+        [TestMethod]
+        public void ShouldReturnRefIfNoColIxMoreThanOneRow()
+        {
+            _worksheet.Cells["A1"].Value = 1;
+            _worksheet.Cells["B1"].Value = 2;
+            _worksheet.Cells["A2"].Value = 3;
+            _worksheet.Cells["B2"].Value = 4;
+            _worksheet.Cells["A2"].Formula = "INDEX(A1:B2,2)";
+            _worksheet.Calculate();
+            Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Ref), _worksheet.Cells["A2"].Value);
         }
     }
 }


### PR DESCRIPTION
If the range supplied to INDEX has only one row and row_no > 1 it should be used as column index instead.

Closes #1038 