### PR TITLE
Resolved table names with " character crashing

### DIFF
--- a/src/EPPlus/LoadFunctions/LoadFromDataTable.cs
+++ b/src/EPPlus/LoadFunctions/LoadFromDataTable.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   07/16/2020         EPPlus Software AB       EPPlus 5.2.1
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.ExcelUtilities;
 using OfficeOpenXml.LoadFunctions.Params;
 using OfficeOpenXml.Table;
 using System;
@@ -17,6 +18,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Text;
+using System.Xml.Linq;
 
 namespace OfficeOpenXml.LoadFunctions
 {
@@ -66,7 +68,13 @@ namespace OfficeOpenXml.LoadFunctions
             int rows = (_dataTable.Rows.Count == 0 ? 1 : _dataTable.Rows.Count) + (_printHeaders ? 1 : 0);
             if (rows >= 0 && _dataTable.Columns.Count > 0 && _tableStyle.HasValue)
             {
-                var tbl = _worksheet.Tables.Add(new ExcelAddressBase(_range._fromRow, _range._fromCol, _range._fromRow + rows - 1, _range._fromCol + _dataTable.Columns.Count - 1), _dataTable.TableName);
+                string name = _dataTable.TableName;
+                if (!ExcelAddressUtil.IsValidName(name))
+                {
+                    name = _worksheet.Tables.GetNewTableName();
+                }
+
+                var tbl = _worksheet.Tables.Add(new ExcelAddressBase(_range._fromRow, _range._fromCol, _range._fromRow + rows - 1, _range._fromCol + _dataTable.Columns.Count - 1), name);
                 tbl.ShowHeader = _printHeaders;
                 tbl.TableStyle = _tableStyle.Value;
             }

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -5418,5 +5418,33 @@ namespace EPPlusTest
                 Assert.AreEqual("0", result);
             }
         }
+        [TestMethod]
+        public void i1110()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("NewSheet");
+
+                var table = new DataTable("A Table \"named\"");
+
+                DataColumn column = new DataColumn();
+                column.DataType = System.Type.GetType("System.Int32");
+                column.ColumnName = "rowNr";
+                column.ReadOnly = true;
+                column.Unique = true;
+
+                table.Columns.Add(column);
+
+                DataRow row;
+                for (int i = 0; i <= 2; i++)
+                {
+                    row = table.NewRow();
+                    row["rowNr"] = i;
+                    table.Rows.Add(row);
+                }
+
+                var tbl = sheet.Cells["A1:B10"].LoadFromDataTable(table, false, OfficeOpenXml.Table.TableStyles.Dark1);
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves #1110 

Potential Improvement Note: ExcelAddressUtil.SheetNameInvalidChars may need to have `[]` added and ExcelAddressUtil.NameInvalidChars might need to have `"` added to it.
Uncertain if there's some reason we haven't already.