### PR TITLE
Behaviour-fixes for COUNTA, SUBTOTAL and AGGREGATE

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/ArgumentCollectionUtil.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/ArgumentCollectionUtil.cs
@@ -36,16 +36,26 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
             _objectEnumerableArgConverter = objectEnumerableArgConverter;
         }
 
-        public virtual IEnumerable<ExcelDoubleCellValue> ArgsToDoubleEnumerable(bool ignoreHidden, bool ignoreErrors, IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreNonNumeric = false)
+        public virtual IEnumerable<ExcelDoubleCellValue> ArgsToDoubleEnumerable(bool ignoreHidden, bool ignoreErrors, bool ignoreSubtotalAggregate, IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreNonNumeric = false)
         {
-            return _doubleEnumerableArgConverter.ConvertArgs(ignoreHidden, ignoreErrors, arguments, context, ignoreNonNumeric);
+            return _doubleEnumerableArgConverter.ConvertArgs(ignoreHidden, ignoreErrors, ignoreSubtotalAggregate, arguments, context, ignoreNonNumeric);
         }
 
         public virtual IEnumerable<object> ArgsToObjectEnumerable(bool ignoreHidden,
+                                                                  bool ignoreErrors,
+                                                                  bool ignoreNestedSubtotalAggregate,
                                                                   IEnumerable<FunctionArgument> arguments,
                                                                   ParsingContext context)
         {
-            return _objectEnumerableArgConverter.ConvertArgs(ignoreHidden, arguments, context);
+            return _objectEnumerableArgConverter.ConvertArgs(ignoreHidden, ignoreErrors, ignoreNestedSubtotalAggregate, arguments, context);
+        }
+
+        public virtual IEnumerable<object> ArgsToObjectEnumerable(bool ignoreHidden,
+                                                                  bool ignoreErrors,
+                                                                  IEnumerable<FunctionArgument> arguments,
+                                                                  ParsingContext context)
+        {
+            return _objectEnumerableArgConverter.ConvertArgs(ignoreHidden, ignoreErrors, arguments, context);
         }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/CellStateHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/CellStateHelper.cs
