### PR TITLE
Setting The Pivot table SourceRange to the same range as an existing Pivot Cache could cause a corrupt worbook

### DIFF
--- a/src/EPPlus/Table/PivotTable/ExcelPivotTable.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotTable.cs
@@ -141,7 +141,7 @@ namespace OfficeOpenXml.Table.PivotTable
             CreatePivotTable(sheet, address, pivotTableCache.Fields.Count, name, tblId);
 
             CacheDefinition = new ExcelPivotCacheDefinition(sheet.NameSpaceManager, this, pivotTableCache);
-            CacheId = pivotTableCache.CacheId;
+            CacheId = pivotTableCache.ExtLstCacheId;
 
             LoadFields();
             Styles = new ExcelPivotTableAreaStyleCollection(this);
@@ -160,7 +160,7 @@ namespace OfficeOpenXml.Table.PivotTable
             CreatePivotTable(sheet, address, sourceAddress._toCol - sourceAddress._fromCol + 1, name, tblId);
 
             CacheDefinition = new ExcelPivotCacheDefinition(sheet.NameSpaceManager, this, sourceAddress);
-            CacheId = CacheDefinition._cacheReference.CacheId;
+            CacheId = CacheDefinition._cacheReference.ExtLstCacheId;
 
             LoadFields();
             Styles = new ExcelPivotTableAreaStyleCollection(this);
@@ -206,7 +206,6 @@ namespace OfficeOpenXml.Table.PivotTable
                 fld.LoadItems();
                 Fields.AddInternal(fld);
             }
-
         }
         private string GetStartXml(string name, ExcelAddressBase address, int fields)
         {
@@ -1145,6 +1144,7 @@ namespace OfficeOpenXml.Table.PivotTable
             var newCacheId = WorkSheet.Workbook.GetNewPivotCacheId();
             CacheId = newCacheId;
             CacheDefinition._cacheReference.CacheId = newCacheId;
+            CacheDefinition._cacheReference.ExtLstCacheId = newCacheId;
             WorkSheet.Workbook.SetXmlNodeInt($"d:pivotCaches/d:pivotCache[@cacheId={oldCacheId}]/@cacheId", newCacheId);
 
             return newCacheId;

--- a/src/EPPlus/Table/PivotTable/PivotTableCacheInternal.cs
+++ b/src/EPPlus/Table/PivotTable/PivotTableCacheInternal.cs
@@ -31,9 +31,10 @@ namespace OfficeOpenXml.Table.PivotTable
             CacheDefinitionXml = new XmlDocument();
             LoadXmlSafe(CacheDefinitionXml, Part.GetStream());
             TopNode = CacheDefinitionXml.DocumentElement;
-            if (CacheId <= 0)   //Check if the is set via exLst (used by for example slicers), otherwise set it to the cacheId
+            CacheId = cacheId;
+            if (ExtLstCacheId <= 0)   //Check if the is set via exLst (used by for example slicers), otherwise set it to the cacheId
             {
-                CacheId = cacheId;
+                ExtLstCacheId = cacheId;
             }
 
             ZipPackageRelationship rel = Part.GetRelationshipsByType(ExcelPackage.schemaRelationships + "/pivotCacheRecords").FirstOrDefault();
@@ -489,7 +490,7 @@ namespace OfficeOpenXml.Table.PivotTable
                 }
             }
 
-            CacheId = _wb.GetNewPivotCacheId();
+            CacheId = ExtLstCacheId = _wb.GetNewPivotCacheId();
 
             var c = CacheId;
             CacheDefinitionUri = GetNewUri(pck, "/xl/pivotCache/pivotCacheDefinition{0}.xml", ref c);
@@ -565,28 +566,50 @@ namespace OfficeOpenXml.Table.PivotTable
             SetXmlNodeString(_sourceAddressPath, address);
         }
         int _cacheId = int.MinValue;
