### PR TITLE
Changed cast type to long to cover large numbers accurately

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/Math/Rounddown.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Math/Rounddown.cs
@@ -42,7 +42,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Math
             }
             else
             {
-                result = (int)System.Math.Floor(number);
+                result = (long)System.Math.Floor(number);
                 result = result - (result % System.Math.Pow(10, (nDecimals*-1)));
             }
             return CreateResult(result * nFactor, DataType.Decimal);
@@ -50,7 +50,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Math
 
         private static double RoundDownDecimalNumber(double number, int nDecimals)
         {
-            int integerRepresentation = (int)System.Math.Floor(number * System.Math.Pow(10d, nDecimals));
+            long integerRepresentation = (long)System.Math.Floor(number * System.Math.Pow(10d, nDecimals));
             var result = integerRepresentation / System.Math.Pow(10d, nDecimals);
             return result;
         }

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -39,6 +39,7 @@ using OfficeOpenXml.Drawing.Slicer;
 using OfficeOpenXml.Drawing.Style.Coloring;
 using OfficeOpenXml.Export.HtmlExport.Interfaces;
 using OfficeOpenXml.Filter;
+using OfficeOpenXml.FormulaParsing;
 using OfficeOpenXml.Sparkline;
 using OfficeOpenXml.Style;
 using OfficeOpenXml.Table;
@@ -5444,6 +5445,20 @@ namespace EPPlusTest
                 }
 
                 var tbl = sheet.Cells["A1:B10"].LoadFromDataTable(table, false, OfficeOpenXml.Table.TableStyles.Dark1);
+            }
+        }
+
+        [TestMethod]
+        public void i1087LongNumber()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test");
+                sheet.Cells["A1"].Value = 2347440000d;
+                sheet.Cells["A2"].Formula = "ROUNDDOWN(A1,-5)";
+                sheet.Calculate(opt => opt.PrecisionAndRoundingStrategy = PrecisionAndRoundingStrategy.Excel);
+
+                Assert.AreEqual(2347400000d, sheet.Cells["A2"].Value);
             }
         }
     }


### PR DESCRIPTION
fix for second issue of #1087 where high numbers with a negative number of decimals resulted in unintended behaviour.