@@ -19,9 +19,15 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 {
     internal static class CellStateHelper
     {
-        private static bool IsSubTotal(ICellInfo c, ParsingContext context)
+        private static bool ShouldIgnoreNestedSubtotal(bool ignoreNestedSubtotalAndAggregate, ulong cellId, ParsingContext context)
         {
-            return context.IsSubtotal && context.SubtotalAddresses.Contains(c.Id);
+            if (!ignoreNestedSubtotalAndAggregate) return false;
+            return context.SubtotalAddresses.Contains(cellId);
+        }
+
+        internal static bool ShouldIgnore(bool ignoreHiddenValues, bool ignoreNestedSubtotalAndAggregate, ICellInfo c, ParsingContext context)
+        {
+            return ShouldIgnore(ignoreHiddenValues, false, c, context, ignoreNestedSubtotalAndAggregate);
         }
 
         internal static bool ShouldIgnore(bool ignoreHiddenValues, ICellInfo c, ParsingContext context)
@@ -29,7 +35,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
             return ShouldIgnore(ignoreHiddenValues, false, c, context);
         }
 
-        internal static bool ShouldIgnore(bool ignoreHiddenValues, bool ignoreNonNumeric, ICellInfo c, ParsingContext context)
+        internal static bool ShouldIgnore(bool ignoreHiddenValues, bool ignoreNonNumeric, ICellInfo c, ParsingContext context, bool ignoreNestedSubtotalAndAggregate = true)
         {
             if(c.Address==null) return false;
             if (ignoreNonNumeric && !ConvertUtil.IsNumericOrDate(c.Value)) return true;
@@ -38,17 +44,23 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
             {
                 hasFilter = context.Parser.FilterInfo.WorksheetHasFilter(context.Package.Workbook.Worksheets[c.WorksheetName].IndexInList);
             }
-            return ((ignoreHiddenValues || hasFilter) && c.IsHiddenRow) || IsSubTotal(c, context);
+            return ((ignoreHiddenValues || hasFilter) && c.IsHiddenRow) || ShouldIgnoreNestedSubtotal(ignoreNestedSubtotalAndAggregate, c.Id, context);
         }
 
-        internal static bool ShouldIgnore(bool ignoreHiddenValues, FunctionArgument arg, ParsingContext context)
+        internal static bool ShouldIgnore(bool ignoreHiddenValues, bool ignoreNestedSubtotalAndAggregate, FunctionArgument arg, ParsingContext context)
         {
             var hasFilter = false;
             if (context.Parser != null && context.Parser.FilterInfo != null && context.Parser.FilterInfo.WorksheetHasFilter(context.CurrentCell.WorksheetIx))
             {
                 hasFilter = true;
             }
-            return (ignoreHiddenValues || hasFilter) && arg.ExcelStateFlagIsSet(ExcelCellState.HiddenCell);
+            var include = true;
+            if(ignoreNestedSubtotalAndAggregate && arg.Address != null)
+            {
+                var cellId = arg.Address.GetTopLeftCellId();
+                include = !ShouldIgnoreNestedSubtotal(ignoreNestedSubtotalAndAggregate, cellId, context);
+            }
+            return (ignoreHiddenValues || hasFilter) && arg.ExcelStateFlagIsSet(ExcelCellState.HiddenCell) && include;
         }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/DoubleEnumerableArgConverter.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/DoubleEnumerableArgConverter.cs
@@ -22,7 +22,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 {
     public class DoubleEnumerableArgConverter : CollectionFlattener<ExcelDoubleCellValue>
     {
-        public virtual IEnumerable<ExcelDoubleCellValue> ConvertArgs(bool ignoreHidden, bool ignoreErrors, IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreNonNumeric = false)
+        public virtual IEnumerable<ExcelDoubleCellValue> ConvertArgs(bool ignoreHidden, bool ignoreErrors, bool ignoreSubtotalAggregate, IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreNonNumeric = false)
         {
             return base.FuncArgsToFlatEnumerable(arguments, (arg, argList) =>
                 {
@@ -31,7 +31,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
                         foreach (var cell in arg.ValueAsRangeInfo)
                         {
                             if(!ignoreErrors && cell.IsExcelError) throw new ExcelErrorValueException(ExcelErrorValue.Parse(cell.Value.ToString()));
-                            if (!CellStateHelper.ShouldIgnore(ignoreHidden, ignoreNonNumeric, cell, context) && ConvertUtil.IsExcelNumeric(cell.Value))
+                            if (!CellStateHelper.ShouldIgnore(ignoreHidden, ignoreNonNumeric, cell, context, ignoreSubtotalAggregate) && ConvertUtil.IsExcelNumeric(cell.Value))
                             {
                                 var val = new ExcelDoubleCellValue(cell.ValueDouble, cell.Row, cell.Column);
                                 argList.Add(val);
@@ -41,7 +41,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
                     else
                     {
                         if(!ignoreErrors && arg.ValueIsExcelError) throw new ExcelErrorValueException(arg.ValueAsExcelErrorValue);
-                        if (ConvertUtil.IsExcelNumeric(arg.Value) && !CellStateHelper.ShouldIgnore(ignoreHidden, arg, context))
+                        if (ConvertUtil.IsExcelNumeric(arg.Value) && !CellStateHelper.ShouldIgnore(ignoreHidden, ignoreSubtotalAggregate, arg, context))
                         {
                             var val = new ExcelDoubleCellValue(ConvertUtil.GetValueDouble(arg.Value));
                             argList.Add(val);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/HiddenValuesHandlingFunction.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/HiddenValuesHandlingFunction.cs
@@ -27,6 +27,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
         public HiddenValuesHandlingFunction()
         {
             IgnoreErrors = true;
+            IgnoreNestedSubtotalsAndAggregates = true;
         }
         /// <summary>
         /// Set to true or false to indicate whether the function should ignore hidden values.
@@ -45,6 +46,11 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
             get; set;
         }
 
+        /// <summary>
+        /// Set to true to indicate whether the function should ignore nested SUBTOTAL and AGGREGATE functions
+        /// </summary>
+        public bool IgnoreNestedSubtotalsAndAggregates { get; set; }
+
         protected override IEnumerable<ExcelDoubleCellValue> ArgsToDoubleEnumerable(IEnumerable<FunctionArgument> arguments, ParsingContext context)
         {
             return ArgsToDoubleEnumerable(arguments, context, IgnoreErrors, false);
@@ -61,12 +67,12 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
                 var nonHidden = arguments.Where(x => !x.ExcelStateFlagIsSet(ExcelCellState.HiddenCell));
                 return base.ArgsToDoubleEnumerable(IgnoreHiddenValues, nonHidden, context);
             }
-            return base.ArgsToDoubleEnumerable(IgnoreHiddenValues, ignoreErrors, arguments, context, ignoreNonNumeric);
+            return base.ArgsToDoubleEnumerable(IgnoreHiddenValues, ignoreErrors, IgnoreNestedSubtotalsAndAggregates, arguments, context, ignoreNonNumeric);
         }
 
         protected bool ShouldIgnore(ICellInfo c, ParsingContext context)
         {
-            if(CellStateHelper.ShouldIgnore(IgnoreHiddenValues, c, context))
+            if(CellStateHelper.ShouldIgnore(IgnoreHiddenValues, IgnoreNestedSubtotalsAndAggregates, c, context))
             {
                 return true;
             }
@@ -78,7 +84,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
         }
         protected bool ShouldIgnore(FunctionArgument arg, ParsingContext context)
         {
-            if (CellStateHelper.ShouldIgnore(IgnoreHiddenValues, arg, context))
+            if (CellStateHelper.ShouldIgnore(IgnoreHiddenValues, IgnoreNestedSubtotalsAndAggregates, arg, context))
             {
                 return true;
             }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Aggregate.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Aggregate.cs
@@ -40,11 +40,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             {
                 context.SubtotalAddresses.Add(cellId);
             }
-            
-            if (IgnoreNestedSubtotalAndAggregate(options))
-            {
-                context.IsSubtotal = true;
-            }
 
             CompileResult result = null;
             switch(funcNum)
@@ -53,7 +48,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f1 = new Average()
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f1.Execute(arguments.Skip(nToSkip).ToList(), context);
                     break;
@@ -61,7 +57,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f2 = new Count()
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f2.Execute(arguments.Skip(nToSkip).ToList(), context);
                     break;
@@ -69,7 +66,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f3 = new CountA
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f3.Execute(arguments.Skip(nToSkip).ToList(), context);
                     break;
@@ -77,7 +75,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f4 = new Max 
                     { 
                         IgnoreHiddenValues = IgnoreHidden(options), 
-                        IgnoreErrors = IgnoreErrors(options) 
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f4.Execute(arguments.Skip(nToSkip).ToList(), context);
                     break;
@@ -85,7 +84,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f5 = new Min
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f5.Execute(arguments.Skip(nToSkip).ToList(), context);
                     break;
@@ -93,7 +93,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f6 = new Product
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f6.Execute(arguments.Skip(nToSkip).ToList(), context);
                     break;
@@ -101,7 +102,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f7 = new StdevDotS
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f7.Execute(arguments.Skip(nToSkip).ToList(), context);
                     break;
@@ -109,7 +111,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f8 = new StdevDotP
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f8.Execute(arguments.Skip(nToSkip).ToList(), context);
                     break;
@@ -117,7 +120,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f9 = new SumSubtotal
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f9.Execute(arguments.Skip(nToSkip).ToList(), context);
                     break;
@@ -125,7 +129,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     VarDotS f10 = new VarDotS
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f10.Execute(arguments.Skip(nToSkip).ToList(), context);
                     break;
@@ -133,7 +138,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f11 = new VarDotP
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f11.Execute(arguments.Skip(nToSkip).ToList(), context);
                     break;
@@ -141,7 +147,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f12 = new Median
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f12.Execute(arguments.Skip(nToSkip).ToList(), context);
                     break;
@@ -149,7 +156,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f13 = new ModeSngl
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f13.Execute(arguments.Skip(nToSkip).ToList(), context);
                     break;
@@ -157,7 +165,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f14 = new Large
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     var a141 = arguments.ElementAt(nToSkip);
                     var a142 = arguments.ElementAt(nToSkip + 1);
@@ -167,7 +176,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f15 = new Small
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f15.Execute(new List<FunctionArgument> { arguments.ElementAt(nToSkip), arguments.ElementAt(nToSkip + 1) }, context);
                     break;
@@ -175,7 +185,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f16 = new PercentileInc
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f16.Execute(new List<FunctionArgument> { arguments.ElementAt(nToSkip), arguments.ElementAt(nToSkip + 1) }, context);
                     break;
@@ -183,7 +194,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f17 = new QuartileInc
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f17.Execute(new List<FunctionArgument> { arguments.ElementAt(nToSkip), arguments.ElementAt(nToSkip + 1) }, context);
                     break;
@@ -191,7 +203,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f18 = new PercentileExc
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f18.Execute(new List<FunctionArgument> { arguments.ElementAt(nToSkip), arguments.ElementAt(nToSkip + 1) }, context);
                     break;
@@ -199,7 +212,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     var f19 = new QuartileExc
                     {
                         IgnoreHiddenValues = IgnoreHidden(options),
-                        IgnoreErrors = IgnoreErrors(options)
+                        IgnoreErrors = IgnoreErrors(options),
+                        IgnoreNestedSubtotalsAndAggregates = IgnoreNestedSubtotalAndAggregate(options)
                     };
                     result = f19.Execute(new List<FunctionArgument> { arguments.ElementAt(nToSkip), arguments.ElementAt(nToSkip + 1) }, context);
                     break;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Min.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Min.cs
@@ -37,7 +37,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var values = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, arguments, context, true);
+            var values = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, IgnoreNestedSubtotalsAndAggregates, arguments, context, true);
             if(!values.Any())
             {
                 return CreateResult(0d, DataType.Decimal);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Product.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Product.cs
@@ -28,6 +28,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public Product()
         {
             IgnoreErrors = false;
+            IgnoreHiddenValues = false;
         }
 
         public override int ArgumentMinLength => 1;
@@ -39,7 +40,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             }
             ((List<FunctionArgument>)arguments).RemoveAll(x => ShouldIgnore(x, context));
             var result = 1d;
-            var values = ArgsToObjectEnumerable(true, arguments, context);
+            var values = ArgsToObjectEnumerable(IgnoreHiddenValues, IgnoreErrors, IgnoreNestedSubtotalsAndAggregates, arguments, context);
             foreach (var obj in values.Where(x => x != null && IsNumeric(x)))
             {
                 result *= Convert.ToDouble(obj);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/StdevP.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/StdevP.cs
@@ -40,7 +40,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var args = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, arguments, context);
+            var args = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, IgnoreNestedSubtotalsAndAggregates, arguments, context);
             return CreateResult(StandardDeviation(args.Select(x => (double)x)), DataType.Decimal);
         }
 

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Subtotal.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Subtotal.cs
@@ -75,7 +75,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             {
                 context.SubtotalAddresses.Add(cellId);
             }
-            context.IsSubtotal = true;
 
             var actualArgs = arguments.Skip(1);
             var function = GetFunctionByCalcType(funcNum);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/SumSubtotal.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/SumSubtotal.cs
@@ -60,33 +60,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         private object Calculate(FunctionArgument arg, ParsingContext context)
         {
             KahanSum retVal = 0d;
-            if (ShouldIgnore(arg, context))
-            {
-                return retVal.Get();
-            }
-            if (arg.DataType == DataType.ExcelError)
-            {
-                return arg.Value;
-            }
-            if (arg.Value is IEnumerable<FunctionArgument> args)
-            {
-                foreach (var item in args)
-                {
-                    if(!ShouldIgnore(arg, context))
-                    {
-                        var c = Calculate(item, context);
-                        if (c is ExcelErrorValue e)
-                        {
-                            return e;
-                        }
-                        else
-                        {
-                            retVal += (double)c;
-                        }
-                    }
-                }
-            }
-            else if (arg.Value is IRangeInfo ri)
+            if (arg.Value is IRangeInfo ri)
             {
                 foreach (var c in ri)
                 {
@@ -100,7 +74,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             }
             else
             {
-                //CheckForAndHandleExcelError(arg);
+                if(arg.Address != null && ShouldIgnore(arg, context))
+                {
+                    return retVal.Get();
+                }
                 retVal += ConvertUtil.GetValueDouble(arg.Value, true);
             }
             return retVal.Get();

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Var.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Var.cs
@@ -34,7 +34,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var args = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, arguments, context);
+            var args = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, IgnoreNestedSubtotalsAndAggregates, arguments, context);
             return new CompileResult(VarMethods.Var(args), DataType.Decimal);
         }
     }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/VarP.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/VarP.cs
@@ -32,7 +32,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var args = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, arguments, context);
+            var args = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, IgnoreNestedSubtotalsAndAggregates, arguments, context);
             return new CompileResult(VarMethods.VarP(args), DataType.Decimal);
         }
         public override ExcelFunctionParametersInfo ParametersInfo => new ExcelFunctionParametersInfo(new Func<int, FunctionParameterInformation>((argumentIndex) =>

--- a/src/EPPlus/FormulaParsing/LexicalAnalysis/FormulaAddress.cs
+++ b/src/EPPlus/FormulaParsing/LexicalAnalysis/FormulaAddress.cs
@@ -802,6 +802,11 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
             }            
         }
 
+        internal ulong GetTopLeftCellId()
+        {
+            return ExcelCellBase.GetCellId(WorksheetIx, FromRow, FromCol);
+        }
+
         public FormulaRangeAddress Address => this;
     }
     public class FormulaTableAddress : FormulaRangeAddress

