### PR TITLE
Rounding down e.g. 17.38 resulted 17.37. Now results 17.38

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/Math/Rounddown.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Math/Rounddown.cs
@@ -50,11 +50,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Math
 
         private static double RoundDownDecimalNumber(double number, int nDecimals)
         {
-            var integerPart = System.Math.Floor(number);
-            var decimalPart = number - integerPart;
-            decimalPart = System.Math.Pow(10d, nDecimals)*decimalPart;
-            decimalPart = System.Math.Truncate(decimalPart)/System.Math.Pow(10d, nDecimals);
-            var result = integerPart + decimalPart;
+            int integerRepresentation = (int)System.Math.Floor(number * System.Math.Pow(10d, nDecimals));
+            var result = integerRepresentation / System.Math.Pow(10d, nDecimals);
             return result;
         }
     }


### PR DESCRIPTION
Rounding down sometimes resulted in floating-point errors. This avoids that by making the double into an integer representation first and then dividing it back down to the appropriate amount of decimals.