### PR TITLE
Resolved dxfStyle missmatch and read-in of stopIfTrue

### DIFF
--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingRule.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingRule.cs
@@ -211,7 +211,13 @@ namespace OfficeOpenXml.ConditionalFormatting
 
             Type = type;
 
-            if(!string.IsNullOrEmpty(xr.GetAttribute("id")))
+            if (!string.IsNullOrEmpty(xr.GetAttribute("stopIfTrue")))
+            {
+                StopIfTrue = int.Parse(xr.GetAttribute("stopIfTrue")) == 1;
+            }
+                
+
+            if (!string.IsNullOrEmpty(xr.GetAttribute("id")))
             {
                 Uid = xr.GetAttribute("id");
             }
@@ -528,6 +534,7 @@ namespace OfficeOpenXml.ConditionalFormatting
             Type = original.Type;
             PivotTable = original.PivotTable;
             _text = original._text;
+            StopIfTrue = original.StopIfTrue;
 
             if(original._stdDev != 0)
             {

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -1054,6 +1054,7 @@ namespace EPPlusTest
             using (var p1 = OpenTemplatePackage("Sample_Cond_Format.xlsx"))
             {
                 var ws = p1.Workbook.Worksheets[0];
+
                 using (var p2 = new ExcelPackage())
                 {
                     var ws2 = p2.Workbook.Worksheets.Add("Test", ws);


### PR DESCRIPTION
The DXFIds when copying a single worksheet page from one package to another were missmatched due to faulty 
copying in CopyDxfStylesConditionalFormatting.

Also fixed reading in StopIfTrue flag from file.