--- a/src/EPPlus/FormulaParsing/ParsingContext.cs
+++ b/src/EPPlus/FormulaParsing/ParsingContext.cs
@@ -155,11 +155,6 @@ namespace OfficeOpenXml.FormulaParsing
                 }
                 return null;
             }
-        }       
-        public bool IsSubtotal  //Used in CountA via the aggregate function.
-        {
-            get;
-            set;
         }
     }
 }

--- a/src/EPPlusTest/EppAssert.cs
+++ b/src/EPPlusTest/EppAssert.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace EPPlusTest
+{
+    internal class EppAssert
+    {
+        public static void DoublesAreEqual(double expected, object actual, int nRoundingDecimals)
+        {
+            if (actual == null) throw new AssertFailedException("EppAssert.DoublesAreEqual failed: parameter actual was null");
+            if (!(actual is double d)) throw new AssertFailedException("EppAssert.DoublesAreEqual failed: parameter actual is not a double");
+            var roundedResult = Math.Round(d, nRoundingDecimals);
+            Assert.AreEqual(expected, roundedResult);
+        }
+
+        public static void DoublesAreEqual(double expected, object actual, int nRoundingDecimals, string msg)
+        {
+            if (actual == null) throw new AssertFailedException("EppAssert.DoublesAreEqual failed: parameter actual was null. " + msg);
+            if (!(actual is double d)) throw new AssertFailedException("EppAssert.DoublesAreEqual failed: parameter actual is not a double. " + msg);
+            var roundedResult = Math.Round(d, nRoundingDecimals);
+            Assert.AreEqual(expected, roundedResult, msg);
+        }
+    }
+}

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/ArabicTest.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/ArabicTest.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
     public class ArabicTest : TestBase

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/AverageATests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/AverageATests.cs
@@ -39,7 +39,7 @@ using OfficeOpenXml.FormulaParsing.Exceptions;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
 using OfficeOpenXml.FormulaParsing.Ranges;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
 	[TestClass]
 	public class AverageATests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/AverageIfTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/AverageIfTests.cs
@@ -35,10 +35,10 @@ using OfficeOpenXml.FormulaParsing.ExcelUtilities;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
 using static OfficeOpenXml.FormulaParsing.ExcelDataProvider;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
-    public class SumIfTests
+    public class AverageIfTests
     {
         private ExcelPackage _package;
         private EpplusExcelDataProvider _provider;
@@ -61,7 +61,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void SumIfNumeric()
+        public void AverageIfNumeric()
         {
             _worksheet.Cells["A1"].Value = 1d;
             _worksheet.Cells["A2"].Value = 2d;
@@ -69,16 +69,16 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
+            var func = new AverageIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, ">1", range2);
             var result = func.Execute(args, _parsingContext);
-            Assert.AreEqual(8d, result.Result);
+            Assert.AreEqual(4d, result.Result);
         }
 
         [TestMethod]
