### PR TITLE
Adjusted rolling buffer size to avoid reading issues

### DIFF
--- a/src/EPPlus/WorksheetZipStream.cs
+++ b/src/EPPlus/WorksheetZipStream.cs
@@ -19,7 +19,7 @@ namespace OfficeOpenXml
 {
     internal class WorksheetZipStream : Stream
     {
-        RollingBuffer _rollingBuffer = new RollingBuffer(8192);
+        RollingBuffer _rollingBuffer = new RollingBuffer(8192 * 2);
         private Stream _stream;
         //private long _size;
         //private long _bytesRead;


### PR DESCRIPTION
We've already made this change in epplus7 so doing it here now too.
Basically the buffer was too small to contain the end node of LastElement in very rare cases.

Causing s#515