+        /// <summary>
+        /// This is the cache id from the workbook 
+        /// </summary>
         internal int CacheId
         {
             get
             {
-                if (_cacheId < 0)
+                if(_cacheId<0)
                 {
-                    _cacheId = GetXmlNodeInt("d:extLst/d:ext/x14:pivotCacheDefinition/@pivotCacheId");
-                    if (_cacheId < 0)
-                    {
-                        _cacheId = _wb.GetPivotCacheId(CacheDefinitionUri);
-                        var node = GetOrCreateExtLstSubNode(ExtLstUris.PivotCacheDefinitionUri, "x14");
-                        node.InnerXml = $"<x14:pivotCacheDefinition pivotCacheId=\"{_cacheId}\"/>";
-                    }
+                    _cacheId = _wb.GetPivotCacheId(CacheDefinitionUri);
                 }
                 return _cacheId;
+            }
+            set
+            {
+                _cacheId = value;
+            }
+        }
+        int _extLstCacheId = int.MinValue;
+        /// <summary>
+        /// This a second cache id used for newer items like slicers. EPPlus will set this id to the same as the cache id by default.
+        /// </summary>
+        internal int ExtLstCacheId
+        {
+            get
+            {
+                if (_extLstCacheId < 0)
+                {
+                    _extLstCacheId = GetXmlNodeInt("d:extLst/d:ext/x14:pivotCacheDefinition/@pivotCacheId");
+                    if (_extLstCacheId < 0)
+                    {
+                        _extLstCacheId = CacheId;
+                        var node = GetOrCreateExtLstSubNode(ExtLstUris.PivotCacheDefinitionUri, "x14");
+                        node.InnerXml = $"<x14:pivotCacheDefinition pivotCacheId=\"{_extLstCacheId}\"/>";
+                    }
+                }
+                return _extLstCacheId;
             }
             set
             {
                 var node = GetOrCreateExtLstSubNode(ExtLstUris.PivotCacheDefinitionUri, "x14");
                 if(node.InnerXml=="")
                 {
-                    node.InnerXml = $"<x14:pivotCacheDefinition pivotCacheId=\"{_cacheId}\"/>";
+                    node.InnerXml = $"<x14:pivotCacheDefinition pivotCacheId=\"{_extLstCacheId}\"/>";
                 }
                 else
                 {

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -5274,5 +5274,44 @@ namespace EPPlusTest
                 Assert.AreEqual(1d, ws.Cells["A1"].Value);
             }
         }
+        [TestMethod]
+        public void s532()
+        {
+            var pivotTableWorksheetName = "Sheet3";
+            var NewSourceDataSheetName = "Sheet2";
+            var pivotTableName = "PivotTable1";
+            var exc = "";
+            var pivotTableCount = 0;
+            try
+            {
+
+                using (var package = OpenTemplatePackage("Pivot_Test_Orig.xlsx"))
+                {
+                    var pivotTableWorksheet = package.Workbook.Worksheets[pivotTableWorksheetName];
+
+                    ExcelWorksheet ws = package.Workbook.Worksheets[NewSourceDataSheetName];
+
+                    pivotTableCount = pivotTableWorksheet.PivotTables.Count;
+
+                    //var foundCache = package.Workbook.GetPivotCacheFromAddress(ws.Cells["M6:S16"].FullAddress, out PivotTableCacheInternal cache);
+
+                    pivotTableWorksheet.PivotTables[pivotTableName].CacheDefinition.SourceRange = ws.Cells["M6:S16"];
+
+                    SaveAndCleanup(package);
+                }
+            }
+            catch (Exception e)
+            {
+                exc = "Failed. " + e.ToString();
+            }
+
+            finally
+
+            {
+
+                System.GC.Collect();
+
+            }
+        }
     }
 }


### PR DESCRIPTION
Setting The Pivot table SourceRange to the same range as an existing Pivot Cache where the cache has an extLst cacheId causes the worbook to be corrupt.

Fixes issue #1089