-        public void SumIfNonNumeric()
+        public void AverageIfNonNumeric()
         {
             _worksheet.Cells["A1"].Value = "Monday";
             _worksheet.Cells["A2"].Value = "Tuesday";
@@ -86,34 +86,21 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
+            var func = new AverageIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "T*day", range2);
             var result = func.Execute(args, _parsingContext);
-            Assert.AreEqual(8d, result.Result);
+            Assert.AreEqual(4d, result.Result);
         }
 
         [TestMethod]
-        public void SumIfShouldIgnoreNumericStrings()
-        {
-            _worksheet.Cells["A1"].Value = 2;
-            _worksheet.Cells["A2"].Value = 1;
-            _worksheet.Cells["A3"].Value = "4";
-            var func = new SumIf();
-            IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
-            var args = FunctionsHelper.CreateArgs(range1, ">1");
-            var result = func.Execute(args, _parsingContext);
-            Assert.AreEqual(2d, result.Result);
-        }
-
-        [TestMethod]
-        public void SumIfNumericExpression()
+        public void AverageIfNumericExpression()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = 1d;
             _worksheet.Cells["A3"].Value = "Not Empty";
-            var func = new SumIf();
+            var func = new AverageIf();
             IRangeInfo range = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             var args = FunctionsHelper.CreateArgs(range, 1d);
             var result = func.Execute(args, _parsingContext);
@@ -121,7 +108,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void SumIfEqualToEmptyString()
+        public void AverageIfEqualToEmptyString()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -129,33 +116,33 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
+            var func = new AverageIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "", range2);
+            var result = func.Execute(args, _parsingContext);
+            Assert.AreEqual(2d, result.Result);
+        }
+
+        [TestMethod]
+        public void AverageIfNotEqualToNull()
+        {
+            _worksheet.Cells["A1"].Value = null;
+            _worksheet.Cells["A2"].Value = string.Empty;
+            _worksheet.Cells["A3"].Value = "Not Empty";
+            _worksheet.Cells["B1"].Value = 1d;
+            _worksheet.Cells["B2"].Value = 3d;
+            _worksheet.Cells["B3"].Value = 5d;
+            var func = new AverageIf();
+            IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
+            IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
+            var args = FunctionsHelper.CreateArgs(range1, "<>", range2);
             var result = func.Execute(args, _parsingContext);
             Assert.AreEqual(4d, result.Result);
         }
 
         [TestMethod]
-        public void SumIfNotEqualToNull()
-        {
-            _worksheet.Cells["A1"].Value = null;
-            _worksheet.Cells["A2"].Value = string.Empty;
-            _worksheet.Cells["A3"].Value = "Not Empty";
-            _worksheet.Cells["B1"].Value = 1d;
-            _worksheet.Cells["B2"].Value = 3d;
-            _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
-            IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
-            IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
-            var args = FunctionsHelper.CreateArgs(range1, "<>", range2);
-            var result = func.Execute(args, _parsingContext);
-            Assert.AreEqual(8d, result.Result);
-        }
-
-        [TestMethod]
-        public void SumIfEqualToZero()
+        public void AverageIfEqualToZero()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -163,7 +150,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
+            var func = new AverageIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "0", range2);
@@ -172,7 +159,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void SumIfNotEqualToZero()
+        public void AverageIfNotEqualToZero()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -180,16 +167,16 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
+            var func = new AverageIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "<>0", range2);
             var result = func.Execute(args, _parsingContext);
-            Assert.AreEqual(4d, result.Result);
+            Assert.AreEqual(2d, result.Result);
         }
 
         [TestMethod]
-        public void SumIfGreaterThanZero()
+        public void AverageIfGreaterThanZero()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -197,7 +184,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
+            var func = new AverageIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, ">0", range2);
@@ -206,7 +193,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void SumIfGreaterThanOrEqualToZero()
+        public void AverageIfGreaterThanOrEqualToZero()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -214,7 +201,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
+            var func = new AverageIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, ">=0", range2);
@@ -223,7 +210,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void SumIfLessThanZero()
+        public void AverageIfLessThanZero()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -231,7 +218,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
+            var func = new AverageIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "<0", range2);
@@ -240,7 +227,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void SumIfLessThanOrEqualToZero()
+        public void AverageIfLessThanOrEqualToZero()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -248,7 +235,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
+            var func = new AverageIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "<=0", range2);
@@ -257,7 +244,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void SumIfLessThanCharacter()
+        public void AverageIfLessThanCharacter()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -265,7 +252,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
+            var func = new AverageIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "<a", range2);
@@ -274,7 +261,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void SumIfLessThanOrEqualToCharacter()
+        public void AverageIfLessThanOrEqualToCharacter()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -282,7 +269,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
+            var func = new AverageIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "<=a", range2);
@@ -291,7 +278,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void SumIfGreaterThanCharacter()
+        public void AverageIfGreaterThanCharacter()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -299,7 +286,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
+            var func = new AverageIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, ">a", range2);
@@ -308,7 +295,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void SumIfGreaterThanOrEqualToCharacter()
+        public void AverageIfGreaterThanOrEqualToCharacter()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -316,7 +303,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
+            var func = new AverageIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, ">=a", range2);
@@ -325,142 +312,55 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void SumIfHandleDates()
+        public void AverageIfShouldNotCompareNumericStrings()
         {
-            _worksheet.Cells["A1"].Value = null;
-            _worksheet.Cells["A2"].Value = string.Empty;
-            _worksheet.Cells["A3"].Value = "Not Empty";
-            _worksheet.Cells["B1"].Value = 1d;
-            _worksheet.Cells["B2"].Value = 3d;
-            _worksheet.Cells["B3"].Value = 5d;
-            var func = new SumIf();
+            _worksheet.Cells["A1"].Value = "1";
+            _worksheet.Cells["A2"].Value = 2;
+            _worksheet.Cells["A3"].Value = "3";
+            var func = new AverageIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
-            IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
-            var args = FunctionsHelper.CreateArgs(range1, ">=a", range2);
+            var args = FunctionsHelper.CreateArgs(range1, ">0");
             var result = func.Execute(args, _parsingContext);
-            Assert.AreEqual(5d, result.Result);
+            Assert.AreEqual(2d, result.Result);
         }
 
         [TestMethod]
