### PR TITLE
Ensured empty dataValidation node is not written when only extLst

### DIFF
--- a/src/EPPlus/ExcelXMLWriter/ExcelXmlWriter.cs
+++ b/src/EPPlus/ExcelXMLWriter/ExcelXmlWriter.cs
@@ -78,7 +78,7 @@ namespace OfficeOpenXml.ExcelXMLWriter
             if (_ws.GetNode("d:dataValidations") != null)
             {
                 FindNodePositionAndClearIt(sw, xml, "dataValidations", ref startOfNode, ref endOfNode);
-                if(_ws.DataValidations.Count > 0)
+                if(_ws.DataValidations.GetNonExtLstCount() > 0)
                 {
                     sw.Write(UpdateDataValidation(prefix));
                 }


### PR DESCRIPTION
An empty dataValidation node with count = 0 was created when only ExtLst dataValidations existed within the workbook.
This caused the entire workbook to be rendered corrupt by excel when trying to open it there.