### PR TITLE
Bug/i1102

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Substitute.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Substitute.cs
@@ -34,7 +34,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
             {
                 if (arg.ValueIsExcelError)
                 {
-                    throw new ExcelErrorValueException(arg.ValueAsExcelErrorValue);
+                    return new CompileResult(arg.ValueAsExcelErrorValue, DataType.ExcelError);
                 }
             }
 

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Substitute.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Substitute.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
+using OfficeOpenXml.FormulaParsing.Exceptions;
 using OfficeOpenXml.FormulaParsing.ExpressionGraph;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
@@ -28,6 +29,15 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
         public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
         {
             ValidateArguments(arguments, 3);
+          
+            foreach (var arg in arguments)
+            {
+                if (arg.ValueIsExcelError)
+                {
+                    throw new ExcelErrorValueException(arg.ValueAsExcelErrorValue);
+                }
+            }
+
             var text = ArgToString(arguments, 0);
             var find = ArgToString(arguments, 1);
             var replaceWith = ArgToString(arguments, 2);

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -5274,5 +5274,26 @@ namespace EPPlusTest
                 Assert.AreEqual(1d, ws.Cells["A1"].Value);
             }
         }
+
+        [TestMethod]
+        public void i1102()
+        {
+            using (var excel = new ExcelPackage())
+            {
+                var worksheet = excel.Workbook.Worksheets.Add("Test Worksheet");
+                var targetCell = worksheet.Cells[1, 1];
+                var validationCell = worksheet.Cells[1, 2];
+
+                validationCell.Formula = "IFERROR(SUBSTITUTE(RIGHT(A1,LEN(A1)-FIND(\"-\",A1)),\"-\",\"|\"),\"0\")";
+
+                targetCell.Value = "invalid";
+
+                validationCell.Calculate();
+
+                var result = validationCell.GetValue<string>();
+
+                Assert.AreEqual("0", result);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -5274,27 +5274,6 @@ namespace EPPlusTest
                 Assert.AreEqual(1d, ws.Cells["A1"].Value);
             }
         }
-
-        [TestMethod]
-        public void i1102()
-        {
-            using (var excel = new ExcelPackage())
-            {
-                var worksheet = excel.Workbook.Worksheets.Add("Test Worksheet");
-                var targetCell = worksheet.Cells[1, 1];
-                var validationCell = worksheet.Cells[1, 2];
-
-                validationCell.Formula = "IFERROR(SUBSTITUTE(RIGHT(A1,LEN(A1)-FIND(\"-\",A1)),\"-\",\"|\"),\"0\")";
-
-                targetCell.Value = "invalid";
-
-                validationCell.Calculate();
-
-                var result = validationCell.GetValue<string>();
-
-                Assert.AreEqual("0", result);
-            }
-        }
         [TestMethod]
         public void s532()
         {
@@ -5417,6 +5396,26 @@ namespace EPPlusTest
                 Debug.WriteLine("after:");
                 DebugGetFontInfo();
                 SaveAndCleanup(package);
+            }
+        }
+        [TestMethod]
+        public void i1102()
+        {
+            using (var excel = new ExcelPackage())
+            {
+                var worksheet = excel.Workbook.Worksheets.Add("Test Worksheet");
+                var targetCell = worksheet.Cells[1, 1];
+                var validationCell = worksheet.Cells[1, 2];
+
+                validationCell.Formula = "IFERROR(SUBSTITUTE(RIGHT(A1,LEN(A1)-FIND(\"-\",A1)),\"-\",\"|\"),\"0\")";
+
+                targetCell.Value = "invalid";
+
+                validationCell.Calculate();
+
+                var result = validationCell.GetValue<string>();
+
+                Assert.AreEqual("0", result);
             }
         }
     }


### PR DESCRIPTION
Substitute did not return results with IsExcelError if one or more of the input parameters were for example a #VALUE! error. It now iterates each input parameter and throws if it finds an error like other CompileResults. That error is then caught and handled appropriately.
Fixes #1102 