-        public void SumIfShouldHandleBooleanArg()
+        public void AverageIfShouldHandleArrayCritera()
         {
-            using (var pck = new ExcelPackage())
+            using (var package = new ExcelPackage())
             {
-                var sheet = pck.Workbook.Worksheets.Add("test");
-                sheet.Cells["A1"].Value = true;
-                sheet.Cells["B1"].Value = 1;
-                sheet.Cells["A2"].Value = false;
-                sheet.Cells["B2"].Value = 1;
-                sheet.Cells["C1"].Formula = "SUMIF(A1:A2,TRUE,B1:B2)";
+                var sheet = package.Workbook.Worksheets.Add("test");
+                sheet.Cells["A1"].Value = 1;
+                sheet.Cells["A2"].Value = 2;
+                sheet.Cells["A3"].Value = 3;
+                sheet.Cells["A4"].Value = 4;
+                sheet.Cells["B1"].Value = ">1";
+                sheet.Cells["B2"].Value = ">2";
+
+                sheet.Cells["A5"].Formula = "AVERAGEIF(A1:A4,B1:B2)";
                 sheet.Calculate();
-                Assert.AreEqual(1d, sheet.Cells["C1"].Value);
+                Assert.AreEqual(3d, sheet.Cells["A5"].Value);
+                Assert.AreEqual(3.5d, sheet.Cells["A6"].Value);
             }
         }
 
         [TestMethod]
-        public void SumIfShouldHandleArrayOfCriterias()
+        public void AverageIfShouldHandleArrayCritera2()
         {
-            using (var pck = new ExcelPackage())
+            using (var package = new ExcelPackage())
             {
-                var sheet = pck.Workbook.Worksheets.Add("test");
-                sheet.Cells["A1"].Value = "A";
-                sheet.Cells["A2"].Value = "B";
-                sheet.Cells["A3"].Value = "A";
-                sheet.Cells["A4"].Value = "B";
-                sheet.Cells["A5"].Value = "C";
-                sheet.Cells["A6"].Value = "B";
+                var sheet = package.Workbook.Worksheets.Add("test");
+                sheet.Cells["A1"].Value = 1;
+                sheet.Cells["A2"].Value = 2;
+                sheet.Cells["A3"].Value = 3;
+                sheet.Cells["A4"].Value = 4;
+                sheet.Cells["B1"].Value = "<1";
+                sheet.Cells["B2"].Value = ">2";
 
-                sheet.Cells["B1"].Value = 10;
-                sheet.Cells["B2"].Value = 20;
-                sheet.Cells["B3"].Value = 10;
-                sheet.Cells["B4"].Value = 30;
-                sheet.Cells["B5"].Value = 40;
-                sheet.Cells["B6"].Value = 10;
-
-                sheet.Cells["A9"].Formula = "SUMIF(A1:A6,{\"A\",\"C\"}, B1:B6)";
+                sheet.Cells["A5"].Formula = "AVERAGEIF(A1:A4,B1:B2)";
                 sheet.Calculate();
-                Assert.AreEqual(20d, sheet.Cells["A9"].Value);
-                Assert.AreEqual(40d, sheet.Cells["B9"].Value);
-            }
-        }
-
-        [TestMethod]
-        public void SumIfShouldHandleRangeWithCriterias()
-        {
-            using (var pck = new ExcelPackage())
-            {
-                var sheet = pck.Workbook.Worksheets.Add("test");
-                sheet.Cells["A1"].Value = "A";
-                sheet.Cells["A2"].Value = "B";
-                sheet.Cells["A3"].Value = "A";
-                sheet.Cells["A4"].Value = "B";
-                sheet.Cells["A5"].Value = "C";
-                sheet.Cells["A6"].Value = "B";
-
-                sheet.Cells["B1"].Value = 10;
-                sheet.Cells["B2"].Value = 20;
-                sheet.Cells["B3"].Value = 10;
-                sheet.Cells["B4"].Value = 30;
-                sheet.Cells["B5"].Value = 40;
-                sheet.Cells["B6"].Value = 10;
-
-                sheet.Cells["D9"].Value = "A";
-                sheet.Cells["E9"].Value = "C";
-
-                sheet.Cells["A9"].Formula = "SUMIF(A1:A6,D9:E9, B1:B6)";
-                sheet.Calculate();
-                Assert.AreEqual(20d, sheet.Cells["A9"].Value);
-                Assert.AreEqual(40d, sheet.Cells["B9"].Value);
-            }
-        }
-
-        [TestMethod]
-        public void SumIfSingleCell()
-        {
-            _worksheet.Cells["A1"].Value = 20;
-            _worksheet.Cells["A2"].Formula = "SUMIF(A1,\">0\")";
-            _worksheet.Calculate();
-
-            Assert.AreEqual(20d, _worksheet.Cells["A2"].Value);
-        }
-
-        [TestMethod]
-        public void SumIfEqualToEmptyString_Parser()
-        {
-            using (var pck = new ExcelPackage())
-            {
-                var sheet = pck.Workbook.Worksheets.Add("test");
-                sheet.Cells["A1"].Value = null;
-                sheet.Cells["A2"].Value = string.Empty;
-                sheet.Cells["A3"].Value = "Not Empty";
-                sheet.Cells["B1"].Value = 1d;
-                sheet.Cells["B2"].Value = 3d;
-                sheet.Cells["B3"].Value = 5d;
-
-                sheet.Cells["B4"].Formula = "SUMIF(A1:A3,\"=\",B1:B3)";
-                sheet.Cells["B5"].Formula = "SUMIF(A1:A3,\"\",B1:B3)";
-                sheet.Calculate();
-                Assert.AreEqual(1d, sheet.Cells["B4"].Value);
-                Assert.AreEqual(4d, sheet.Cells["B5"].Value);
-            }
-        }
-
-        [TestMethod]
-        public void SumIfNotEqualToNull_Parser()
-        {
-            using (var pck = new ExcelPackage())
-            {
-                var sheet = pck.Workbook.Worksheets.Add("test");
-                sheet.Cells["A1"].Value = null;
-                sheet.Cells["A2"].Value = string.Empty;
-                sheet.Cells["A3"].Value = "Not Empty";
-                sheet.Cells["B1"].Value = 1d;
-                sheet.Cells["B2"].Value = 3d;
-                sheet.Cells["B3"].Value = 5d;
-
-                sheet.Cells["B4"].Formula = "SUMIF(A1:A3,\"<>\",B1:B3)";
-                sheet.Calculate();
-                Assert.AreEqual(8d, sheet.Cells["B4"].Value);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Div0), sheet.Cells["A5"].Value);
+                Assert.AreEqual(3.5d, sheet.Cells["A6"].Value);
             }
         }
     }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/AverageIfsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/AverageIfsTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
     public class AverageIfsTests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/AverageTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/AverageTests.cs
@@ -38,7 +38,7 @@ using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
 using OfficeOpenXml.FormulaParsing.Ranges;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
 	[TestClass]
 	public class AverageTests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/CeilingTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/CeilingTests.cs
@@ -11,7 +11,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
     public class CeilingTests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/CountBlankTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/CountBlankTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
     public class CountBlankTests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/CountIfTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/CountIfTests.cs
