### PR TITLE
Fix/cf internal and valid address check

### DIFF
--- a/docs/articles/breakingchanges.md
+++ b/docs/articles/breakingchanges.md
@@ -111,5 +111,6 @@ Misspelled property `ExcelIgnoreError.CalculatedColumm` has been renamed `Calcul
 * Updating ConditionalFormatting via the XML DOM will not work as read and write is performed on load/save.
 * The base class `ConditionalFormattingRule` and all derived classes no longer contain the Node property.
 * Misspelled enum member `eTrendLine.MovingAvgerage` has been removed and replaced with `eTrendLine.MovingAverage`
+* ConditionalFormatting classes are now Internal. Interfaces for each class exist and have all relevant properties instead.
 #### ExcelHyperlink
 * Renamed misspelled properties `ColSpann` and `RowSpann` to `ColSpan` and `RowSpan` on the `ExcelHyperLink` class.

--- a/docs/articles/fixedissues.md
+++ b/docs/articles/fixedissues.md
@@ -13,8 +13,9 @@
 * Breaking changes: Updated calculation engine, See [Breaking Changes in EPPlus 7](https://github.com/EPPlusSoftware/EPPlus/wiki/Breaking-Changes-in-EPPlus-7) for more information
 * Conditional Formatting improvements
 	* Improved performance, xml is now read and written on load and save.
-	* Cross worksheet support formula support.
+	* Cross worksheet formula support.
 	* Extended styling options for color scales, data bars and icon sets.
+	* Added String constructor that creates an ExcelAddress internally.
 
 ## Version 6.2.4
 ### Minor Features

--- a/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
+++ b/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
@@ -668,9 +668,16 @@ namespace OfficeOpenXml.ConditionalFormatting
           eExcelConditionalFormattingRuleType type,
           ExcelAddress address, bool allowNullAddress = false)
         {
-            if(!allowNullAddress)
+            if (!allowNullAddress)
             {
                 Require.Argument(address).IsNotNull("address");
+
+                if (!ExcelCellBase.IsValidAddress(address.Address))
+                {
+                    throw new ArgumentException(
+                        $"Address: \"{address.Address}\" for Conditional Formatting rule of type {type} " +
+                        $"is not a valid address");
+                }
             }
 
             // Create the Rule according to the correct type, address and priority

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingContainsText.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingContainsText.cs
@@ -20,7 +20,7 @@ namespace OfficeOpenXml.ConditionalFormatting
     internal class ExcelConditionalFormattingContainsText : ExcelConditionalFormattingRule,
     IExcelConditionalFormattingContainsText
     {
-        public ExcelConditionalFormattingContainsText(
+        internal ExcelConditionalFormattingContainsText(
           ExcelAddress address,
           int priority,
           ExcelWorksheet worksheet)
@@ -30,7 +30,7 @@ namespace OfficeOpenXml.ConditionalFormatting
             Text = string.Empty;
         }
 
-        public ExcelConditionalFormattingContainsText(
+        internal ExcelConditionalFormattingContainsText(
           ExcelAddress address, ExcelWorksheet ws, XmlReader xr)
           : base(eExcelConditionalFormattingRuleType.ContainsText, address, ws, xr)
         {

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingLast7Days.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingLast7Days.cs
@@ -18,7 +18,7 @@ namespace OfficeOpenXml.ConditionalFormatting
     /// <summary>
     /// ExcelConditionalFormattingLast7Days
     /// </summary>
-    public class ExcelConditionalFormattingLast7Days: ExcelConditionalFormattingTimePeriodGroup
+    internal class ExcelConditionalFormattingLast7Days: ExcelConditionalFormattingTimePeriodGroup
     {
         #region Constructors
         /// <summary>
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.ConditionalFormatting
         /// <param name="address"></param>
         /// <param name="ws"></param>
         /// <param name="xr"></param>
-        public ExcelConditionalFormattingLast7Days(
+        internal ExcelConditionalFormattingLast7Days(
             ExcelAddress address, ExcelWorksheet ws, XmlReader xr)
             : base(eExcelConditionalFormattingRuleType.Last7Days, address, ws, xr)
         {

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingLastMonth.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingLastMonth.cs
@@ -18,7 +18,7 @@ namespace OfficeOpenXml.ConditionalFormatting
     /// <summary>
     /// ExcelConditionalFormattingLast7Days
     /// </summary>
-    public class ExcelConditionalFormattingLastMonth: ExcelConditionalFormattingTimePeriodGroup
+    internal class ExcelConditionalFormattingLastMonth: ExcelConditionalFormattingTimePeriodGroup
     {
         #region Constructors
         /// <summary>
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.ConditionalFormatting
         /// <param name="address"></param>
         /// <param name="ws"></param>
         /// <param name="xr"></param>
-        public ExcelConditionalFormattingLastMonth(
+        internal ExcelConditionalFormattingLastMonth(
             ExcelAddress address, ExcelWorksheet ws, XmlReader xr)
             : base(eExcelConditionalFormattingRuleType.LastMonth, address, ws, xr)
         {

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingLastWeek.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingLastWeek.cs
@@ -18,7 +18,7 @@ namespace OfficeOpenXml.ConditionalFormatting
     /// <summary>
     /// ExcelConditionalFormattingLast7Days
     /// </summary>
-    public class ExcelConditionalFormattingLastWeek: ExcelConditionalFormattingTimePeriodGroup
+    internal class ExcelConditionalFormattingLastWeek: ExcelConditionalFormattingTimePeriodGroup
     {
         #region Constructors
         /// <summary>
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.ConditionalFormatting
         /// <param name="address"></param>
         /// <param name="ws"></param>
         /// <param name="xr"></param>
-        public ExcelConditionalFormattingLastWeek(
+        internal ExcelConditionalFormattingLastWeek(
             ExcelAddress address, ExcelWorksheet ws, XmlReader xr)
             : base(eExcelConditionalFormattingRuleType.LastWeek, address, ws, xr)
         {

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingLessThan.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingLessThan.cs
@@ -18,7 +18,7 @@ namespace OfficeOpenXml.ConditionalFormatting
 {
     internal class ExcelConditionalFormattingLessThan : ExcelConditionalFormattingRule, IExcelConditionalFormattingLessThan
     {
-        public ExcelConditionalFormattingLessThan(
+        internal ExcelConditionalFormattingLessThan(
           ExcelAddress address,
           int priority,
           ExcelWorksheet worksheet)
@@ -27,7 +27,7 @@ namespace OfficeOpenXml.ConditionalFormatting
             Operator = eExcelConditionalFormattingOperatorType.LessThan;
         }
 
-        public ExcelConditionalFormattingLessThan(
+        internal ExcelConditionalFormattingLessThan(
           ExcelAddress address, ExcelWorksheet ws, XmlReader xr)
           : base(eExcelConditionalFormattingRuleType.LessThan, address, ws, xr)
         {

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingNextMonth.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingNextMonth.cs
@@ -18,7 +18,7 @@ namespace OfficeOpenXml.ConditionalFormatting
     /// <summary>
     /// ExcelConditionalFormattingLast7Days
     /// </summary>
-    public class ExcelConditionalFormattingNextMonth: ExcelConditionalFormattingTimePeriodGroup
+    internal class ExcelConditionalFormattingNextMonth: ExcelConditionalFormattingTimePeriodGroup
     {
         #region Constructors
         /// <summary>
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.ConditionalFormatting
         /// <param name="address"></param>
         /// <param name="ws"></param>
         /// <param name="xr"></param>
-        public ExcelConditionalFormattingNextMonth(
+        internal ExcelConditionalFormattingNextMonth(
             ExcelAddress address, ExcelWorksheet ws, XmlReader xr)
         : base(eExcelConditionalFormattingRuleType.NextMonth, address, ws, xr)
         {

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingNextWeek.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingNextWeek.cs
@@ -18,7 +18,7 @@ namespace OfficeOpenXml.ConditionalFormatting
     /// <summary>
     /// ExcelConditionalFormattingLast7Days
     /// </summary>
-    public class ExcelConditionalFormattingNextWeek: ExcelConditionalFormattingTimePeriodGroup
+    internal class ExcelConditionalFormattingNextWeek: ExcelConditionalFormattingTimePeriodGroup
     {
         #region Constructors
         /// <summary>
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.ConditionalFormatting
         /// <param name="address"></param>
         /// <param name="ws"></param>
         /// <param name="xr"></param>
-        public ExcelConditionalFormattingNextWeek(
+        internal ExcelConditionalFormattingNextWeek(
             ExcelAddress address, ExcelWorksheet ws, XmlReader xr)
             : base(eExcelConditionalFormattingRuleType.NextWeek, address, ws, xr)
         {

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingNotContainsText.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingNotContainsText.cs
@@ -19,7 +19,7 @@ namespace OfficeOpenXml.ConditionalFormatting
     internal class ExcelConditionalFormattingNotContainsText : ExcelConditionalFormattingRule,
     IExcelConditionalFormattingNotContainsText
     {
-        public ExcelConditionalFormattingNotContainsText(
+        internal ExcelConditionalFormattingNotContainsText(
           ExcelAddress address,
           int priority,
           ExcelWorksheet worksheet)
@@ -29,7 +29,7 @@ namespace OfficeOpenXml.ConditionalFormatting
             Text = string.Empty;
         }
 
-        public ExcelConditionalFormattingNotContainsText(
+        internal ExcelConditionalFormattingNotContainsText(
           ExcelAddress address, ExcelWorksheet ws, XmlReader xr)
           : base(eExcelConditionalFormattingRuleType.ContainsText, address, ws, xr)
         {

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingThisMonth.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingThisMonth.cs
@@ -18,7 +18,7 @@ namespace OfficeOpenXml.ConditionalFormatting
     /// <summary>
     /// ExcelConditionalFormattingLast7Days
     /// </summary>
-    public class ExcelConditionalFormattingThisMonth: ExcelConditionalFormattingTimePeriodGroup
+    internal class ExcelConditionalFormattingThisMonth: ExcelConditionalFormattingTimePeriodGroup
     {
         #region Constructors
         /// <summary>
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.ConditionalFormatting
         /// <param name="address"></param>
         /// <param name="ws"></param>
         /// <param name="xr"></param>
-        public ExcelConditionalFormattingThisMonth(
+        internal ExcelConditionalFormattingThisMonth(
             ExcelAddress address, ExcelWorksheet ws, XmlReader xr)
             : base(eExcelConditionalFormattingRuleType.ThisMonth, address, ws, xr)
         {

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingThisWeek.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingThisWeek.cs
@@ -18,7 +18,7 @@ namespace OfficeOpenXml.ConditionalFormatting
     /// <summary>
     /// ExcelConditionalFormattingLast7Days
     /// </summary>
-    public class ExcelConditionalFormattingThisWeek: ExcelConditionalFormattingTimePeriodGroup
+    internal class ExcelConditionalFormattingThisWeek: ExcelConditionalFormattingTimePeriodGroup
     {
         #region Constructors
         /// <summary>
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.ConditionalFormatting
         /// <param name="address"></param>
         /// <param name="ws"></param>
         /// <param name="xr"></param>
-        public ExcelConditionalFormattingThisWeek(
+        internal ExcelConditionalFormattingThisWeek(
             ExcelAddress address, ExcelWorksheet ws, XmlReader xr)
             : base(eExcelConditionalFormattingRuleType.ThisWeek, address, ws, xr)
         {

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingThreeColorScale.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingThreeColorScale.cs
@@ -18,7 +18,7 @@ using OfficeOpenXml.ConditionalFormatting.Contracts;
 
 namespace OfficeOpenXml.ConditionalFormatting
 {
-    public class ExcelConditionalFormattingThreeColorScale : ExcelConditionalFormattingTwoColorScale,
+    internal class ExcelConditionalFormattingThreeColorScale : ExcelConditionalFormattingTwoColorScale,
     IExcelConditionalFormattingThreeColorScale
     {
         internal ExcelConditionalFormattingThreeColorScale(ExcelAddress address, int priority, ExcelWorksheet ws)

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingTimePeriodGroup.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingTimePeriodGroup.cs
@@ -18,7 +18,7 @@ namespace OfficeOpenXml.ConditionalFormatting
   /// <summary>
   /// ExcelConditionalFormattingTimePeriodGroup
   /// </summary>
-  public class ExcelConditionalFormattingTimePeriodGroup: ExcelConditionalFormattingRule,
+  internal class ExcelConditionalFormattingTimePeriodGroup: ExcelConditionalFormattingRule,
     IExcelConditionalFormattingTimePeriodGroup
   {
     /****************************************************************************************/

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingToday.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingToday.cs
@@ -18,7 +18,7 @@ namespace OfficeOpenXml.ConditionalFormatting
     /// <summary>
     /// ExcelConditionalFormattingLast7Days
     /// </summary>
-    public class ExcelConditionalFormattingToday: ExcelConditionalFormattingTimePeriodGroup
+    internal class ExcelConditionalFormattingToday: ExcelConditionalFormattingTimePeriodGroup
     {
         #region Constructors
         /// <summary>
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.ConditionalFormatting
         /// <param name="address"></param>
         /// <param name="ws"></param>
         /// <param name="xr"></param>
-        public ExcelConditionalFormattingToday(
+        internal ExcelConditionalFormattingToday(
             ExcelAddress address, ExcelWorksheet ws, XmlReader xr)
             : base(eExcelConditionalFormattingRuleType.Today, address, ws, xr)
         {

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingTomorrow.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingTomorrow.cs
@@ -18,7 +18,7 @@ namespace OfficeOpenXml.ConditionalFormatting
     /// <summary>
     /// ExcelConditionalFormattingLast7Days
     /// </summary>
-    public class ExcelConditionalFormattingTomorrow: ExcelConditionalFormattingTimePeriodGroup
+    internal class ExcelConditionalFormattingTomorrow: ExcelConditionalFormattingTimePeriodGroup
     {
         #region Constructors
         /// <summary>
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.ConditionalFormatting
         /// <param name="address"></param>
         /// <param name="ws"></param>
         /// <param name="xr"></param>
-        public ExcelConditionalFormattingTomorrow(
+        internal ExcelConditionalFormattingTomorrow(
             ExcelAddress address, ExcelWorksheet ws, XmlReader xr)
             : base(eExcelConditionalFormattingRuleType.Tomorrow, address, ws, xr)
         {

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingTwoColorScale.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingTwoColorScale.cs
@@ -22,7 +22,7 @@ namespace OfficeOpenXml.ConditionalFormatting
     /// <summary>
     /// Two Colour Scale class
     /// </summary>
-    public class ExcelConditionalFormattingTwoColorScale : ExcelConditionalFormattingRule,
+    internal class ExcelConditionalFormattingTwoColorScale : ExcelConditionalFormattingRule,
     IExcelConditionalFormattingTwoColorScale
     {
         internal ExcelConditionalFormattingTwoColorScale(

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingYesterday.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingYesterday.cs
@@ -18,7 +18,7 @@ namespace OfficeOpenXml.ConditionalFormatting
     /// <summary>
     /// ExcelConditionalFormattingLast7Days
     /// </summary>
-    public class ExcelConditionalFormattingYesterday: ExcelConditionalFormattingTimePeriodGroup
+    internal class ExcelConditionalFormattingYesterday: ExcelConditionalFormattingTimePeriodGroup
     {
         #region Constructors
         /// <summary>
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.ConditionalFormatting
         /// <param name="address"></param>
         /// <param name="ws"></param>
         /// <param name="xr"></param>
-        public ExcelConditionalFormattingYesterday(
+        internal ExcelConditionalFormattingYesterday(
             ExcelAddress address, ExcelWorksheet ws, XmlReader xr)
             : base(eExcelConditionalFormattingRuleType.Yesterday, address, ws, xr)
         {

--- a/src/EPPlusTest/ConditionalFormatting/ConditionalFormattingTests.cs
+++ b/src/EPPlusTest/ConditionalFormatting/ConditionalFormattingTests.cs
@@ -1875,7 +1875,7 @@ namespace EPPlusTest.ConditionalFormatting
             {
                 var sheet = pck.Workbook.Worksheets.Add("performanceTest");
 
-                for (int i = 0; i < 210000; i++)
+                for (int i = 1; i < 16384; i++)
                 {
                     sheet.ConditionalFormatting.AddAboveAverage(new ExcelAddress(1, 1, i, 3));
                     sheet.ConditionalFormatting.AddBelowAverage(new ExcelAddress(1, 2, i, 3));
@@ -1986,6 +1986,18 @@ namespace EPPlusTest.ConditionalFormatting
                 var sheet = pck.Workbook.Worksheets.Add("NewWorksheet");
 
                 sheet.ConditionalFormatting.AddAboveAverage("InvalidAddressAttempt");
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void InvalidAddressShouldThrowOnNumbers()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet = pck.Workbook.Worksheets.Add("NewWorksheet");
+
+                sheet.ConditionalFormatting.AddDatabar("1234", Color.Gold);
             }
         }
 


### PR DESCRIPTION
Made CF classes internal as all relevant properties are now accessible via interface.
Ensured string-creation of conditionalFormatting Addresses are valid.
