### PR TITLE
Refactored ExcelFunction.ArgToDoubleEnumerable

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/Database/DSum.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Database/DSum.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 
@@ -30,7 +31,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Database
         {
             var values = GetMatchingValues(arguments, context);
             if (!values.Any()) return CreateResult(0d, DataType.Integer);
-            return CreateResult(values.Sum(), DataType.Integer);
+            return CreateResult(values.SumKahan(), DataType.Integer);
         }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Database/Daverage.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Database/Daverage.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 
@@ -30,7 +31,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Database
         {
             var values = GetMatchingValues(arguments, context);
             if (!values.Any()) return CreateResult(0d, DataType.Integer);
-            return CreateResult(values.Average(), DataType.Integer);
+            return CreateResult(values.AverageKahan(), DataType.Integer);
         }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/DoubleEnumerableArgParser.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/DoubleEnumerableArgParser.cs
@@ -1,0 +1,90 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  03/10/2023         EPPlus Software AB       Initial release EPPlus 7
+ *************************************************************************************************/
+using OfficeOpenXml.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OfficeOpenXml.FormulaParsing.Excel.Functions
+{
+    internal class DoubleEnumerableArgParser
+    {
+        public DoubleEnumerableArgParser(
+            IEnumerable<FunctionArgument> args, 
+            ParsingContext context,
+            DoubleEnumerableParseOptions options)
+        {
+            _args = args;
+            _context = context;
+            _options = options;
+            _result = new List<double>();
+        }
+
+        private readonly IEnumerable<FunctionArgument> _args;
+        private readonly ParsingContext _context;
+        private readonly DoubleEnumerableParseOptions _options;
+        private readonly List<double> _result;
+
+        private void Parse(IEnumerable<FunctionArgument> args, DoubleEnumerableParseOptions options, out ExcelErrorValue error)
+        {
+            error = null;
+            foreach (var arg in args)
+            {
+                if (arg.IsExcelRange)
+                {
+                    foreach (var cell in arg.ValueAsRangeInfo)
+                    {
+                        if (!options.IgnoreErrors && cell.IsExcelError) 
+                        {
+                            error = ExcelErrorValue.Parse(cell.Value.ToString());
+                            return;
+                        }
+                        if (!CellStateHelper.ShouldIgnore(options.IgnoreHiddenCells, options.IgnoreNonNumeric, cell, _context, options.IgnoreNestedSubtotalAggregate) && ConvertUtil.IsExcelNumeric(cell.Value))
+                        {
+                            var val = new ExcelDoubleCellValue(cell.ValueDouble, cell.Row, cell.Column);
+                            _result.Add(val);
+                        }
+                    }
+                }
+                else if(arg.Value is IEnumerable<FunctionArgument> fArgs)
+                {
+                    Parse(fArgs, options, out error);
+                }
+                else
+                {
+                    if (!options.IgnoreErrors && arg.ValueIsExcelError)
+                    {
+                        error = arg.ValueAsExcelErrorValue;
+                        return;
+                    }
+                    if (ConvertUtil.IsExcelNumeric(arg.Value) && !CellStateHelper.ShouldIgnore(options.IgnoreHiddenCells, options.IgnoreNestedSubtotalAggregate, arg, _context))
+                    {
+                        var val = new ExcelDoubleCellValue(ConvertUtil.GetValueDouble(arg.Value));
+                        _result.Add(val);
+                    }
+                }
+            }
+        }
+
+        public IList<double> GetResult(out ExcelErrorValue error)
+        {
+            Parse(_args, _options, out error);
+            if(error != null)
+            {
+                return new List<double>();
+            }
+            return _result;
+        }
+    }
+}