@@ -35,7 +35,7 @@ using OfficeOpenXml.FormulaParsing.ExcelUtilities;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
 using static OfficeOpenXml.FormulaParsing.ExcelDataProvider;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
     public class CountIfTests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/CountIfsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/CountIfsTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
     public class CountIfsTests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/CountaTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/CountaTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
 
     [TestClass]

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/FloorTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/FloorTests.cs
@@ -10,7 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
     public class FloorTests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/IsoCeilingTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/IsoCeilingTests.cs
@@ -10,7 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
     public class IsoCeilingTests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/RandArrayTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/RandArrayTests.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
     public class RandArrayTests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/RoundTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/RoundTests.cs
@@ -36,7 +36,7 @@ using OfficeOpenXml.FormulaParsing.Excel.Functions;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing.Exceptions;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
 	[TestClass]
 	public class RoundTests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/RoundingHelperTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/RoundingHelperTests.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
     public class RoundingHelperTests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/SequemceTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/SequemceTests.cs
@@ -13,7 +13,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
     public class SequenceTests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/SubtotalTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/SubtotalTests.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
+{
+    [TestClass]
+    public class SubtotalTests : TestBase
+    {
+        [TestMethod]
+        public void IgnoringNested1To10()
+        {
+            using(var package = OpenTemplatePackage("Subtotal_All.xlsx"))
+            {
+                var sheet1 = package.Workbook.Worksheets["Sheet1"];
+
+                sheet1.Calculate();
+                
+                Assert.AreEqual(5.5, sheet1.Cells["A6"].Value, "AVERAGE (1)");
+                Assert.AreEqual(5.5, sheet1.Cells["A8"].Value, "AVERAGE (1) nested");
+
+                Assert.AreEqual(3d, sheet1.Cells["B6"].Value, "COUNT (2)");
+                Assert.AreEqual(3d, sheet1.Cells["B8"].Value, "COUNT (2) nested");
+
+                Assert.AreEqual(3d, sheet1.Cells["C6"].Value, "COUNTA (3)");
+                Assert.AreEqual(3d, sheet1.Cells["C8"].Value, "COUNTA (3) nested");
+
+                Assert.AreEqual(8d, sheet1.Cells["D6"].Value, "MAX (4)");
+                Assert.AreEqual(8d, sheet1.Cells["D8"].Value, "MAX (4) nested");
+
+                Assert.AreEqual(2d, sheet1.Cells["E6"].Value, "MIN (5)");
+                Assert.AreEqual(2d, sheet1.Cells["E8"].Value, "MIN (5) nested");
+
+                Assert.AreEqual(280d, sheet1.Cells["F6"].Value, "PRODUCT (6)");
+                Assert.AreEqual(280d, sheet1.Cells["F8"].Value, "PRODUCT (6) nested");
+
+                EppAssert.DoublesAreEqual(2.9439, sheet1.Cells["G6"].Value, 4, "STDEV.S (7)");
+                EppAssert.DoublesAreEqual(2.9439, sheet1.Cells["G8"].Value, 4, "STDEV.S (7) nested");
+
+                EppAssert.DoublesAreEqual(1.118, sheet1.Cells["H6"].Value, 4, "STDEV.P (8)");
+                EppAssert.DoublesAreEqual(1.118, sheet1.Cells["H8"].Value, 4, "STDEV.P (8) nested");
+
+                Assert.AreEqual(10d, sheet1.Cells["I6"].Value, "SUM (9)");
+                Assert.AreEqual(10d, sheet1.Cells["I8"].Value, "SUM (9) nested");
+
+                EppAssert.DoublesAreEqual(6.9167, sheet1.Cells["J6"].Value, 4, "VAR.S (10)");
+                EppAssert.DoublesAreEqual(6.9167, sheet1.Cells["J8"].Value, 4, "VAR.S (10) nested");
+
+                EppAssert.DoublesAreEqual(2.6875, sheet1.Cells["K6"].Value, 4, "VAR.P (11)");
+                EppAssert.DoublesAreEqual(2.6875, sheet1.Cells["K8"].Value, 4, "VAR.P (11) nested");
+
+                Assert.AreEqual("OK", sheet1.Cells["D11"].Value, "Test with IF and nested SUBTOTAL failed");
+            }
+        }
+
+        [TestMethod]
+        public void ThreeNestedSubtotals()
+        {
+            using (var package = OpenTemplatePackage("Subtotal_All.xlsx"))
+            {
+                package.Workbook.Calculate();
+                var sheet1 = package.Workbook.Worksheets["Sheet1"];
+
+                Assert.AreEqual(22d, sheet1.Cells["J11"].Value);
+            }
+        }
+
+        [TestMethod]
+        public void SumTest()
+        {
+            using (var package = OpenTemplatePackage("Subtotal_All.xlsx"))
+            {
+                package.Workbook.Calculate();
+                var sheet1 = package.Workbook.Worksheets["Sheet1"];
+
+                Assert.AreEqual(581d, sheet1.Cells["G11"].Value);
+            }
+        }
+    }
+}

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/SumIfTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/SumIfTests.cs
@@ -35,10 +35,10 @@ using OfficeOpenXml.FormulaParsing.ExcelUtilities;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
 using static OfficeOpenXml.FormulaParsing.ExcelDataProvider;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
-    public class AverageIfTests
+    public class SumIfTests
     {
         private ExcelPackage _package;
         private EpplusExcelDataProvider _provider;
@@ -61,7 +61,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void AverageIfNumeric()
+        public void SumIfNumeric()
         {
             _worksheet.Cells["A1"].Value = 1d;
             _worksheet.Cells["A2"].Value = 2d;
@@ -69,16 +69,16 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new AverageIf();
+            var func = new SumIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, ">1", range2);
             var result = func.Execute(args, _parsingContext);
-            Assert.AreEqual(4d, result.Result);
+            Assert.AreEqual(8d, result.Result);
         }
 
         [TestMethod]
-        public void AverageIfNonNumeric()
+        public void SumIfNonNumeric()
         {
             _worksheet.Cells["A1"].Value = "Monday";
             _worksheet.Cells["A2"].Value = "Tuesday";
@@ -86,21 +86,34 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new AverageIf();
+            var func = new SumIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "T*day", range2);
             var result = func.Execute(args, _parsingContext);
-            Assert.AreEqual(4d, result.Result);
+            Assert.AreEqual(8d, result.Result);
         }
 
         [TestMethod]
-        public void AverageIfNumericExpression()
+        public void SumIfShouldIgnoreNumericStrings()
+        {
+            _worksheet.Cells["A1"].Value = 2;
+            _worksheet.Cells["A2"].Value = 1;
+            _worksheet.Cells["A3"].Value = "4";
+            var func = new SumIf();
+            IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
+            var args = FunctionsHelper.CreateArgs(range1, ">1");
+            var result = func.Execute(args, _parsingContext);
+            Assert.AreEqual(2d, result.Result);
+        }
+
+        [TestMethod]
+        public void SumIfNumericExpression()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = 1d;
             _worksheet.Cells["A3"].Value = "Not Empty";
