### PR TITLE
#1092 - fixed filtering of member attributes in LoadFromCollection

### DIFF
--- a/src/EPPlus/LoadFunctions/LoadFromCollectionColumns.cs
+++ b/src/EPPlus/LoadFunctions/LoadFromCollectionColumns.cs
@@ -112,11 +112,13 @@ namespace OfficeOpenXml.LoadFunctions
             return copy;
         }
 
-        private bool ShouldIgnoreMember(MemberInfo member)
+        private bool ShouldIgnoreMember(MemberInfo member, bool isNested)
         {
             if (member == null) return true;
             if (member.HasPropertyOfType<EpplusIgnore>()) return true;
             if(_members.Count == 0) return false;
+            //ignore by member info only works for the first level (outer class)
+            if (isNested) return false;
             return !(_members.ContainsKey(member.DeclaringType) && _members[member.DeclaringType].Contains(member.Name));
         }
 
@@ -132,7 +134,7 @@ namespace OfficeOpenXml.LoadFunctions
                 {
                     var hPrefix = default(string);
                     var sortOrderList = CopyList(sortOrderListArg);
-                    if (ShouldIgnoreMember(member))
+                    if (ShouldIgnoreMember(member, isNestedClass))
                     {
                         continue;
                     }
@@ -255,7 +257,7 @@ namespace OfficeOpenXml.LoadFunctions
             {
                 var index = 0;
                 result.AddRange(members
-                    .Where(x => !x.HasPropertyOfType<EpplusIgnore>() && !ShouldIgnoreMember(x))
+                    .Where(x => !x.HasPropertyOfType<EpplusIgnore>() && !ShouldIgnoreMember(x, isNestedClass))
                     .Select(member => {
                         var h = default(string);
                         var mp = default(string);

--- a/src/EPPlusTest/LoadFunctions/LoadFromCollectionAttributesMemberFilterTests.cs
+++ b/src/EPPlusTest/LoadFunctions/LoadFromCollectionAttributesMemberFilterTests.cs
@@ -24,13 +24,16 @@ namespace EPPlusTest.LoadFunctions
                     new LfcaTestClass1{ Id = 3, Item = new LfcaTestClass2{ Id = 4, Name = "Test 1"}}
                 };
                 var t = typeof(LfcaTestClass1);
+                var t2 = typeof(LfcaTestClass2);
                 sheet.Cells["A1"].LoadFromCollection(items, c =>
                 {
                     c.PrintHeaders = true;
                     c.Members = new MemberInfo[]
                     {
                         t.GetProperty("Id"),
-                        t.GetProperty("Item")
+                        t.GetProperty("Item"),
+                        t2.GetProperty("Id"),
+                        t2.GetProperty("Name")
                     };
                 });
 

--- a/src/EPPlusTest/LoadFunctions/LoadFromCollectionAttributesMemberFilterTests.cs
+++ b/src/EPPlusTest/LoadFunctions/LoadFromCollectionAttributesMemberFilterTests.cs
@@ -31,9 +31,7 @@ namespace EPPlusTest.LoadFunctions
                     c.Members = new MemberInfo[]
                     {
                         t.GetProperty("Id"),
-                        t.GetProperty("Item"),
-                        t2.GetProperty("Id"),
-                        t2.GetProperty("Name")
+                        t.GetProperty("Item")
                     };
                 });
 
@@ -44,6 +42,37 @@ namespace EPPlusTest.LoadFunctions
                 Assert.AreEqual(2, sheet.Cells["B2"].Value);
                 Assert.AreEqual("Test 1", sheet.Cells["C2"].Value);
                 Assert.IsNull(sheet.Cells["D1"].Value);
+            }
+        }
+
+        [TestMethod]
+        public void ShouldFilterNestedPropertiesByMemberList2()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test");
+                var items = new List<LfcaTestClass1>
+                {
+                    new LfcaTestClass1{ Id = 1, Item2 = new LfcaTestClass3{ Id = 2, Name = "Test 1"}},
+                    new LfcaTestClass1{ Id = 3, Item2 = new LfcaTestClass3{ Id = 4, Name = "Test 1"}}
+                };
+                var t = typeof(LfcaTestClass1);
+                var t2 = typeof(LfcaTestClass2);
+                sheet.Cells["A1"].LoadFromCollection(items, c =>
+                {
+                    c.PrintHeaders = true;
+                    c.Members = new MemberInfo[]
+                    {
+                        t.GetProperty("Id"),
+                        t.GetProperty("Item2")
+                    };
+                });
+
+                Assert.AreEqual("Id", sheet.Cells["A1"].Value);
+                Assert.AreEqual("Class 3 Name", sheet.Cells["B1"].Value);
+                Assert.AreEqual(1, sheet.Cells["A2"].Value);
+                Assert.AreEqual("Test 1", sheet.Cells["B2"].Value);
+                Assert.IsNull(sheet.Cells["C1"].Value);
             }
         }
     }
@@ -59,11 +88,18 @@ namespace EPPlusTest.LoadFunctions
         public LfcaTestClass2 Item { get; set; }
 
         [EpplusNestedTableColumn(HeaderPrefix = "Class 3", Order = 3)]
-        public LfcaTestClass2 Item2 { get; set; }
+        public LfcaTestClass3 Item2 { get; set; }
     }
 
-    internal class  LfcaTestClass2
+    internal class LfcaTestClass2
     {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    internal class LfcaTestClass3
+    {
+        [EpplusIgnore]
         public int Id { get; set; }
         public string Name { get; set; }
     }

--- a/src/EPPlusTest/LoadFunctions/LoadFromCollectionTests.cs
+++ b/src/EPPlusTest/LoadFunctions/LoadFromCollectionTests.cs
@@ -257,6 +257,34 @@ namespace EPPlusTest.LoadFunctions
         }
 
         [TestMethod]
+        public void ShouldFilterMembers2()
+        {
+            var items = new List<Aclass>()
+            {
+                new Aclass(){ Id = "123", Name = "Item 1", Number = 3}
+            };
+            using (var pck = new ExcelPackage(new MemoryStream()))
+            {
+                var sheet = pck.Workbook.Worksheets.Add("sheet");
+                var t = typeof(Aclass);
+                sheet.Cells["C1"].LoadFromCollection(items, true, TableStyles.Dark1, LoadFromCollectionParams.DefaultBindingFlags,
+                    new MemberInfo[]
+                    {
+                        t.GetProperty("Id"),
+                        t.GetProperty("Name")
+                    });
+
+                Assert.AreEqual(1, sheet.Dimension._toCol - sheet.Dimension._fromCol);
+                Assert.AreEqual("Id", sheet.Cells["C1"].Value);
+                Assert.AreEqual("Name", sheet.Cells["D1"].Value);
+                Assert.IsNull(sheet.Cells["E1"].Value);
+                Assert.AreEqual("123", sheet.Cells["C2"].Value);
+                Assert.AreEqual("Item 1", sheet.Cells["D2"].Value);
+                Assert.IsNull(sheet.Cells["E2"].Value);
+            }
+        }
+
+        [TestMethod]
         public void ShouldFilterOneMember()
         {
             var items = new List<BaseClass>()


### PR DESCRIPTION
See #1092.

This fix contains a small behaviour change:

Previously when using the ExcelNestedTableColumn attribute on a property of a complex class all members of the nested class was included. Now only attributes specified in the members list (LoadFromCollection argument) will be included for the 1st level. For nested (complex) classes on properties configuration from attributes will be used.