--- a/src/EPPlus/FormulaParsing/Excel/Functions/DoubleEnumerableParseOptions.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/DoubleEnumerableParseOptions.cs
@@ -17,23 +17,38 @@ using System.Text;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 {
-    internal class DoubleEnumerableParseOptions
+    /// <summary>
+    /// Options for parsing function arguments to a list of doubles
+    /// </summary>
+    public class DoubleEnumerableParseOptions
     {
+        /// <summary>
+        /// Ignore errors in cells
+        /// </summary>
         public bool IgnoreErrors
         {
             get; set;
         }
 
+        /// <summary>
+        /// Ignore hidden cells
+        /// </summary>
         public bool IgnoreHiddenCells
         {
             get; set;
         }
 
+        /// <summary>
+        /// Ignore results from underlying SUBTOTAL or AGGREGATE functions
+        /// </summary>
         public bool IgnoreNestedSubtotalAggregate
         {
             get; set;
         }
 
+        /// <summary>
+        /// Ignore cells with non-numeric values
+        /// </summary>
         public bool IgnoreNonNumeric
         {
             get; set;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/DoubleEnumerableParseOptions.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/DoubleEnumerableParseOptions.cs
@@ -1,0 +1,42 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  03/10/2023         EPPlus Software AB       Initial release EPPlus 7
+ *************************************************************************************************/
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OfficeOpenXml.FormulaParsing.Excel.Functions
+{
+    internal class DoubleEnumerableParseOptions
+    {
+        public bool IgnoreErrors
+        {
+            get; set;
+        }
+
+        public bool IgnoreHiddenCells
+        {
+            get; set;
+        }
+
+        public bool IgnoreNestedSubtotalAggregate
+        {
+            get; set;
+        }
+
+        public bool IgnoreNonNumeric
+        {
+            get; set;
+        }
+    }
+}

--- a/src/EPPlus/FormulaParsing/Excel/Functions/ExcelFunction.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/ExcelFunction.cs
@@ -491,8 +491,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 
         protected bool IsNumericString(object value)
         {
-            if (value == null || string.IsNullOrEmpty(value.ToString())) return false;
-            return Regex.IsMatch(value.ToString(), @"^[\d]+(\,[\d])?");
+            if (value == null) return false;
+            return double.TryParse(value.ToString(), NumberStyles.Any, CultureInfo.CurrentCulture, out double d);
         }
 
         protected bool IsInteger(object n)
@@ -624,81 +624,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
             return ArgsToDoubleEnumerable(arguments, context, x => { }, out error);
         }
 
-        /// <summary>
-        /// Will return the arguments as an enumerable of doubles.
-        /// </summary>
-        /// <param name="ignoreHiddenCells">If a cell is hidden and this value is true the value of that cell will be ignored</param>
-        /// <param name="ignoreErrors">If a cell contains an error, that error will be ignored if this method is set to true</param>
-        /// <param name="arguments"></param>
-        /// <param name="context"></param>
-        /// <returns></returns>
-        protected virtual IEnumerable<ExcelDoubleCellValue> ArgsToDoubleEnumerable(bool ignoreHiddenCells, bool ignoreErrors, IEnumerable<FunctionArgument> arguments, ParsingContext context)
-        {
-            return _argumentCollectionUtil.ArgsToDoubleEnumerable(ignoreHiddenCells, ignoreErrors, false, arguments, context, false);
-        }
-
-        /// <summary>
-        /// Will return the arguments as an enumerable of doubles.
-        /// </summary>
-        /// <param name="ignoreHiddenCells">If a cell is hidden and this value is true the value of that cell will be ignored</param>
-        /// <param name="ignoreErrors">If a cell contains an error, that error will be ignored if this method is set to true</param>
-        /// <param name="ignoreNestedSubtotalAggregate">If cells which value comes from the calculation of a SUBTOTAL or an AGGREGATE function should be ignored, set this to true</param>
-        /// <param name="arguments"></param>
-        /// <param name="context"></param>
-        /// <returns></returns>
-        protected virtual IList<double> ArgsToDoubleEnumerable(
-            bool ignoreHiddenCells, 
-            bool ignoreErrors, 
-            bool ignoreNestedSubtotalAggregate, 
-            IEnumerable<FunctionArgument> arguments, 
-            ParsingContext context)
-        {
-            //return _argumentCollectionUtil.ArgsToDoubleEnumerable(ignoreHiddenCells, ignoreErrors, ignoreNestedSubtotalAggregate, arguments, context, false);
-            var options = new DoubleEnumerableParseOptions
-            {
-                IgnoreHiddenCells = ignoreHiddenCells,
-                IgnoreErrors = ignoreErrors,
-                IgnoreNestedSubtotalAggregate = ignoreNestedSubtotalAggregate,
-                IgnoreNonNumeric = false
-            };
-            var parser = new DoubleEnumerableArgParser(arguments, context, options);
-            var result = parser.GetResult(out ExcelErrorValue error);
-            if (error != null)
-            {
-                throw new ExcelErrorValueException(error);
-            }
-            return result;
-        }
-
-
-        /// <summary>
-        /// Will return the arguments as an enumerable of doubles.
-        /// </summary>
-        /// <param name="ignoreHiddenCells">If a cell is hidden and this value is true the value of that cell will be ignored</param>
-        /// <param name="ignoreErrors">If a cell contains an error, that error will be ignored if this method is set to true</param>
-        /// <param name="ignoreNestedSubtotalAggregate">If cells which value comes from the calculation of a SUBTOTAL or an AGGREGATE function should be ignored, set this to true</param>
-        /// <param name="arguments"></param>
-        /// <param name="context"></param>
-        /// <param name="ignoreNonNumeric"></param>
-        /// <returns></returns>
-        protected virtual IList<double> ArgsToDoubleEnumerable(bool ignoreHiddenCells, bool ignoreErrors, bool ignoreNestedSubtotalAggregate, IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreNonNumeric)
-        {
-            //return _argumentCollectionUtil.ArgsToDoubleEnumerable(ignoreHiddenCells, ignoreErrors, ignoreNestedSubtotalAggregate, arguments, context, ignoreNonNumeric);
-            var options = new DoubleEnumerableParseOptions
-            {
-                IgnoreHiddenCells = ignoreHiddenCells,
-                IgnoreErrors = ignoreErrors,
-                IgnoreNestedSubtotalAggregate = ignoreNestedSubtotalAggregate,
-                IgnoreNonNumeric = ignoreNonNumeric
-            };
-            var parser = new DoubleEnumerableArgParser(arguments, context, options);
-            var result = parser.GetResult(out ExcelErrorValue error);
-            if(error != null)
-            {
-                throw new ExcelErrorValueException(error);
-            }
-            return result;
-        }
 
         /// <summary>
         /// Will return the arguments as an enumerable of doubles.
@@ -751,45 +676,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
         {
             return ArgsToDoubleEnumerable(argument, context, x => { }, out error);
         }
-        /// <summary>
-        /// Will return the arguments as an enumerable of doubles.
-        /// </summary>
-        /// <param name="ignoreHiddenCells">If a cell is hidden and this value is true the value of that cell will be ignored</param>
-        /// <param name="ignoreNestedSubtotalAggregate">If cells which value comes from the calculation of a SUBTOTAL or an AGGREGATE function should be ignored, set this to true</param>
-        /// <param name="arguments"></param>
-        /// <param name="context"></param>
-        /// <param name="ignoreNonNumeric"></param>
-        /// <returns></returns>
-            //protected virtual IList<double> ArgsToDoubleEnumerable(bool ignoreHiddenCells, bool ignoreNestedSubtotalAggregate, IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreNonNumeric)
-            //{
-            //    return ArgsToDoubleEnumerable(ignoreHiddenCells, true, ignoreNestedSubtotalAggregate, arguments, context, ignoreNonNumeric);
-            //}
-
-            /// <summary>
-            /// Will return the arguments as an enumerable of doubles.
-            /// </summary>
-            /// <param name="ignoreHiddenCells">If a cell is hidden and this value is true the value of that cell will be ignored</param>
-            /// <param name="arguments"></param>
-            /// <param name="context"></param>
-            /// <param name="ignoreNonNumeric"></param>
-            /// <returns></returns>
-            //protected virtual IList<double> ArgsToDoubleEnumerable(bool ignoreHiddenCells, IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreNonNumeric)
-            //{
-            //    return ArgsToDoubleEnumerable(ignoreHiddenCells, true, false, arguments, context, ignoreNonNumeric);
-            //}
-
-
-            /// <summary>
-            /// Will return the arguments as an enumerable of doubles.
-            /// </summary>
-            /// <param name="ignoreHiddenCells">If a cell is hidden and this value is true the value of that cell will be ignored</param>
-            /// <param name="arguments"></param>
-            /// <param name="context"></param>        
-            /// <returns></returns>
-            //protected virtual IList<double> ArgsToDoubleEnumerable(bool ignoreHiddenCells, IEnumerable<FunctionArgument> arguments, ParsingContext context)
-            //{
-            //    return ArgsToDoubleEnumerable(ignoreHiddenCells, true, arguments, context, false);
-            //}
 
         protected virtual IEnumerable<double> ArgsToDoubleEnumerableZeroPadded(bool ignoreHiddenCells, IRangeInfo rangeInfo, ParsingContext context)
         {
@@ -799,9 +685,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
             var endCol = rangeInfo.Address.ToCol > rangeInfo.Worksheet.Dimension._toCol ? rangeInfo.Worksheet.Dimension._toCol : rangeInfo.Address.ToCol;
             var horizontal = (startRow == endRow && rangeInfo.Address.FromCol < rangeInfo.Address.ToCol);
             var funcArg = new FunctionArgument(rangeInfo, DataType.ExcelRange);
-            //var dResult = ArgsToDoubleEnumerable(ignoreHiddenCells, new List<FunctionArgument> { funcArg }, context);
             var result = _argumentCollectionUtil.ArgsToDoubleEnumerable(ignoreHiddenCells, false, false, new List<FunctionArgument> { funcArg }, context);
-            //var result = dResult.Select(x => new ExcelDoubleCellValue(x));
             var dict = new Dictionary<int, double>();
             result.ToList().ForEach(x => dict.Add(horizontal ? x.CellCol.Value : x.CellRow.Value, x.Value));
             var resultList = new List<double>();

--- a/src/EPPlus/FormulaParsing/Excel/Functions/ExcelFunction.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/ExcelFunction.cs
@@ -615,11 +615,13 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
         /// </summary>
         /// <param name="arguments"></param>
         /// <param name="context"></param>
+        /// <param name="error"></param>
         /// <returns></returns>
         protected virtual IList<double> ArgsToDoubleEnumerable(IEnumerable<FunctionArgument> arguments,
-                                                                     ParsingContext context)
+                                                                     ParsingContext context, out ExcelErrorValue error)
         {
-            return ArgsToDoubleEnumerable(false, arguments, context);
+            error = null;
+            return ArgsToDoubleEnumerable(arguments, context, x => { }, out error);
         }
 
         /// <summary>
@@ -644,7 +646,12 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
         /// <param name="arguments"></param>
         /// <param name="context"></param>
         /// <returns></returns>
-        protected virtual IList<double> ArgsToDoubleEnumerable(bool ignoreHiddenCells, bool ignoreErrors, bool ignoreNestedSubtotalAggregate, IEnumerable<FunctionArgument> arguments, ParsingContext context)
+        protected virtual IList<double> ArgsToDoubleEnumerable(
+            bool ignoreHiddenCells, 
+            bool ignoreErrors, 
+            bool ignoreNestedSubtotalAggregate, 
+            IEnumerable<FunctionArgument> arguments, 
+            ParsingContext context)
         {
             //return _argumentCollectionUtil.ArgsToDoubleEnumerable(ignoreHiddenCells, ignoreErrors, ignoreNestedSubtotalAggregate, arguments, context, false);
             var options = new DoubleEnumerableParseOptions
@@ -696,42 +703,93 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
         /// <summary>
         /// Will return the arguments as an enumerable of doubles.
         /// </summary>
+        /// <param name="arguments"></param>
+        /// <param name="context"></param>
+        /// <param name="configHandler"></param>
+        /// <param name="error"></param>
+        /// <returns></returns>
+        /// <exception cref="ExcelErrorValueException"></exception>
+        protected virtual IList<double> ArgsToDoubleEnumerable(
+            IEnumerable<FunctionArgument> arguments, 
+            ParsingContext context, 
+            Action<DoubleEnumerableParseOptions> configHandler, 
+            out ExcelErrorValue error)
+        {
+            error = null;
+            var options = new DoubleEnumerableParseOptions();
+            configHandler(options);
+            var parser = new DoubleEnumerableArgParser(arguments, context, options);
+            var result = parser.GetResult(out error);
+            if (error != null)
+            {
+                throw new ExcelErrorValueException(error);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Will return the arguments as an enumerable of doubles.
+        /// </summary>
+        /// <param name="argument"></param>
+        /// <param name="context"></param>
+        /// <param name="configHandler"></param>
+        /// <param name="error"></param>
+        /// <returns></returns>
+        protected virtual IList<double> ArgsToDoubleEnumerable(FunctionArgument argument, ParsingContext context, Action<DoubleEnumerableParseOptions> configHandler, out ExcelErrorValue error)
+        {
+            return ArgsToDoubleEnumerable(new List<FunctionArgument> { argument }, context, configHandler, out error);
+        }
+
+        /// <summary>
+        /// Will return the arguments as an enumerable of doubles using default parameters
+        /// </summary>
+        /// <param name="argument"></param>
+        /// <param name="context"></param>
+        /// <param name="error"></param>
+        /// <returns></returns>
+        protected virtual IList<double> ArgsToDoubleEnumerable(FunctionArgument argument, ParsingContext context, out ExcelErrorValue error)
+        {
+            return ArgsToDoubleEnumerable(argument, context, x => { }, out error);
+        }
+        /// <summary>
+        /// Will return the arguments as an enumerable of doubles.
+        /// </summary>
         /// <param name="ignoreHiddenCells">If a cell is hidden and this value is true the value of that cell will be ignored</param>
         /// <param name="ignoreNestedSubtotalAggregate">If cells which value comes from the calculation of a SUBTOTAL or an AGGREGATE function should be ignored, set this to true</param>
         /// <param name="arguments"></param>
         /// <param name="context"></param>
         /// <param name="ignoreNonNumeric"></param>
         /// <returns></returns>
-        protected virtual IList<double> ArgsToDoubleEnumerable(bool ignoreHiddenCells, bool ignoreNestedSubtotalAggregate, IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreNonNumeric)
-        {
-            return ArgsToDoubleEnumerable(ignoreHiddenCells, true, ignoreNestedSubtotalAggregate, arguments, context, ignoreNonNumeric);
-        }
+            //protected virtual IList<double> ArgsToDoubleEnumerable(bool ignoreHiddenCells, bool ignoreNestedSubtotalAggregate, IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreNonNumeric)
+            //{
+            //    return ArgsToDoubleEnumerable(ignoreHiddenCells, true, ignoreNestedSubtotalAggregate, arguments, context, ignoreNonNumeric);
+            //}
 
-        /// <summary>
-        /// Will return the arguments as an enumerable of doubles.
-        /// </summary>
-        /// <param name="ignoreHiddenCells">If a cell is hidden and this value is true the value of that cell will be ignored</param>
-        /// <param name="arguments"></param>
-        /// <param name="context"></param>
-        /// <param name="ignoreNonNumeric"></param>
-        /// <returns></returns>
-        protected virtual IList<double> ArgsToDoubleEnumerable(bool ignoreHiddenCells, IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreNonNumeric)
-        {
-            return ArgsToDoubleEnumerable(ignoreHiddenCells, true, false, arguments, context, ignoreNonNumeric);
-        }
+            /// <summary>
+            /// Will return the arguments as an enumerable of doubles.
+            /// </summary>
+            /// <param name="ignoreHiddenCells">If a cell is hidden and this value is true the value of that cell will be ignored</param>
+            /// <param name="arguments"></param>
+            /// <param name="context"></param>
+            /// <param name="ignoreNonNumeric"></param>
+            /// <returns></returns>
+            //protected virtual IList<double> ArgsToDoubleEnumerable(bool ignoreHiddenCells, IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreNonNumeric)
+            //{
+            //    return ArgsToDoubleEnumerable(ignoreHiddenCells, true, false, arguments, context, ignoreNonNumeric);
+            //}
 
 
-        /// <summary>
-        /// Will return the arguments as an enumerable of doubles.
-        /// </summary>
-        /// <param name="ignoreHiddenCells">If a cell is hidden and this value is true the value of that cell will be ignored</param>
-        /// <param name="arguments"></param>
-        /// <param name="context"></param>        
-        /// <returns></returns>
-        protected virtual IList<double> ArgsToDoubleEnumerable(bool ignoreHiddenCells, IEnumerable<FunctionArgument> arguments, ParsingContext context)
-        {
-            return ArgsToDoubleEnumerable(ignoreHiddenCells, true, arguments, context, false);
-        }
+            /// <summary>
+            /// Will return the arguments as an enumerable of doubles.
+            /// </summary>
+            /// <param name="ignoreHiddenCells">If a cell is hidden and this value is true the value of that cell will be ignored</param>
+            /// <param name="arguments"></param>
+            /// <param name="context"></param>        
+            /// <returns></returns>
+            //protected virtual IList<double> ArgsToDoubleEnumerable(bool ignoreHiddenCells, IEnumerable<FunctionArgument> arguments, ParsingContext context)
+            //{
+            //    return ArgsToDoubleEnumerable(ignoreHiddenCells, true, arguments, context, false);
+            //}
 
         protected virtual IEnumerable<double> ArgsToDoubleEnumerableZeroPadded(bool ignoreHiddenCells, IRangeInfo rangeInfo, ParsingContext context)
         {
@@ -741,8 +799,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
             var endCol = rangeInfo.Address.ToCol > rangeInfo.Worksheet.Dimension._toCol ? rangeInfo.Worksheet.Dimension._toCol : rangeInfo.Address.ToCol;
             var horizontal = (startRow == endRow && rangeInfo.Address.FromCol < rangeInfo.Address.ToCol);
             var funcArg = new FunctionArgument(rangeInfo, DataType.ExcelRange);
-            var dResult = ArgsToDoubleEnumerable(ignoreHiddenCells, new List<FunctionArgument> { funcArg }, context);
-            var result = dResult.Select(x => new ExcelDoubleCellValue(x));
+            //var dResult = ArgsToDoubleEnumerable(ignoreHiddenCells, new List<FunctionArgument> { funcArg }, context);
+            var result = _argumentCollectionUtil.ArgsToDoubleEnumerable(ignoreHiddenCells, false, false, new List<FunctionArgument> { funcArg }, context);
+            //var result = dResult.Select(x => new ExcelDoubleCellValue(x));
             var dict = new Dictionary<int, double>();
             result.ToList().ForEach(x => dict.Add(horizontal ? x.CellCol.Value : x.CellRow.Value, x.Value));
             var resultList = new List<double>();

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Finance/FvSchedule.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Finance/FvSchedule.cs
@@ -32,7 +32,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Finance
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
 
             var scheduleArg = new List<FunctionArgument> { arguments[1] };
-            var schedule = ArgsToDoubleEnumerable(scheduleArg, context);
+            var schedule = ArgsToDoubleEnumerable(scheduleArg, context, out ExcelErrorValue e2);
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
             var result = principal;
             foreach(var interest in schedule)
             {

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Finance/Irr.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Finance/Irr.cs
@@ -29,7 +29,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Finance
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var values = ArgsToDoubleEnumerable(new List<FunctionArgument> { arguments[0] }, context);
+            var values = ArgsToDoubleEnumerable(arguments[0], context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             var result = default(FinanceCalcResult<double>);
             if(arguments.Count == 1)
             {
@@ -37,8 +38,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Finance
             }
             else
             {
-                var guess = ArgToDecimal(arguments, 1, out ExcelErrorValue e1);
-                if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+                var guess = ArgToDecimal(arguments, 1, out ExcelErrorValue e2);
+                if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
                 result = IrrImpl.Irr(values.Select(x => (double)x).ToArray(), guess);
             }
             if (result.HasError) return CompileResult.GetErrorResult(result.ExcelErrorType);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Finance/Mirr.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Finance/Mirr.cs
@@ -29,13 +29,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Finance
         public override int ArgumentMinLength => 3;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var values = ArgsToDoubleEnumerable(new List<FunctionArgument> { arguments.ElementAt(0) }, context);
-            
-            var financeRate = ArgToDecimal(arguments, 1, out ExcelErrorValue e1);
+            var values = ArgsToDoubleEnumerable(arguments.ElementAt(0), context, out ExcelErrorValue e1);
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
 
-            var reinvestState = ArgToDecimal(arguments, 2, out ExcelErrorValue e2);
+            var financeRate = ArgToDecimal(arguments, 1, out ExcelErrorValue e2);
             if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
+
+            var reinvestState = ArgToDecimal(arguments, 2, out ExcelErrorValue e3);
+            if (e3 != null) return CompileResult.GetErrorResult(e3.Type);
 
             var result = MirrImpl.MIRR(values.Select(x => (double)x).ToArray(), financeRate, reinvestState);
             if (result.HasError) return CompileResult.GetErrorResult(result.ExcelErrorType);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Finance/Npv.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Finance/Npv.cs
@@ -31,7 +31,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Finance
         {
             var rate = ArgToDecimal(arguments, 0, out ExcelErrorValue e1);
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
-            var args = ArgsToDoubleEnumerable(false, true, arguments, context).ToList();
+            var args = ArgsToDoubleEnumerable(arguments, context, x => x.IgnoreErrors = true, out ExcelErrorValue e2);
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
             var retVal = CashFlowHelper.Npv(rate, args.Skip(1).Select(x => (double)x));
             return CreateResult(retVal, DataType.Decimal);
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Finance/Xirr.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Finance/Xirr.cs
@@ -29,13 +29,15 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Finance
         public override int ArgumentMinLength => 2;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var values = ArgsToDoubleEnumerable(new List<FunctionArgument> { arguments.ElementAt(0) }, context).Select(x => (double)x);
-            var dates = ArgsToDoubleEnumerable(new List<FunctionArgument> { arguments.ElementAt(1) }, context).Select(x => DateTime.FromOADate(x));
+            var values = ArgsToDoubleEnumerable(arguments.ElementAt(0), context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            var dates = ArgsToDoubleEnumerable(arguments.ElementAt(1), context, out ExcelErrorValue e2).Select(x => DateTime.FromOADate(x));
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
             var guess = 0.1;
             if(arguments.Count > 2)
             {
-                guess = ArgToDecimal(arguments, 2, out ExcelErrorValue e1);
-                if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+                guess = ArgToDecimal(arguments, 2, out ExcelErrorValue e3);
+                if (e3 != null) return CompileResult.GetErrorResult(e3.Type);
             }
             var result = XirrImpl.GetXirr(values, dates, guess);
             if (result.HasError) return CompileResult.GetErrorResult(result.ExcelErrorType);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Finance/Xnpv.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Finance/Xnpv.cs
@@ -33,13 +33,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Finance
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
 
             var arg2 = new List<FunctionArgument> { arguments.ElementAt(1) };
-            var values = ArgsToDoubleEnumerable(arg2, context);
-            var dates = GetDates(arguments.ElementAt(2), context);
-            if (values.Count() != dates.Count())
+            var values = ArgsToDoubleEnumerable(arg2, context, out ExcelErrorValue e2);
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
+            var dates = GetDates(arguments.ElementAt(2));
+            if (values.Count != dates.Count())
                 return CreateResult(eErrorType.Num);
             var firstDate = dates.First();
             var result = 0d;
-            for(var i = 0; i < values.Count(); i++)
+            for(var i = 0; i < values.Count; i++)
             {
                 var dt = dates.ElementAt(i);
                 var val = values.ElementAt(i);
@@ -49,7 +50,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Finance
             return CreateResult(result, DataType.Decimal);
         }
 
-        private IEnumerable<DateTime> GetDates(FunctionArgument arg, ParsingContext context)
+        private static IEnumerable<DateTime> GetDates(FunctionArgument arg)
         {
             var dates = new List<DateTime>();
             if(arg.Value is IEnumerable<FunctionArgument>)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/CalcExtensions.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/CalcExtensions.cs
@@ -54,6 +54,36 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
             return sum.Get() / values.Count();
         }
 
+        public static double AverageKahan(this IList<double> values)
+        {
+            KahanSum sum = 0.0;
+            foreach (var val in values)
+            {
+                sum += val;
+            }
+            return sum.Get() / values.Count();
+        }
+
+        public static double AverageKahan(this IList<double?> values)
+        {
+            KahanSum sum = 0.0;
+            foreach (var val in values)
+            {
+                sum += val ?? 0;
+            }
+            return sum.Get() / values.Count(x => x.HasValue);
+        }
+
+        public static double AverageKahan(this double[] values)
+        {
+            KahanSum sum = 0.0;
+            foreach (var val in values)
+            {
+                sum += val;
+            }
+            return sum.Get() / values.Count();
+        }
+
         public static double AverageKahan(this IEnumerable<double> values, Func<double, double> selector)
         {
             KahanSum sum = 0.0;
@@ -80,6 +110,16 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
             foreach (var val in values)
             {
                 sum += val;
+            }
+            return sum.Get();
+        }
+
+        public static double SumKahan(this IEnumerable<double?> values)
+        {
+            KahanSum sum = 0.0;
+            foreach (var val in values)
+            {
+                sum += val ?? 0;
             }
             return sum.Get();
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/HiddenValuesHandlingFunction.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/HiddenValuesHandlingFunction.cs
@@ -51,16 +51,16 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
         /// </summary>
         public bool IgnoreNestedSubtotalsAndAggregates { get; set; }
 
-        protected override IEnumerable<ExcelDoubleCellValue> ArgsToDoubleEnumerable(IEnumerable<FunctionArgument> arguments, ParsingContext context)
+        protected override IList<double> ArgsToDoubleEnumerable(IEnumerable<FunctionArgument> arguments, ParsingContext context)
         {
             return ArgsToDoubleEnumerable(arguments, context, IgnoreErrors, false);
         }
 
-        protected IEnumerable<ExcelDoubleCellValue> ArgsToDoubleEnumerable(IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreErrors, bool ignoreNonNumeric)
+        protected IList<double> ArgsToDoubleEnumerable(IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreErrors, bool ignoreNonNumeric)
         {
             if (!arguments.Any())
             {
-                return Enumerable.Empty<ExcelDoubleCellValue>();
+                return new List<double>();
             }
             if (IgnoreHiddenValues)
             {

--- a/src/EPPlus/FormulaParsing/Excel/Functions/HiddenValuesHandlingFunction.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/HiddenValuesHandlingFunction.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Text;
 using OfficeOpenXml.FormulaParsing;
 using OfficeOpenXml.FormulaParsing.Exceptions;
+using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 {
@@ -51,8 +52,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
         /// </summary>
         public bool IgnoreNestedSubtotalsAndAggregates { get; set; }
 
-        protected override IList<double> ArgsToDoubleEnumerable(IEnumerable<FunctionArgument> arguments, ParsingContext context)
+        protected override IList<double> ArgsToDoubleEnumerable(IEnumerable<FunctionArgument> arguments, ParsingContext context, out ExcelErrorValue error)
         {
+            error = null;
             return ArgsToDoubleEnumerable(arguments, context, IgnoreErrors, false);
         }
 
@@ -65,7 +67,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
             if (IgnoreHiddenValues)
             {
                 var nonHidden = arguments.Where(x => !x.ExcelStateFlagIsSet(ExcelCellState.HiddenCell));
-                return base.ArgsToDoubleEnumerable(IgnoreHiddenValues, nonHidden, context);
+                var res = base.ArgsToDoubleEnumerable(nonHidden, context, x => x.IgnoreHiddenCells = IgnoreHiddenValues, out ExcelErrorValue e1);
+                if (e1 != null) throw new ExcelErrorValueException(e1.Type);
             }
             return base.ArgsToDoubleEnumerable(IgnoreHiddenValues, ignoreErrors, IgnoreNestedSubtotalsAndAggregates, arguments, context, ignoreNonNumeric);
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/HiddenValuesHandlingFunction.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/HiddenValuesHandlingFunction.cs
@@ -54,14 +54,24 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 
         protected override IList<double> ArgsToDoubleEnumerable(IEnumerable<FunctionArgument> arguments, ParsingContext context, out ExcelErrorValue error)
         {
-            error = null;
-            return ArgsToDoubleEnumerable(arguments, context, IgnoreErrors, false);
+            return ArgsToDoubleEnumerable(arguments, context, IgnoreErrors, false, out error);
         }
 
-        protected IList<double> ArgsToDoubleEnumerable(IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreErrors, bool ignoreNonNumeric)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="arguments"></param>
+        /// <param name="context"></param>
+        /// <param name="ignoreErrors"></param>
+        /// <param name="ignoreNonNumeric"></param>
+        /// <param name="error"></param>
+        /// <returns></returns>
+        /// <exception cref="ExcelErrorValueException"></exception>
+        protected IList<double> ArgsToDoubleEnumerable(IEnumerable<FunctionArgument> arguments, ParsingContext context, bool ignoreErrors, bool ignoreNonNumeric, out ExcelErrorValue error)
         {
             if (!arguments.Any())
             {
+                error = null;
                 return new List<double>();
             }
             if (IgnoreHiddenValues)
@@ -70,7 +80,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
                 var res = base.ArgsToDoubleEnumerable(nonHidden, context, x => x.IgnoreHiddenCells = IgnoreHiddenValues, out ExcelErrorValue e1);
                 if (e1 != null) throw new ExcelErrorValueException(e1.Type);
             }
-            return base.ArgsToDoubleEnumerable(IgnoreHiddenValues, ignoreErrors, IgnoreNestedSubtotalsAndAggregates, arguments, context, ignoreNonNumeric);
+            //return base.ArgsToDoubleEnumerable(IgnoreHiddenValues, ignoreErrors, IgnoreNestedSubtotalsAndAggregates, arguments, context, ignoreNonNumeric);
+            return base.ArgsToDoubleEnumerable(arguments, context, x =>
+            {
+                x.IgnoreHiddenCells = IgnoreHiddenValues;
+                x.IgnoreErrors = ignoreErrors;
+                x.IgnoreNestedSubtotalAggregate = IgnoreNestedSubtotalsAndAggregates;
+                x.IgnoreNonNumeric = ignoreNonNumeric;
+            }, out error);
         }
 
         protected bool ShouldIgnore(ICellInfo c, ParsingContext context)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/AverageIfs.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/AverageIfs.cs
@@ -43,7 +43,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         }));
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var sumRange = ArgsToDoubleEnumerable(false, new List<FunctionArgument> { arguments[0] }, context).ToList();
+            var sumRange = ArgsToDoubleEnumerable(arguments[0], context, out ExcelErrorValue e1).ToList();
             var argRanges = new List<RangeOrValue>();
             var criterias = new List<object>();
             for (var ix = 1; ix < 31; ix += 2)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Covar.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Covar.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   10/12/2020         EPPlus Software AB       Version 5.5
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using System;
@@ -34,8 +35,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
             if (array1.Count != array2.Count) return CreateResult(eErrorType.NA);
             if (array1.Count == 0) return CreateResult(eErrorType.Div0);
-            var avg1 = array1.Average();
-            var avg2 = array2.Average();
+            var avg1 = array1.AverageKahan();
+            var avg2 = array2.AverageKahan();
             var result = 0d;
             for(var x = 0; x < array1.Count; x++)
             {

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Covar.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Covar.cs
@@ -28,18 +28,20 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 2;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var array1 = ArgsToDoubleEnumerable(arguments.Take(1), context).ToArray();
-            var array2 = ArgsToDoubleEnumerable(arguments.Skip(1).Take(1), context).ToArray();
-            if (array1.Length != array2.Length) return CreateResult(eErrorType.NA);
-            if (array1.Length == 0) return CreateResult(eErrorType.Div0);
-            var avg1 = array1.Select(x => x.Value).Average();
-            var avg2 = array2.Select(x => x.Value).Average();
+            var array1 = ArgsToDoubleEnumerable(arguments.Take(1), context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            var array2 = ArgsToDoubleEnumerable(arguments.Skip(1).Take(1), context, out ExcelErrorValue e2);
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
+            if (array1.Count != array2.Count) return CreateResult(eErrorType.NA);
+            if (array1.Count == 0) return CreateResult(eErrorType.Div0);
+            var avg1 = array1.Average();
+            var avg2 = array2.Average();
             var result = 0d;
-            for(var x = 0; x < array1.Length; x++)
+            for(var x = 0; x < array1.Count; x++)
             {
                 result += (array1[x] - avg1) * (array2[x] - avg2);
             }
-            result /= array1.Length;
+            result /= array1.Count;
             return CreateResult(result, DataType.Decimal);
         }
     }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Gcd.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Gcd.cs
@@ -28,7 +28,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var numbers = ArgsToDoubleEnumerable(arguments, context).Select(x => (int)x);
+            var numbers = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1).Select(x => (int)x);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             return CreateResult(MathHelper.GreatestCommonDevisor(numbers.ToArray()), DataType.Integer);
         }
     }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Large.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Large.cs
@@ -39,8 +39,12 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         {
             var args = arguments[0];
             var index = ArgToInt(arguments, 1, IgnoreErrors) - 1;
-            var values = ArgsToDoubleEnumerable(new List<FunctionArgument> {args}, context);
-            if (index < 0 || index >= values.Count()) return CompileResult.GetErrorResult(eErrorType.Num);
+            var values = ArgsToDoubleEnumerable(args, context, x => {
+                x.IgnoreHiddenCells = IgnoreHiddenValues;
+                x.IgnoreErrors = IgnoreErrors;
+            }, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            if (index < 0 || index >= values.Count) return CompileResult.GetErrorResult(eErrorType.Num);
             var result = values.OrderByDescending(x => x).ElementAt(index);
             return CreateResult(result, DataType.Decimal);
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Lcm.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Lcm.cs
@@ -28,7 +28,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var numbers = ArgsToDoubleEnumerable(arguments, context).Select(x => (int)x);
+            var numbers = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1).Select(x => (int)x);
             foreach (var number in numbers) if (number < 0) return CompileResult.GetErrorResult(eErrorType.Num);
             return CreateResult(MathHelper.LeastCommonMultiple(numbers.ToArray()), DataType.Integer);
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Max.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Max.cs
@@ -37,7 +37,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var values = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, arguments, context);
+            var values = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             if (!values.Any())
             {
                 return CreateResult(0d, DataType.Decimal);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Median.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Median.cs
@@ -37,7 +37,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var nums = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, arguments, context);
+            var nums = ArgsToDoubleEnumerable( arguments, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             var arr = nums.ToArray();
             Array.Sort(arr);
             if (arr.Length == 0) return CompileResult.GetErrorResult(eErrorType.Num);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Min.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Min.cs
@@ -37,7 +37,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var values = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, IgnoreNestedSubtotalsAndAggregates, arguments, context, true);
+            var values = ArgsToDoubleEnumerable(arguments, context, x =>
+            {
+                x.IgnoreHiddenCells = IgnoreHiddenValues;
+                x.IgnoreErrors = IgnoreErrors;
+                x.IgnoreNestedSubtotalAggregate = IgnoreNestedSubtotalsAndAggregates;
+                x.IgnoreNonNumeric = true;
+            }, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             if(!values.Any())
             {
                 return CreateResult(0d, DataType.Decimal);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Mode.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Mode.cs
@@ -37,7 +37,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
             if (arguments.Count() > 255) return CompileResult.GetErrorResult(eErrorType.Value);
-            var numbers = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, arguments, context);
+            var numbers = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             var counts = new Dictionary<double, int>();
             double? maxCountValue = default;
             foreach(var number in numbers)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Multinomial.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Multinomial.cs
@@ -28,7 +28,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var numbers = ArgsToDoubleEnumerable(arguments, context);
+            var numbers = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             var part1 = 0d;
             var part2 = 1d;
             foreach(var number in numbers)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Percentile.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Percentile.cs
@@ -28,10 +28,11 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 2;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var arr = ArgsToDoubleEnumerable(arguments.Take(1), context).Select(x => (double)x).ToList();
-            
-            var percentile = ArgToDecimal(arguments, 1, out ExcelErrorValue e1);
+            var arr = ArgsToDoubleEnumerable(arguments.Take(1), context, out ExcelErrorValue e1).ToList();
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+
+            var percentile = ArgToDecimal(arguments, 1, out ExcelErrorValue e2);
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
 
             if (percentile < 0 || percentile > 1) return CompileResult.GetErrorResult(eErrorType.Num);
             arr.Sort();

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/PercentileExc.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/PercentileExc.cs
@@ -30,10 +30,11 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 2;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var arr = ArgsToDoubleEnumerable(arguments.Take(1), context).Select(x => (double)x).ToList();
-            
-            var k = ArgToDecimal(arguments, 1, out ExcelErrorValue e1);
+            var arr = ArgsToDoubleEnumerable(arguments.Take(1), context, out ExcelErrorValue e1).ToList();
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+
+            var k = ArgToDecimal(arguments, 1, out ExcelErrorValue e2);
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
 
             if (k <= 0 || k >= 1) return CreateResult(eErrorType.Num);
             var n = arr.Count;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/PercentileInc.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/PercentileInc.cs
@@ -29,9 +29,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 2;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var arr = ArgsToDoubleEnumerable(arguments.Take(1), context).Select(x => (double)x).ToList();
-            var percentile = ArgToDecimal(arguments, 1, out ExcelErrorValue e1);
+            var arr = ArgsToDoubleEnumerable(arguments.Take(1), context, out ExcelErrorValue e1).ToList();
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            var percentile = ArgToDecimal(arguments, 1, out ExcelErrorValue e2);
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
             if (percentile < 0 || percentile > 1) return CompileResult.GetErrorResult(eErrorType.Num);
             arr.Sort();
             var nElements = arr.Count;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Percentrank.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Percentrank.cs
@@ -28,9 +28,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 2;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var array = GetNumbersFromArgs(arguments, 0, context);
-            var number = ArgToDecimal(arguments, 1, out ExcelErrorValue e1);
+            var array = GetNumbersFromArgs(arguments, 0, context, out ExcelErrorValue e1);
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            var number = ArgToDecimal(arguments, 1, out ExcelErrorValue e2);
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
             if (number < array.First() || number > array.Last()) return CompileResult.GetErrorResult(eErrorType.NA);
             var significance = 3;
             if (arguments.Count > 2)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/PercentrankExc.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/PercentrankExc.cs
@@ -30,9 +30,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 2;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var array = GetNumbersFromArgs(arguments, 0, context);
-            var number = ArgToDecimal(arguments, 1, out ExcelErrorValue e1);
+            var array = GetNumbersFromArgs(arguments, 0, context, out ExcelErrorValue e1);
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            var number = ArgToDecimal(arguments, 1, out ExcelErrorValue e2);
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
             if (number < array.First() || number > array.Last()) return CompileResult.GetErrorResult(eErrorType.NA);
             var significance = 3;
             if (arguments.Count() > 2)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/PercentrankInc.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/PercentrankInc.cs
@@ -30,9 +30,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 2;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var array = GetNumbersFromArgs(arguments, 0, context);
-            var number = ArgToDecimal(arguments, 1, out ExcelErrorValue e1);
+            var array = GetNumbersFromArgs(arguments, 0, context, out ExcelErrorValue e1);
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            var number = ArgToDecimal(arguments, 1, out ExcelErrorValue e2);
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
 
             if (number < array.First() || number > array.Last()) return CompileResult.GetErrorResult(eErrorType.NA);
             var significance = 3;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Quartile.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Quartile.cs
@@ -27,7 +27,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
             var arrArg = arguments.Take(1);
-            var arr = ArgsToDoubleEnumerable(arrArg, context).Select(x => (double)x).ToList();
+            var arr = ArgsToDoubleEnumerable(arrArg, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             if (!arr.Any()) return CreateResult(eErrorType.Value);
             var quart = ArgToInt(arguments, 1);
             switch (quart)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/QuartileExc.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/QuartileExc.cs
@@ -30,7 +30,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
             var arrArg = arguments.Take(1);
-            var arr = ArgsToDoubleEnumerable(arrArg, context).Select(x => (double)x).ToList();
+            var arr = ArgsToDoubleEnumerable(arrArg, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             if (!arr.Any()) return CreateResult(eErrorType.Value);
             var quart = ArgToInt(arguments, 1);
             switch (quart)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/QuartileInc.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/QuartileInc.cs
@@ -16,7 +16,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
             var arrArg = arguments.Take(1);
-            var arr = ArgsToDoubleEnumerable(arrArg, context).Select(x => (double)x).ToList();
+            var arr = ArgsToDoubleEnumerable(arrArg, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             if (!arr.Any()) return CompileResult.GetErrorResult(eErrorType.Value);
             var quart = ArgToInt(arguments, 1);
             switch (quart)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/RankFunctionBase.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/RankFunctionBase.cs
@@ -37,9 +37,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             return numbers;
         }
 
-        protected double[] GetNumbersFromArgs(IEnumerable<FunctionArgument> arguments, int index, ParsingContext context)
+        protected double[] GetNumbersFromArgs(IEnumerable<FunctionArgument> arguments, int index, ParsingContext context, out ExcelErrorValue error)
         {
-            var array = ArgsToDoubleEnumerable(new FunctionArgument[] { arguments.ElementAt(index) }, context)
+            var array = ArgsToDoubleEnumerable(arguments.ElementAt(index), context, out error)
                 .Select(x => (double)x)
                 .OrderBy(x => x)
                 .ToArray();

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Seriessum.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Seriessum.cs
@@ -37,7 +37,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             var m = ArgToDecimal(arguments, 2, out ExcelErrorValue e3);
             if (e3 != null) return CompileResult.GetErrorResult(e3.Type);
 
-            var coeffs = ArgsToDoubleEnumerable(new List<FunctionArgument> { arguments.ElementAt(3) }, context).ToArray();
+            var coeffs = ArgsToDoubleEnumerable(arguments[3], context, out ExcelErrorValue e4);
+            if (e4 != null) return CompileResult.GetErrorResult(e4.Type);
             var result = 0d;
             for(var i = 0; i < coeffs.Count(); i++)
             {

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Small.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Small.cs
@@ -42,7 +42,13 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             
             
             var index = ArgToInt(arguments, 1, IgnoreErrors) - 1;
-            var values = ArgsToDoubleEnumerable(false,new List<FunctionArgument> { args }, context, true);
+            var values = ArgsToDoubleEnumerable(args, context, x =>
+            {
+                x.IgnoreNonNumeric = true;
+                x.IgnoreHiddenCells = IgnoreHiddenValues;
+                x.IgnoreErrors = IgnoreErrors;
+            }, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             if (index < 0 || index >= values.Count()) return CompileResult.GetErrorResult(eErrorType.Num);
             var result = values.OrderBy(x => x).ElementAt(index);
             return CreateResult(result, DataType.Decimal);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Stdev.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Stdev.cs
@@ -40,7 +40,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var values = ArgsToDoubleEnumerable(arguments, context).Select(x => (double)x);
+            var values = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             return StandardDeviation(values);
         }
 

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/StdevP.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/StdevP.cs
@@ -40,8 +40,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var args = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, IgnoreNestedSubtotalsAndAggregates, arguments, context);
-            return CreateResult(StandardDeviation(args.Select(x => (double)x)), DataType.Decimal);
+            var args = ArgsToDoubleEnumerable(arguments, context, x =>
+            {
+                x.IgnoreHiddenCells = IgnoreHiddenValues;
+                x.IgnoreErrors = IgnoreErrors;
+                x.IgnoreNestedSubtotalAggregate = IgnoreNestedSubtotalsAndAggregates;
+            }, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            return CreateResult(StandardDeviation(args), DataType.Decimal);
         }
 
         internal static double StandardDeviation(IEnumerable<double> values)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/SumIfs.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/SumIfs.cs
@@ -54,14 +54,16 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         {
             var rows = new List<int>();
             var valueRange = arguments[0].ValueAsRangeInfo;
-            List<double> sumRange;
+            IList<double> sumRange;
             if(valueRange != null)
             {
                 sumRange = ArgsToDoubleEnumerableZeroPadded(false, valueRange, context).ToList();
             }
             else
             {
-                sumRange = ArgsToDoubleEnumerable(false, new List<FunctionArgument> { arguments[0] }, context).Select(x => (double)x).ToList();
+                //sumRange = ArgsToDoubleEnumerable(false, new List<FunctionArgument> { arguments[0] }, context).Select(x => (double)x).ToList();
+                sumRange = ArgsToDoubleEnumerable(arguments[0], context, out ExcelErrorValue e1);
+                if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             } 
             var argRanges = new List<RangeOrValue>();
             var criterias = new List<object>();

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Var.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Var.cs
@@ -34,7 +34,13 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var args = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, IgnoreNestedSubtotalsAndAggregates, arguments, context);
+            var args = ArgsToDoubleEnumerable(arguments, context, x =>
+            {
+                x.IgnoreHiddenCells = IgnoreHiddenValues;
+                x.IgnoreErrors = IgnoreErrors;
+                x.IgnoreNestedSubtotalAggregate = IgnoreNestedSubtotalsAndAggregates;
+            }, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             return new CompileResult(VarMethods.Var(args), DataType.Decimal);
         }
     }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/VarMethods.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/VarMethods.cs
@@ -37,8 +37,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
        
         public static double Var(IEnumerable<double> args)
         {
-            double avg = args.Select(x => (double)x).Average();
-            double d1 = args.Aggregate(0.0, (total, next) => total += System.Math.Pow(next - avg, 2));
+            double avg = args.AverageKahan();
             double d = args.AggregateKahan(0.0, (total, next) => total += System.Math.Pow(next - avg, 2));
             return Divide(d, (args.Count() - 1));
         }
@@ -50,7 +49,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
 
         public static double VarP(IEnumerable<double> args)
         {
-            double avg = args.Select(x => (double)x).Average();
+            double avg = args.AverageKahan();
             double d = args.AggregateKahan(0.0, (total, next) => total += System.Math.Pow(next - avg, 2));
             return Divide(d, args.Count()); 
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/VarP.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/VarP.cs
@@ -32,7 +32,13 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var args = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, IgnoreNestedSubtotalsAndAggregates, arguments, context);
+            var args = ArgsToDoubleEnumerable(arguments, context, x =>
+            {
+                x.IgnoreHiddenCells = IgnoreHiddenValues;
+                x.IgnoreErrors = IgnoreErrors;
+                x.IgnoreNestedSubtotalAggregate = IgnoreNestedSubtotalsAndAggregates;
+            }, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             return new CompileResult(VarMethods.VarP(args), DataType.Decimal);
         }
         public override ExcelFunctionParametersInfo ParametersInfo => new ExcelFunctionParametersInfo(new Func<int, FunctionParameterInformation>((argumentIndex) =>

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Avedev.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Avedev.cs
@@ -28,7 +28,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var arr = ArgsToDoubleEnumerable(arguments, context);
+            var arr = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             if (!arr.Any()) return CreateResult(eErrorType.Div0);
             var dArr = arr.Select(x => (double)x);
             var mean = dArr.Average();

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Avedev.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Avedev.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   05/25/2020         EPPlus Software AB       Implemented function
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using System;
@@ -31,9 +32,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
             var arr = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             if (!arr.Any()) return CreateResult(eErrorType.Div0);
-            var dArr = arr.Select(x => (double)x);
-            var mean = dArr.Average();
-            var result = dArr.Aggregate(0d, (val, x) => val += System.Math.Abs(x - mean)) / dArr.Count();
+            var mean = arr.AverageKahan();
+            var result = arr.AggregateKahan(0d, (val, x) => val += System.Math.Abs(x - mean)) / arr.Count;
             return CreateResult(result, DataType.Decimal);
         }
     }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Devsq.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Devsq.cs
@@ -28,7 +28,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var arr = ArgsToDoubleEnumerable(arguments, context);
+            var arr = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             if (!arr.Any()) return CompileResult.GetErrorResult(eErrorType.Num);
             var mean = arr.Select(x => (double)x).Average();
             var result = arr.Aggregate(0d, (val, x) => val += System.Math.Pow(x - mean, 2));

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Devsq.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Devsq.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   05/25/2020         EPPlus Software AB       Implemented function
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using System;
@@ -31,8 +32,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
             var arr = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             if (!arr.Any()) return CompileResult.GetErrorResult(eErrorType.Num);
-            var mean = arr.Select(x => (double)x).Average();
-            var result = arr.Aggregate(0d, (val, x) => val += System.Math.Pow(x - mean, 2));
+            var mean = arr.AverageKahan();
+            var result = arr.AggregateKahan(0d, (val, x) => val += Math.Pow(x - mean, 2));
             return CreateResult(result, DataType.Decimal);
         }
     }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/FTest.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/FTest.cs
@@ -54,8 +54,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
 
         internal static double VarianceCalc(List<double> values)
         {
-            var mean = values.Average();
-            var sumOfSquares = values.Sum(val => Math.Pow(val - mean, 2));
+            var mean = values.AverageKahan();
+            var sumOfSquares = values.SumKahan(val => Math.Pow(val - mean, 2));
             var setVariance = sumOfSquares / (values.Count() - 1);
             return setVariance;
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Forecast.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Forecast.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   22/10/2022         EPPlus Software AB           EPPlus v6
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using System;
@@ -34,8 +35,12 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
 
             var arg1 = arguments[1];
             var arg2 = arguments[2];
-            var arrayY = ArgsToDoubleEnumerable(false, false, new FunctionArgument[] { arg1 }, context).Select(a => a.Value).ToArray();
-            var arrayX = ArgsToDoubleEnumerable(false, false, new FunctionArgument[] { arg2 }, context).Select(b => b.Value).ToArray();
+            //var arrayY = ArgsToDoubleEnumerable(false, false, new FunctionArgument[] { arg1 }, context).Select(a => a.Value).ToArray();
+            //var arrayX = ArgsToDoubleEnumerable(false, false, new FunctionArgument[] { arg2 }, context).Select(b => b.Value).ToArray();
+            var arrayY = ArgsToDoubleEnumerable(arg1, context, out ExcelErrorValue e2).ToArray();
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
+            var arrayX = ArgsToDoubleEnumerable(arg2, context, out ExcelErrorValue e3).ToArray();
+            if (e3 != null) return CompileResult.GetErrorResult(e3.Type);
             if (arrayY.Count() != arrayX.Count()) return CompileResult.GetErrorResult(eErrorType.NA);
             if (!arrayY.Any()) return CompileResult.GetErrorResult(eErrorType.NA);
             var result = ForecastImpl(x, arrayY, arrayX);
@@ -44,8 +49,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
 
         internal static double ForecastImpl(double x, double[] arrayY, double[] arrayX)
         {
-            var avgY = arrayY.Average();
-            var avgX = arrayX.Average();
+            var avgY = arrayY.AverageKahan();
+            var avgX = arrayX.AverageKahan();
             var nItems = arrayY.Length;
             var upperEquationPart = 0d;
             var lowerEquationPart = 0d;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/ForecastLinear.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/ForecastLinear.cs
@@ -31,10 +31,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
             var x = ArgToDecimal(arguments, 0, out ExcelErrorValue e1);
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
 
-            var arg1 = arguments[1];
-            var arg2 = arguments[2];
-            var arrayY = ArgsToDoubleEnumerable(false, false, new FunctionArgument[] { arg1 }, context).Select(a => a.Value).ToArray();
-            var arrayX = ArgsToDoubleEnumerable(false, false, new FunctionArgument[] { arg2 }, context).Select(b => b.Value).ToArray();
+            var arrayY = ArgsToDoubleEnumerable(arguments[1], context, out ExcelErrorValue e2).ToArray();
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
+            var arrayX = ArgsToDoubleEnumerable(arguments[2], context, out ExcelErrorValue e3).ToArray();
+            if (e3 != null) return CompileResult.GetErrorResult(e3.Type);
             if (arrayY.Count() != arrayX.Count()) return CompileResult.GetErrorResult(eErrorType.NA);
             if (!arrayY.Any()) return CompileResult.GetErrorResult(eErrorType.NA);
             var result = Forecast.ForecastImpl(x, arrayY, arrayX);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Geomean.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Geomean.cs
@@ -29,15 +29,15 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var numbers = ArgsToDoubleEnumerable(arguments, context);
-            if (numbers.Any(x => x.Value <= 0d)) return CompileResult.GetErrorResult(eErrorType.Num);
+            var numbers = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            if (numbers.Any(x => x <= 0d)) return CompileResult.GetErrorResult(eErrorType.Num);
             var p = 1d;
             for(var x = 0; x < numbers.Count(); x++)
             {
-                var n = numbers.ElementAt(x);
-                p *= n.Value;
+                p *= numbers.ElementAt(x);
             }
-            var result = System.Math.Pow(p, 1d / numbers.Count());
+            var result = System.Math.Pow(p, 1d / numbers.Count);
             return CreateResult(result, DataType.Decimal);
         }
     }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Harmean.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Harmean.cs
@@ -28,14 +28,15 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var numbers = ArgsToDoubleEnumerable(arguments, context);
-            if (numbers.Any(x => x.Value <= 0d)) return CompileResult.GetErrorResult(eErrorType.Num);
+            var numbers = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            if (numbers.Any(x => x <= 0d)) return CompileResult.GetErrorResult(eErrorType.Num);
             var n = 0d;
             for (var x = 0; x < numbers.Count(); x++)
             {
                 n += 1d/numbers.ElementAt(x);
             }
-            var result = (double)numbers.Count() / n;
+            var result = numbers.Count / n;
             return CreateResult(result, DataType.Decimal);
         }
     }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Kurt.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Kurt.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   22/10/2022         EPPlus Software AB           EPPlus v6
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
@@ -39,13 +40,13 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
                 return stdev;
             }
             var part1 = (n * (n + 1)) / ((n - 1) * (n - 2) * (n - 3));
-            var avg = numbers.Average();
+            var avg = numbers.AverageKahan();
             var part2 = 0d;
             for(var x = 0; x < n; x++)
             {
-                part2 += System.Math.Pow((numbers.ElementAt(x) - avg), 4);
+                part2 += Math.Pow((numbers.ElementAt(x) - avg), 4);
             }
-            part2 /= System.Math.Pow((double)stdev.Result, 4);
+            part2 /= Math.Pow((double)stdev.Result, 4);
             var result = part1 * part2 - (3 * System.Math.Pow(n - 1, 2)) / ((n - 2) * (n - 3));
             return CreateResult(result, DataType.Decimal);
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Kurt.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Kurt.cs
@@ -32,13 +32,13 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
             var numbers = ArgsToDoubleEnumerable(true, arguments, context, true);
             var n = (double)numbers.Count();
             if (n < 4) return CompileResult.GetErrorResult(eErrorType.Div0);
-            var stdev = new Stdev().StandardDeviation(numbers.Select(x => x.Value));
+            var stdev = new Stdev().StandardDeviation(numbers);
             if(stdev.DataType == DataType.ExcelError)
             {
                 return stdev;
             }
             var part1 = (n * (n + 1)) / ((n - 1) * (n - 2) * (n - 3));
-            var avg = numbers.Select(x => x.Value).Average();
+            var avg = numbers.Average();
             var part2 = 0d;
             for(var x = 0; x < n; x++)
             {

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Kurt.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Kurt.cs
@@ -29,7 +29,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var numbers = ArgsToDoubleEnumerable(true, arguments, context, true);
+            var numbers = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             var n = (double)numbers.Count();
             if (n < 4) return CompileResult.GetErrorResult(eErrorType.Div0);
             var stdev = new Stdev().StandardDeviation(numbers);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/ModeDotMult.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/ModeDotMult.cs
@@ -66,7 +66,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
             {
                 return CompileResult.GetErrorResult(eErrorType.Value);
             }
-            var numbers = ArgsToDoubleEnumerable(IgnoreHiddenValues, IgnoreErrors, arguments, context);
+            var numbers = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             var countNumbers = new Dictionary<double, ModeValue>();
             int maxCount = 0;
             var sortOrder = 1;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Pearson.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Pearson.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   22/10/2022         EPPlus Software AB           EPPlus v6
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using System;
@@ -30,9 +31,11 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
         {
             var arg1 = arguments[0];
             var arg2 = arguments[1];
-            var array1 = ArgsToDoubleEnumerable(new FunctionArgument[] { arg1 }, context).Select(x => x.Value).ToArray();
-            var array2 = ArgsToDoubleEnumerable(new FunctionArgument[] { arg2 }, context).Select(x => x.Value).ToArray();
-            if (array1.Count() != array2.Count()) return CompileResult.GetErrorResult(eErrorType.NA);
+            var array1 = ArgsToDoubleEnumerable(arg1, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            var array2 = ArgsToDoubleEnumerable(arg2, context, out ExcelErrorValue e2);
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
+            if (array1.Count != array2.Count) return CompileResult.GetErrorResult(eErrorType.NA);
             if (!array1.Any()) return CompileResult.GetErrorResult(eErrorType.NA);
             var result = PearsonImpl(array1, array2);
             return CreateResult(result, DataType.Decimal);
@@ -40,18 +43,18 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
 
         internal static double PearsonImpl(IEnumerable<double> arr1, IEnumerable<double> arr2)
         {
-            var avg1 = arr1.Average();
-            var avg2 = arr2.Average();
+            var avg1 = arr1.AverageKahan();
+            var avg2 = arr2.AverageKahan();
             var length = arr1.Count();
             var number = 0d;
             double d1 = 0d, d2 = 0d;
             for(var x = 0; x < length; x++)
             {
                 number += (arr1.ElementAt(x) - avg1) * (arr2.ElementAt(x) - avg2);
-                d1 += System.Math.Pow(arr1.ElementAt(x) - avg1, 2);
-                d2 += System.Math.Pow(arr2.ElementAt(x) - avg2, 2);
+                d1 += Math.Pow(arr1.ElementAt(x) - avg1, 2);
+                d2 += Math.Pow(arr2.ElementAt(x) - avg2, 2);
             }
-            return number / System.Math.Sqrt(d1 * d2);
+            return number / Math.Sqrt(d1 * d2);
         }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Prob.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Prob.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   21/06/2023         EPPlus Software AB       Initial release EPPlus 7
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Logical;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.ExcelUtilities;
@@ -63,7 +64,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
             {
                 return CompileResult.GetErrorResult(eErrorType.NA);
             }
-            if (probRange.Sum() != 1)
+            if (probRange.SumKahan() != 1)
             {
                 return CompileResult.GetErrorResult(eErrorType.Num);
             }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Rsq.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Rsq.cs
@@ -28,11 +28,11 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
         public override int ArgumentMinLength => 2;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var arg1 = arguments[0];
-            var arg2 = arguments[1];
-            var knownXs = ArgsToDoubleEnumerable(false, false, new FunctionArgument[] { arg1 }, context).ToArray();
-            var knownYs = ArgsToDoubleEnumerable(false, false, new FunctionArgument[] { arg2 }, context).ToArray();
-            var result = Math.Pow(Pearson.PearsonImpl(knownXs.Select(x => x.Value).ToArray(), knownYs.Select(x => x.Value).ToArray()), 2);
+            var knownXs = ArgsToDoubleEnumerable(arguments[0], context, out ExcelErrorValue e1).ToArray();
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            var knownYs = ArgsToDoubleEnumerable(arguments[1], context, out ExcelErrorValue e2).ToArray();
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
+            var result = Math.Pow(Pearson.PearsonImpl(knownXs, knownYs), 2);
             return CreateResult(result, DataType.Decimal);
         }
     }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Skew.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Skew.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   22/10/2022         EPPlus Software AB           EPPlus v6
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
@@ -29,9 +30,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var numbers = ArgsToDoubleEnumerable(arguments, context).Select(x => x.Value).ToArray();
-            var n = numbers.Length;
-            var avg = numbers.Average();
+            var numbers = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            var n = numbers.Count;
+            var avg = numbers.AverageKahan();
             var s = 0d;
             for (var ix = 0; ix < n; ix++)
             {

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/SkewP.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/SkewP.cs
@@ -30,7 +30,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var numbers = ArgsToDoubleEnumerable(arguments, context).Select(x => x.Value).ToArray();
+            var numbers = ArgsToDoubleEnumerable(arguments, context).ToArray();
             var n = numbers.Length;
             var avg = numbers.Average();
             var sd = CalcStandardDev(numbers, avg);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/SkewP.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/SkewP.cs
@@ -30,8 +30,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var numbers = ArgsToDoubleEnumerable(arguments, context).ToArray();
-            var n = numbers.Length;
+            var numbers = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
+            if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            var n = numbers.Count;
             var avg = numbers.Average();
             var sd = CalcStandardDev(numbers, avg);
             var i = 0d;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/SkewP.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/SkewP.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   22/10/2022         EPPlus Software AB           EPPlus v6
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
@@ -33,12 +34,12 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
             var numbers = ArgsToDoubleEnumerable(arguments, context, out ExcelErrorValue e1);
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             var n = numbers.Count;
-            var avg = numbers.Average();
+            var avg = numbers.AverageKahan();
             var sd = CalcStandardDev(numbers, avg);
             var i = 0d;
             foreach(var number in numbers)
             {
-                i += System.Math.Pow((number - avg)/sd, 3);
+                i += Math.Pow((number - avg)/sd, 3);
             }
             var result = i / n;
             return CreateResult(result, DataType.Decimal);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Slope.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Slope.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   21/06/2023         EPPlus Software AB       Initial release EPPlus 7
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.ExcelUtilities;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
@@ -43,8 +44,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
 
             RangeFlattener.GetNumericPairLists(r1, r2, true, out List<double> yValuesFinal, out List<double> xValuesFinal);
 
-            double yMean = yValuesFinal.Select(y => (double)y).Average();
-            double xMean = xValuesFinal.Select(x => (double)x).Average();
+            double yMean = yValuesFinal.AverageKahan();
+            double xMean = xValuesFinal.AverageKahan();
 
             var nominator = 0d;
             var denominator = 0d;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Steyx.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Steyx.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   20/06/2023         EPPlus Software AB           EPPlus v7
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using OfficeOpenXml.Utils;
@@ -72,8 +73,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
 
 
 
-            double yMean = yValues.Average();
-            double xMean = xValues.Average();
+            double yMean = yValues.AverageKahan();
+            double xMean = xValues.AverageKahan();
             int sampleSize = yValues.Count;
             var p1 = 0d;
             var numerator = 0d;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/TTest.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/TTest.cs
@@ -79,7 +79,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
                 }
 
                 var differenceSD = StandardDeviation(differenceList);
-                tStat = differenceList.Average() / (differenceSD / Math.Sqrt(differenceList.Count()));
+                tStat = differenceList.AverageKahan() / (differenceSD / Math.Sqrt(differenceList.Count()));
                 tStat = Math.Abs(tStat);
 
                 var result = 1 - StudenttHelper.CumulativeDistributionFunction(tStat, differenceList.Count() - 1);
@@ -91,12 +91,12 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
                 var sX = StandardDeviation(list1);
                 var sY = StandardDeviation(list2);
 
-                var sXY = Math.Sqrt(((list1.Count() - 1) * Math.Pow(sX, 2) + (list2.Count() - 1) * Math.Pow(sY, 2))
+                var sXY = Math.Sqrt(((list1.Count() - 1) * Math.Pow(sX, 2) + (list2.Count - 1) * Math.Pow(sY, 2))
                     / (list1.Count() + list2.Count() - 2));
 
-                tStat = (Math.Abs(list1.Average() - list2.Average())) / (sXY * Math.Sqrt(1d / list1.Count() + 1d / list2.Count()));
+                tStat = (Math.Abs(list1.AverageKahan() - list2.AverageKahan())) / (sXY * Math.Sqrt(1d / list1.Count + 1d / list2.Count));
 
-                var result = 1 - StudenttHelper.CumulativeDistributionFunction(tStat, list1.Count() + list2.Count() - 2);
+                var result = 1 - StudenttHelper.CumulativeDistributionFunction(tStat, list1.Count + list2.Count - 2);
                 return CreateResult(tails == 1 ? result : 2 * result, DataType.Decimal);
 
             }
@@ -111,18 +111,18 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
                 var varX = Math.Pow(sX, 2);
                 var varY = Math.Pow(sY, 2);
 
-                var meanX = list1.Average();
-                var meanY = list2.Average();
+                var meanX = list1.AverageKahan();
+                var meanY = list2.AverageKahan();
 
                 //For type = 3 (Welsh-test), the degrees of freedom is calculated differently. Degrees of freedom calculated with Welch-Sattherwaite equation.
 
-                var numerator = Math.Pow(varX / list1.Count() + varY / list2.Count(), 2);
+                var numerator = Math.Pow(varX / list1.Count + varY / list2.Count, 2);
 
-                var denominator = Math.Pow(varX / list1.Count(), 2) / (list1.Count() - 1) + Math.Pow(varY / list2.Count(), 2) / (list2.Count() - 1);
+                var denominator = Math.Pow(varX / list1.Count, 2) / (list1.Count - 1) + Math.Pow(varY / list2.Count, 2) / (list2.Count - 1);
 
                 var degreesOfFreedom = numerator/ denominator; //We do not truncate here for excel compliance.
 
-                tStat = (meanX - meanY) / Math.Sqrt(varX / list1.Count() + varY/ list2.Count());
+                tStat = (meanX - meanY) / Math.Sqrt(varX / list1.Count + varY/ list2.Count);
 
                 tStat = Math.Abs(tStat);
 
@@ -137,7 +137,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
             //Returns the standard deviation of a list
 
             var std = 0d;
-            var mean = values.Average();
+            var mean = values.AverageKahan();
 
             for (var i = 0; i < values.Count; i++)
             {

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Trimmean.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Trimmean.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   21/06/2023         EPPlus Software AB       Initial release EPPlus 7
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using OfficeOpenXml.Utils;
@@ -52,7 +53,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
 
             List<double> trimmedValues = values.Skip(excludeCount).Take(values.Count - 2 * excludeCount).ToList();
 
-            double mean = trimmedValues.Average();
+            double mean = trimmedValues.AverageKahan();
 
             return mean;
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Trimmean.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Trimmean.cs
@@ -30,18 +30,17 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
 
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var values = ArgsToDoubleEnumerable(new List<FunctionArgument> { arguments[0] }, context);
-            var percentage = ArgToDecimal(arguments, 1, out ExcelErrorValue e1);
+            var values = ArgsToDoubleEnumerable(arguments[0], context, out ExcelErrorValue e1);
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+            var percentage = ArgToDecimal(arguments, 1, out ExcelErrorValue e2);
+            if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
 
             if (percentage < 0 || percentage >= 1)
             {
                 return CompileResult.GetErrorResult(eErrorType.Num);
             }
-
-            // cast ExcelDoubleValue to double
-            var doubleValues = values.Select(x => (double)x);   
-            var result = TrimMean(doubleValues.ToList(), percentage);
+ 
+            var result = TrimMean(values.ToList(), percentage);
             return CreateResult(result, DataType.Decimal);
         }
         public static double TrimMean(List<double> values, double percentage)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Ztest.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Ztest.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   21/06/2023         EPPlus Software AB       Initial release EPPlus 7
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.ExcelUtilities;
@@ -47,7 +48,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
                 {
                     return stdev;
                 }
-                double numbersMean = numbers.Select(i => (double)i).Average();
+                double numbersMean = numbers.AverageKahan();
                 var z = (numbersMean - value) / (stdev.ResultNumeric / Math.Sqrt(numbers.Count));
                 if (arguments.Count < 3)
                 {

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/ExcelFunctionTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/ExcelFunctionTests.cs
@@ -36,6 +36,7 @@ using EPPlusTest.FormulaParsing.TestHelpers;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using OfficeOpenXml.FormulaParsing;
 using OfficeOpenXml.FormulaParsing.Ranges;
+using OfficeOpenXml;
 
 namespace EPPlusTest.Excel.Functions
 {
@@ -45,9 +46,9 @@ namespace EPPlusTest.Excel.Functions
         private class ExcelFunctionTester : ExcelFunction
         {
             public override int ArgumentMinLength => 0;
-            public IEnumerable<ExcelDoubleCellValue> ArgsToDoubleEnumerableImpl(IEnumerable<FunctionArgument> args)
+            public IList<double> ArgsToDoubleEnumerableImpl(IEnumerable<FunctionArgument> args)
             {
-                return ArgsToDoubleEnumerable(args, ParsingContext.Create());
+                return ArgsToDoubleEnumerable(args, ParsingContext.Create(), out ExcelErrorValue e1);
             }
             #region Other members
             public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)


### PR DESCRIPTION
Refactored ArgToDoubleEnumerable, removed exception throwing with new errorhandling in functions. Replaced Sum() and Average() with corresponding Kahan methods