-            var func = new AverageIf();
+            var func = new SumIf();
             IRangeInfo range = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             var args = FunctionsHelper.CreateArgs(range, 1d);
             var result = func.Execute(args, _parsingContext);
@@ -108,7 +121,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void AverageIfEqualToEmptyString()
+        public void SumIfEqualToEmptyString()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -116,33 +129,33 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new AverageIf();
+            var func = new SumIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "", range2);
-            var result = func.Execute(args, _parsingContext);
-            Assert.AreEqual(2d, result.Result);
-        }
-
-        [TestMethod]
-        public void AverageIfNotEqualToNull()
-        {
-            _worksheet.Cells["A1"].Value = null;
-            _worksheet.Cells["A2"].Value = string.Empty;
-            _worksheet.Cells["A3"].Value = "Not Empty";
-            _worksheet.Cells["B1"].Value = 1d;
-            _worksheet.Cells["B2"].Value = 3d;
-            _worksheet.Cells["B3"].Value = 5d;
-            var func = new AverageIf();
-            IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
-            IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
-            var args = FunctionsHelper.CreateArgs(range1, "<>", range2);
             var result = func.Execute(args, _parsingContext);
             Assert.AreEqual(4d, result.Result);
         }
 
         [TestMethod]
-        public void AverageIfEqualToZero()
+        public void SumIfNotEqualToNull()
+        {
+            _worksheet.Cells["A1"].Value = null;
+            _worksheet.Cells["A2"].Value = string.Empty;
+            _worksheet.Cells["A3"].Value = "Not Empty";
+            _worksheet.Cells["B1"].Value = 1d;
+            _worksheet.Cells["B2"].Value = 3d;
+            _worksheet.Cells["B3"].Value = 5d;
+            var func = new SumIf();
+            IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
+            IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
+            var args = FunctionsHelper.CreateArgs(range1, "<>", range2);
+            var result = func.Execute(args, _parsingContext);
+            Assert.AreEqual(8d, result.Result);
+        }
+
+        [TestMethod]
+        public void SumIfEqualToZero()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -150,7 +163,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new AverageIf();
+            var func = new SumIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "0", range2);
@@ -159,7 +172,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void AverageIfNotEqualToZero()
+        public void SumIfNotEqualToZero()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -167,16 +180,16 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new AverageIf();
+            var func = new SumIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "<>0", range2);
             var result = func.Execute(args, _parsingContext);
-            Assert.AreEqual(2d, result.Result);
+            Assert.AreEqual(4d, result.Result);
         }
 
         [TestMethod]
-        public void AverageIfGreaterThanZero()
+        public void SumIfGreaterThanZero()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -184,7 +197,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new AverageIf();
+            var func = new SumIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, ">0", range2);
@@ -193,7 +206,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void AverageIfGreaterThanOrEqualToZero()
+        public void SumIfGreaterThanOrEqualToZero()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -201,7 +214,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new AverageIf();
+            var func = new SumIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, ">=0", range2);
@@ -210,7 +223,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void AverageIfLessThanZero()
+        public void SumIfLessThanZero()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -218,7 +231,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new AverageIf();
+            var func = new SumIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "<0", range2);
@@ -227,7 +240,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void AverageIfLessThanOrEqualToZero()
+        public void SumIfLessThanOrEqualToZero()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -235,7 +248,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new AverageIf();
+            var func = new SumIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "<=0", range2);
@@ -244,7 +257,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void AverageIfLessThanCharacter()
+        public void SumIfLessThanCharacter()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -252,7 +265,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new AverageIf();
+            var func = new SumIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "<a", range2);
@@ -261,7 +274,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void AverageIfLessThanOrEqualToCharacter()
+        public void SumIfLessThanOrEqualToCharacter()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -269,7 +282,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new AverageIf();
+            var func = new SumIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, "<=a", range2);
@@ -278,7 +291,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void AverageIfGreaterThanCharacter()
+        public void SumIfGreaterThanCharacter()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -286,7 +299,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new AverageIf();
+            var func = new SumIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, ">a", range2);
@@ -295,7 +308,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void AverageIfGreaterThanOrEqualToCharacter()
+        public void SumIfGreaterThanOrEqualToCharacter()
         {
             _worksheet.Cells["A1"].Value = null;
             _worksheet.Cells["A2"].Value = string.Empty;
@@ -303,7 +316,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
             _worksheet.Cells["B1"].Value = 1d;
             _worksheet.Cells["B2"].Value = 3d;
             _worksheet.Cells["B3"].Value = 5d;
-            var func = new AverageIf();
+            var func = new SumIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
             IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
             var args = FunctionsHelper.CreateArgs(range1, ">=a", range2);
@@ -312,55 +325,142 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
         }
 
         [TestMethod]
-        public void AverageIfShouldNotCompareNumericStrings()
+        public void SumIfHandleDates()
         {
-            _worksheet.Cells["A1"].Value = "1";
-            _worksheet.Cells["A2"].Value = 2;
-            _worksheet.Cells["A3"].Value = "3";
-            var func = new AverageIf();
+            _worksheet.Cells["A1"].Value = null;
+            _worksheet.Cells["A2"].Value = string.Empty;
+            _worksheet.Cells["A3"].Value = "Not Empty";
+            _worksheet.Cells["B1"].Value = 1d;
+            _worksheet.Cells["B2"].Value = 3d;
+            _worksheet.Cells["B3"].Value = 5d;
+            var func = new SumIf();
             IRangeInfo range1 = _provider.GetRange(_worksheet.Name, 1, 1, 3, 1);
-            var args = FunctionsHelper.CreateArgs(range1, ">0");
+            IRangeInfo range2 = _provider.GetRange(_worksheet.Name, 1, 2, 3, 2);
+            var args = FunctionsHelper.CreateArgs(range1, ">=a", range2);
             var result = func.Execute(args, _parsingContext);
-            Assert.AreEqual(2d, result.Result);
+            Assert.AreEqual(5d, result.Result);
         }
 
         [TestMethod]
-        public void AverageIfShouldHandleArrayCritera()
+        public void SumIfShouldHandleBooleanArg()
         {
-            using (var package = new ExcelPackage())
+            using (var pck = new ExcelPackage())
             {
-                var sheet = package.Workbook.Worksheets.Add("test");
-                sheet.Cells["A1"].Value = 1;
-                sheet.Cells["A2"].Value = 2;
-                sheet.Cells["A3"].Value = 3;
-                sheet.Cells["A4"].Value = 4;
-                sheet.Cells["B1"].Value = ">1";
-                sheet.Cells["B2"].Value = ">2";
-
-                sheet.Cells["A5"].Formula = "AVERAGEIF(A1:A4,B1:B2)";
+                var sheet = pck.Workbook.Worksheets.Add("test");
+                sheet.Cells["A1"].Value = true;
+                sheet.Cells["B1"].Value = 1;
+                sheet.Cells["A2"].Value = false;
+                sheet.Cells["B2"].Value = 1;
+                sheet.Cells["C1"].Formula = "SUMIF(A1:A2,TRUE,B1:B2)";
                 sheet.Calculate();
-                Assert.AreEqual(3d, sheet.Cells["A5"].Value);
-                Assert.AreEqual(3.5d, sheet.Cells["A6"].Value);
+                Assert.AreEqual(1d, sheet.Cells["C1"].Value);
             }
         }
 
         [TestMethod]
