### PR TITLE
Fixed Databar writing error and initial values

### DIFF
--- a/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
+++ b/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
@@ -1869,6 +1869,7 @@ namespace OfficeOpenXml.ConditionalFormatting
                 eExcelConditionalFormattingRuleType.DataBar,
                 new ExcelAddress(Address));
             dataBar.Color = color;
+            dataBar.BorderColor.Color = color;
 
             return dataBar;
         }

--- a/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
+++ b/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
@@ -150,6 +150,10 @@ namespace OfficeOpenXml.ConditionalFormatting
                             dataBar.Border = string.IsNullOrEmpty(xr.GetAttribute("border")) ? false : xr.GetAttribute("border") != "0";
                             dataBar.Gradient = string.IsNullOrEmpty(xr.GetAttribute("gradient")) ? true : xr.GetAttribute("gradient") != "0";
 
+                            bool? negativeBarBorderColorSameAsPositive = null;
+                            bool? negativeBarColorSameAsPositive = null;
+
+
                             if (!string.IsNullOrEmpty(xr.GetAttribute("direction")))
                             {
                                 dataBar.Direction = (eDatabarDirection)xr.GetAttribute("direction").ToEnum<eDatabarDirection>();   
@@ -157,12 +161,12 @@ namespace OfficeOpenXml.ConditionalFormatting
 
                             if(!string.IsNullOrEmpty(xr.GetAttribute("negativeBarBorderColorSameAsPositive")))
                             {
-                                dataBar.NegativeBarBorderColorSameAsPositive = xr.GetAttribute("negativeBarBorderColorSameAsPositive") != "0";
+                                negativeBarBorderColorSameAsPositive = xr.GetAttribute("negativeBarBorderColorSameAsPositive") != "0";
                             }
 
                             if (!string.IsNullOrEmpty(xr.GetAttribute("negativeBarColorSameAsPositive")))
                             {
-                                dataBar.NegativeBarBorderColorSameAsPositive = xr.GetAttribute("negativeBarBorderColorSameAsPositive") != "0";
+                                negativeBarColorSameAsPositive = xr.GetAttribute("negativeBarColorSameAsPositive") != "0";
                             }
 
                             if (!string.IsNullOrEmpty(xr.GetAttribute("axisPosition")))
@@ -227,6 +231,16 @@ namespace OfficeOpenXml.ConditionalFormatting
                                 // textValue -> /xm:sqref -> /conditionalFormatting
                                 xr.Read();
                                 xr.Read();
+                            }
+
+                            if(negativeBarBorderColorSameAsPositive != null)
+                            {
+                                dataBar.NegativeBarBorderColorSameAsPositive = negativeBarBorderColorSameAsPositive.Value;
+                            }
+
+                            if(negativeBarColorSameAsPositive != null)
+                            {
+                                dataBar.NegativeBarColorSameAsPositive = negativeBarColorSameAsPositive.Value;
                             }
 
                             _rules.Add(dataBar);

--- a/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingIconDatabarValue.cs
+++ b/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingIconDatabarValue.cs
@@ -186,7 +186,7 @@ namespace OfficeOpenXml.ConditionalFormatting
                 else
                 {
                     throw new InvalidOperationException("Value can only be changed if Type is Num, Percent or Percentile." +
-                        $"Current Type is \"{Type}\"");
+                        $" Current Type is \"{Type}\"");
                 }
             }
         }

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingDataBar.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingDataBar.cs
@@ -63,6 +63,9 @@ internal class ExcelConditionalFormattingDataBar : ExcelConditionalFormattingRul
 
             //Excel default blue?
             FillColor.Color = Color.FromArgb(int.Parse("FF638EC6", NumberStyles.HexNumber));
+
+            NegativeFillColor.Color = Color.Red;
+            NegativeBorderColor.Color = Color.Red;
         }
 
         private void InitalizeDxfColours()

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingDataBar.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingDataBar.cs
@@ -104,7 +104,10 @@ internal class ExcelConditionalFormattingDataBar : ExcelConditionalFormattingRul
 
             if(!string.IsNullOrEmpty(xr.GetAttribute("val")))
             {
-                HighValue.Value = Double.Parse(xr.GetAttribute("val"));
+                if(highType != eExcelConditionalFormattingValueObjectType.Formula)
+                {
+                    HighValue.Value = Double.Parse(xr.GetAttribute("val"));
+                }
             }
 
             xr.Read();