-        public void AverageIfShouldHandleArrayCritera2()
+        public void SumIfShouldHandleArrayOfCriterias()
         {
-            using (var package = new ExcelPackage())
+            using (var pck = new ExcelPackage())
             {
-                var sheet = package.Workbook.Worksheets.Add("test");
-                sheet.Cells["A1"].Value = 1;
-                sheet.Cells["A2"].Value = 2;
-                sheet.Cells["A3"].Value = 3;
-                sheet.Cells["A4"].Value = 4;
-                sheet.Cells["B1"].Value = "<1";
-                sheet.Cells["B2"].Value = ">2";
+                var sheet = pck.Workbook.Worksheets.Add("test");
+                sheet.Cells["A1"].Value = "A";
+                sheet.Cells["A2"].Value = "B";
+                sheet.Cells["A3"].Value = "A";
+                sheet.Cells["A4"].Value = "B";
+                sheet.Cells["A5"].Value = "C";
+                sheet.Cells["A6"].Value = "B";
 
-                sheet.Cells["A5"].Formula = "AVERAGEIF(A1:A4,B1:B2)";
+                sheet.Cells["B1"].Value = 10;
+                sheet.Cells["B2"].Value = 20;
+                sheet.Cells["B3"].Value = 10;
+                sheet.Cells["B4"].Value = 30;
+                sheet.Cells["B5"].Value = 40;
+                sheet.Cells["B6"].Value = 10;
+
+                sheet.Cells["A9"].Formula = "SUMIF(A1:A6,{\"A\",\"C\"}, B1:B6)";
                 sheet.Calculate();
-                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Div0), sheet.Cells["A5"].Value);
-                Assert.AreEqual(3.5d, sheet.Cells["A6"].Value);
+                Assert.AreEqual(20d, sheet.Cells["A9"].Value);
+                Assert.AreEqual(40d, sheet.Cells["B9"].Value);
+            }
+        }
+
+        [TestMethod]
+        public void SumIfShouldHandleRangeWithCriterias()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet = pck.Workbook.Worksheets.Add("test");
+                sheet.Cells["A1"].Value = "A";
+                sheet.Cells["A2"].Value = "B";
+                sheet.Cells["A3"].Value = "A";
+                sheet.Cells["A4"].Value = "B";
+                sheet.Cells["A5"].Value = "C";
+                sheet.Cells["A6"].Value = "B";
+
+                sheet.Cells["B1"].Value = 10;
+                sheet.Cells["B2"].Value = 20;
+                sheet.Cells["B3"].Value = 10;
+                sheet.Cells["B4"].Value = 30;
+                sheet.Cells["B5"].Value = 40;
+                sheet.Cells["B6"].Value = 10;
+
+                sheet.Cells["D9"].Value = "A";
+                sheet.Cells["E9"].Value = "C";
+
+                sheet.Cells["A9"].Formula = "SUMIF(A1:A6,D9:E9, B1:B6)";
+                sheet.Calculate();
+                Assert.AreEqual(20d, sheet.Cells["A9"].Value);
+                Assert.AreEqual(40d, sheet.Cells["B9"].Value);
+            }
+        }
+
+        [TestMethod]
+        public void SumIfSingleCell()
+        {
+            _worksheet.Cells["A1"].Value = 20;
+            _worksheet.Cells["A2"].Formula = "SUMIF(A1,\">0\")";
+            _worksheet.Calculate();
+
+            Assert.AreEqual(20d, _worksheet.Cells["A2"].Value);
+        }
+
+        [TestMethod]
+        public void SumIfEqualToEmptyString_Parser()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet = pck.Workbook.Worksheets.Add("test");
+                sheet.Cells["A1"].Value = null;
+                sheet.Cells["A2"].Value = string.Empty;
+                sheet.Cells["A3"].Value = "Not Empty";
+                sheet.Cells["B1"].Value = 1d;
+                sheet.Cells["B2"].Value = 3d;
+                sheet.Cells["B3"].Value = 5d;
+
+                sheet.Cells["B4"].Formula = "SUMIF(A1:A3,\"=\",B1:B3)";
+                sheet.Cells["B5"].Formula = "SUMIF(A1:A3,\"\",B1:B3)";
+                sheet.Calculate();
+                Assert.AreEqual(1d, sheet.Cells["B4"].Value);
+                Assert.AreEqual(4d, sheet.Cells["B5"].Value);
+            }
+        }
+
+        [TestMethod]
+        public void SumIfNotEqualToNull_Parser()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet = pck.Workbook.Worksheets.Add("test");
+                sheet.Cells["A1"].Value = null;
+                sheet.Cells["A2"].Value = string.Empty;
+                sheet.Cells["A3"].Value = "Not Empty";
+                sheet.Cells["B1"].Value = 1d;
+                sheet.Cells["B2"].Value = 3d;
+                sheet.Cells["B3"].Value = 5d;
+
+                sheet.Cells["B4"].Formula = "SUMIF(A1:A3,\"<>\",B1:B3)";
+                sheet.Calculate();
+                Assert.AreEqual(8d, sheet.Cells["B4"].Value);
             }
         }
     }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/SumIfsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/SumIfsTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
     public class SumIfsTests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/SumTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/SumTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
     public class SumTests

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/SumXTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/SumXTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
+namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
 {
     [TestClass]
     public class SumXTests

--- a/src/EPPlusTest/TestBase.cs
+++ b/src/EPPlusTest/TestBase.cs
@@ -100,6 +100,7 @@ namespace EPPlusTest
             var di=new DirectoryInfo(_worksheetPath);            
             _worksheetPath = di.FullName + "\\";
         }
+
         /// <summary>
         /// Saves and disposes a package
         /// </summary>


### PR DESCRIPTION
Before submitting this pull request I have...
- [x] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [x] ensured that the functionality I have added/changed is covered by new unit tests.
- [x] merged the target branch into the PR branch and resolved any merge conflicts
- [x] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).

- have removed ParsingContext.IsSubtotal
- Fixed behaviour of COUNTA which now should work as expected
- added tests and corrected behaviour on how SUBTOTAL and AGGREGATE handles nested functions of the same type.
- renamed `EpplusTest.FormulaParsing.Excel.Functions.Math` namespace to `EpplusTest.FormulaParsing.Excel.Functions.MathFunctions` to avoid collisions with the `System.Math` namespace.