@@ -113,7 +116,10 @@ internal class ExcelConditionalFormattingDataBar : ExcelConditionalFormattingRul
 
             if (!string.IsNullOrEmpty(xr.GetAttribute("val")))
             {
-                LowValue.Value = Double.Parse(xr.GetAttribute("val"));
+                if(lowType != eExcelConditionalFormattingValueObjectType.Formula)
+                {
+                    LowValue.Value = Double.Parse(xr.GetAttribute("val"));
+                }
             }
 
             xr.Read();

--- a/src/EPPlus/Core/Worksheet/XmlWriter/WorksheetXmlWriter.cs
+++ b/src/EPPlus/Core/Worksheet/XmlWriter/WorksheetXmlWriter.cs
@@ -1670,8 +1670,37 @@ namespace OfficeOpenXml.Core.Worksheet.XmlWriter
                                 typeHigh = typeHigh.Remove(0, "auto".Length);
                             }
 
-                            cache.Append($"<cfvo type=\"{typeLow.UnCapitalizeFirstLetter()}\"/>");
-                            cache.Append($"<cfvo type=\"{typeHigh.UnCapitalizeFirstLetter()}\"/>");
+                            cache.Append($"<cfvo type=\"{typeLow.UnCapitalizeFirstLetter()}\"");
+
+                            if (dataBar.LowValue.HasValueOrFormula)
+                            {
+                                if (!string.IsNullOrEmpty(dataBar.LowValue.Formula))
+                                {
+                                    cache.Append($" val=\"{dataBar.LowValue.Formula.EncodeXMLAttribute()}\"");
+                                }
+                                else
+                                {
+                                    cache.Append($" val=\"{dataBar.LowValue.Value}\"");
+                                }
+                            }
+
+                            cache.Append("/>");
+
+                            cache.Append($"<cfvo type=\"{typeHigh.UnCapitalizeFirstLetter()}\"");
+
+                            if (dataBar.HighValue.HasValueOrFormula)
+                            {
+                                if (!string.IsNullOrEmpty(dataBar.HighValue.Formula))
+                                {
+                                    cache.Append($" val=\"{dataBar.HighValue.Formula.EncodeXMLAttribute()}\"");
+                                }
+                                else
+                                {
+                                    cache.Append($" val=\"{dataBar.HighValue.Value}\"");
+                                }
+                            }
+
+                            cache.Append("/>");
 
                             WriteDxfColor("", cache, dataBar.FillColor);
 

--- a/src/EPPlusTest/ConditionalFormatting/CF_DatabarTests.cs
+++ b/src/EPPlusTest/ConditionalFormatting/CF_DatabarTests.cs
@@ -128,7 +128,9 @@ namespace EPPlusTest.ConditionalFormatting
 
                 var readPackage = new ExcelPackage(stream);
 
-                var readBar = readPackage.Workbook.Worksheets[0].ConditionalFormatting[0];
+                var ws = readPackage.Workbook.Worksheets[0];
+
+                var readBar = ws.ConditionalFormatting[0];
                 Assert.AreEqual(readBar.As.DataBar.LowValue.Formula, "10");
                 Assert.AreEqual(readBar.As.DataBar.HighValue.Formula, "20");
             }
@@ -359,6 +361,10 @@ namespace EPPlusTest.ConditionalFormatting
                 databar.Gradient = false;
                 databar.Border = true;
                 databar.Direction = eDatabarDirection.RightToLeft;
+
+                //Ensure we read and write the color even if its not currently applied
+                databar.NegativeFillColor.Color = Color.DarkBlue;
+
                 databar.NegativeBarColorSameAsPositive = true;
                 databar.NegativeBarBorderColorSameAsPositive = false;
                 databar.AxisPosition = eExcelDatabarAxisPosition.Middle;
@@ -376,6 +382,8 @@ namespace EPPlusTest.ConditionalFormatting
                 Assert.AreEqual(true, bar.NegativeBarColorSameAsPositive);
                 Assert.AreEqual(false, bar.NegativeBarBorderColorSameAsPositive);
                 Assert.AreEqual(eExcelDatabarAxisPosition.Middle, bar.AxisPosition);
+                //Ensure we read and write the color even if its not currently applied
+                Assert.AreEqual(Color.FromArgb(255, Color.DarkBlue), bar.NegativeFillColor.Color);
             }
         }
     }


### PR DESCRIPTION
Writing values into field instead of formula would fail to display properly in excel due to not existing in the non-extlst version of the databar node. It now displays correctly