### PR TITLE
Ensured item cache is updated when sourcerange changed

### DIFF
--- a/src/EPPlus/Drawing/ExcelDrawings.cs
+++ b/src/EPPlus/Drawing/ExcelDrawings.cs
@@ -1215,9 +1215,9 @@ namespace OfficeOpenXml.Drawing
             {
                 throw new InvalidOperationException("Can't add a slicer to a calculated field");
             }
-            if (Field._pivotTable.CacheId == 0)
+            if (Field.PivotTable.CacheId == 0)
             {
-                Field._pivotTable.ChangeCacheId(0); //Slicers can for some reason not have a cache id of 0.
+                Field.PivotTable.ChangeCacheId(0); //Slicers can for some reason not have a cache id of 0.
             }
             XmlElement drawNode = CreateDrawingXml();
             var slicer = new ExcelPivotTableSlicer(this, drawNode, Field)

--- a/src/EPPlus/Drawing/Slicer/ExcelPivotTableSlicerCache.cs
+++ b/src/EPPlus/Drawing/Slicer/ExcelPivotTableSlicerCache.cs
@@ -46,7 +46,7 @@ namespace OfficeOpenXml.Drawing.Slicer
             _field = field;
             SourceName = _field.Cache.Name;
             wb.Names.AddFormula(Name, "#N/A");
-            PivotTables.Add(_field._pivotTable);           
+            PivotTables.Add(_field.PivotTable);           
             CreateWorkbookReference(wb, ExtLstUris.WorkbookSlicerPivotTableUri);
             SlicerCacheXml.Save(Part.GetStream());
             Data.Items.Refresh();

--- a/src/EPPlus/Drawing/Slicer/ExcelPivotTableSlicerCacheTabularData.cs
+++ b/src/EPPlus/Drawing/Slicer/ExcelPivotTableSlicerCacheTabularData.cs
@@ -144,7 +144,7 @@ namespace OfficeOpenXml.Drawing.Slicer
 
             if (PivotCacheId < 0)
             {
-                PivotCacheId = _cache._field._pivotTable.CacheId;
+                PivotCacheId = _cache._field.PivotTable.CacheId;
             }
             var dataNode = (XmlElement)CreateNode(_topPath+"/x14:items");
             dataNode.SetAttribute("count", x.ToString());

--- a/src/EPPlus/ExcelWorkbook.cs
+++ b/src/EPPlus/ExcelWorkbook.cs
@@ -1596,15 +1596,14 @@ namespace OfficeOpenXml
 		{
 			if (createWorkbookElement)
 			{
-				CreateNode("d:pivotCaches");
+				var pivotCachesNode = CreateNode("d:pivotCaches");
 
 				XmlElement item = WorkbookXml.CreateElement("pivotCache", ExcelPackage.schemaMain);
 				item.SetAttribute("cacheId", cacheReference.CacheId.ToString());
 				var rel = Part.CreateRelationship(UriHelper.ResolvePartUri(WorkbookUri, cacheReference.CacheDefinitionUri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/pivotCacheDefinition");
 				item.SetAttribute("id", ExcelPackage.schemaRelationships, rel.Id);
 
-				var pivotCaches = WorkbookXml.SelectSingleNode("//d:pivotCaches", NameSpaceManager);
-				pivotCaches.AppendChild(item);
+                pivotCachesNode.AppendChild(item);
 			}
 
 			if (cacheReference.CacheSource == eSourceType.Worksheet && cacheReference.SourceRange!=null)

--- a/src/EPPlus/Table/PivotTable/ExcelPivotCacheDefinition.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotCacheDefinition.cs
@@ -17,6 +17,7 @@ using OfficeOpenXml.Utils;
 using System.Security;
 using System.Linq;
 using OfficeOpenXml.Packaging;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Finance;
 
 namespace OfficeOpenXml.Table.PivotTable
 {
@@ -186,9 +187,27 @@ namespace OfficeOpenXml.Table.PivotTable
                     PivotTable.CacheId = _cacheReference.CacheId;
                     _wb.AddPivotTableCache(_cacheReference);
                     Relationship.TargetUri = _cacheReference.CacheDefinitionUri;
+                    UpdateCacheInFields();
                 }
             }
         }
+
+        private void UpdateCacheInFields()
+        {
+            foreach (var field in PivotTable.Fields)
+            {
+                var cf = _cacheReference.Fields.Where(x => x.Name == field.Name).FirstOrDefault();
+                if (cf != null)
+                {
+                    field.CacheField = cf;
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Pivot Table source change: Destination range headers does not match source range headers. Field Name {field.Name} is missing.");
+                }
+            }
+        }
+
         /// <summary>
         /// If Excel will save the source data with the pivot table.
         /// </summary>

--- a/src/EPPlus/Table/PivotTable/ExcelPivotTable.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotTable.cs
@@ -202,7 +202,7 @@ namespace OfficeOpenXml.Table.PivotTable
             foreach (XmlElement fieldElem in pivotFieldNode.SelectNodes("d:pivotField", NameSpaceManager))
             {
                 var fld = new ExcelPivotTableField(NameSpaceManager, fieldElem, this, index, index);
-                fld._cacheField = CacheDefinition._cacheReference.Fields[index++];
+                fld.CacheField = CacheDefinition._cacheReference.Fields[index++];
                 fld.LoadItems();
                 Fields.AddInternal(fld);
             }

--- a/src/EPPlus/Table/PivotTable/ExcelPivotTableDataField.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotTableDataField.cs
@@ -70,7 +70,7 @@ namespace OfficeOpenXml.Table.PivotTable
             }
             set
             {
-                if (Field._pivotTable.DataFields.ExistsDfName(value, this))
+                if (Field.PivotTable.DataFields.ExistsDfName(value, this))
                 {
                     throw (new InvalidOperationException("Duplicate datafield name"));
                 }
@@ -126,18 +126,18 @@ namespace OfficeOpenXml.Table.PivotTable
         {
             get
             {
-                foreach (var nf in Field._pivotTable.WorkSheet.Workbook.Styles.NumberFormats)
+                foreach (var nf in Field.PivotTable.WorkSheet.Workbook.Styles.NumberFormats)
                 {
                     if (nf.NumFmtId == NumFmtId)
                     {
                         return nf.Format;
                     }
                 }
-                return Field._pivotTable.WorkSheet.Workbook.Styles.NumberFormats[0].Format;
+                return Field.PivotTable.WorkSheet.Workbook.Styles.NumberFormats[0].Format;
             }
             set
             {
-                var styles = Field._pivotTable.WorkSheet.Workbook.Styles;
+                var styles = Field.PivotTable.WorkSheet.Workbook.Styles;
 
                 ExcelNumberFormatXml nf = null;
                 if (!styles.NumberFormats.FindById(value, ref nf))

--- a/src/EPPlus/Table/PivotTable/ExcelPivotTableDataFieldShowDataAs.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotTableDataFieldShowDataAs.cs
@@ -245,7 +245,7 @@ namespace OfficeOpenXml.Table.PivotTable
         }
         private void Validate(ExcelPivotTableField baseField, int? baseItem = null)
         {
-            if (baseField._pivotTable != _dataField.Field._pivotTable)
+            if (baseField.PivotTable != _dataField.Field.PivotTable)
             {
                 throw new ArgumentException("The base field must be from the same pivot table as the data field", nameof(baseField));
             }

--- a/src/EPPlus/Table/PivotTable/ExcelPivotTableField.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotTableField.cs
@@ -32,16 +32,14 @@ namespace OfficeOpenXml.Table.PivotTable
     /// A pivot table field.
     /// </summary>
     public class ExcelPivotTableField : XmlHelper
-    {
-        internal ExcelPivotTable _pivotTable;
-        internal ExcelPivotTableCacheField _cacheField = null;        
+    {     
         internal ExcelPivotTableField(XmlNamespaceManager ns, XmlNode topNode, ExcelPivotTable table, int index, int baseIndex) :
             base(ns, topNode)
         {
             SchemaNodeOrder = new string[] { "items","autoSortScope" };
             Index = index;
             BaseIndex = baseIndex;
-            _pivotTable = table;
+            PivotTable = table;
             if(NumFmtId.HasValue)
             {
                 var styles = table.WorkSheet.Workbook.Styles;
@@ -52,6 +50,10 @@ namespace OfficeOpenXml.Table.PivotTable
                 }
             }
         }
+
+        internal ExcelPivotTable PivotTable { get; set; }
+        internal ExcelPivotTableCacheField CacheField { get; set; } = null;
+
         /// <summary>
         /// The index of the pivot table field
         /// </summary>
@@ -78,7 +80,7 @@ namespace OfficeOpenXml.Table.PivotTable
                 string v = GetXmlNodeString("@name");
                 if (v == "")
                 {
-                    return _cacheField?.Name;
+                    return CacheField?.Name;
                 }
                 else
                 {
@@ -266,7 +268,7 @@ namespace OfficeOpenXml.Table.PivotTable
         /// <param name="sortType">Sort ascending or descending</param>
         public void SetAutoSort(ExcelPivotTableDataField dataField, eSortType sortType=eSortType.Ascending)
         {
-            if(dataField.Field._pivotTable!=_pivotTable)
+            if(dataField.Field.PivotTable!=PivotTable)
             {
                 throw (new ArgumentException("The dataField is from another pivot table"));
             }
@@ -274,7 +276,7 @@ namespace OfficeOpenXml.Table.PivotTable
             var node = CreateNode("d:autoSortScope/d:pivotArea");
             if (AutoSort == null)
             {
-                AutoSort = new ExcelPivotAreaAutoSort(NameSpaceManager, node, _pivotTable);
+                AutoSort = new ExcelPivotAreaAutoSort(NameSpaceManager, node, PivotTable);
                 AutoSort.FieldPosition = 0;
                 AutoSort.Outline = false;
                 AutoSort.DataOnly = false;
@@ -456,7 +458,7 @@ namespace OfficeOpenXml.Table.PivotTable
                     var rowsNode = TopNode.SelectSingleNode("../../d:rowFields", NameSpaceManager);
                     if (rowsNode == null)
                     {
-                        _pivotTable.CreateNode("d:rowFields");
+                        PivotTable.CreateNode("d:rowFields");
                     }
                     rowsNode = TopNode.SelectSingleNode("../../d:rowFields", NameSpaceManager);
 
@@ -499,7 +501,7 @@ namespace OfficeOpenXml.Table.PivotTable
                     var columnsNode = TopNode.SelectSingleNode("../../d:colFields", NameSpaceManager);
                     if (columnsNode == null)
                     {
-                        _pivotTable.CreateNode("d:colFields");
+                        PivotTable.CreateNode("d:colFields");
                     }
                     columnsNode = TopNode.SelectSingleNode("../../d:colFields", NameSpaceManager);
 
@@ -553,7 +555,7 @@ namespace OfficeOpenXml.Table.PivotTable
                     var dataFieldsNode = TopNode.SelectSingleNode("../../d:pageFields", NameSpaceManager);
                     if (dataFieldsNode == null)
                     {
-                        _pivotTable.CreateNode("d:pageFields");
+                        PivotTable.CreateNode("d:pageFields");
                         dataFieldsNode = TopNode.SelectSingleNode("../../d:pageFields", NameSpaceManager);
                     }
 
@@ -684,7 +686,7 @@ namespace OfficeOpenXml.Table.PivotTable
         {
             get
             {
-                return _pivotTable.CacheDefinition._cacheReference.Fields[Index];
+                return PivotTable.CacheDefinition._cacheReference.Fields[Index];
             }
         }
         /// <summary>
@@ -696,9 +698,9 @@ namespace OfficeOpenXml.Table.PivotTable
         public void AddNumericGrouping(double Start, double End, double Interval)
         {
             ValidateGrouping();
-            _cacheField.SetNumericGroup(BaseIndex, Start, End, Interval);
-            UpdateGroupItems(_cacheField, true);
-            UpdatePivotTableGroupItems(this, _pivotTable.CacheDefinition._cacheReference, true);
+            CacheField.SetNumericGroup(BaseIndex, Start, End, Interval);
+            UpdateGroupItems(CacheField, true);
+            UpdatePivotTableGroupItems(this, PivotTable.CacheDefinition._cacheReference, true);
         }
         /// <summary>
         /// Will add a slicer to the pivot table field
@@ -707,7 +709,7 @@ namespace OfficeOpenXml.Table.PivotTable
         public ExcelPivotTableSlicer AddSlicer()
         {
             if (_slicer != null) throw new InvalidOperationException("");
-            _slicer = _pivotTable.WorkSheet.Drawings.AddPivotTableSlicer(this);
+            _slicer = PivotTable.WorkSheet.Drawings.AddPivotTableSlicer(this);
             return _slicer;
         }
         ExcelPivotTableSlicer _slicer = null;
@@ -719,13 +721,13 @@ namespace OfficeOpenXml.Table.PivotTable
         {
             get 
             {
-                if (_slicer == null && _pivotTable.WorkSheet.Workbook.ExistsNode($"d:extLst/d:ext[@uri='{ExtLstUris.WorkbookSlicerPivotTableUri}']"))
+                if (_slicer == null && PivotTable.WorkSheet.Workbook.ExistsNode($"d:extLst/d:ext[@uri='{ExtLstUris.WorkbookSlicerPivotTableUri}']"))
                 {
-                    foreach (var ws in _pivotTable.WorkSheet.Workbook.Worksheets)
+                    foreach (var ws in PivotTable.WorkSheet.Workbook.Worksheets)
                     {
                         foreach (var d in ws.Drawings)
                         {
-                            if (d is ExcelPivotTableSlicer s && s.Cache != null && s.Cache.PivotTables.Contains(_pivotTable) && Index == s.Cache._field.Index)
+                            if (d is ExcelPivotTableSlicer s && s.Cache != null && s.Cache.PivotTables.Contains(PivotTable) && Index == s.Cache._field.Index)
                             {
                                 _slicer = s;
                                 return _slicer;
@@ -776,7 +778,7 @@ namespace OfficeOpenXml.Table.PivotTable
         {
             if (firstField == false)
             {
-                ExcelPivotTableField field = _pivotTable.Fields.AddDateGroupField(Index);
+                ExcelPivotTableField field = PivotTable.Fields.AddDateGroupField(Index);
 
                 XmlNode rowColFields;
                 if (IsRowField)
@@ -793,7 +795,7 @@ namespace OfficeOpenXml.Table.PivotTable
                 {
                     if (int.TryParse(rowfield.GetAttribute("x"), out int fieldIndex))
                     {
-                        if (_pivotTable.Fields[fieldIndex].BaseIndex == BaseIndex)
+                        if (PivotTable.Fields[fieldIndex].BaseIndex == BaseIndex)
                         {
                             var newElement = rowColFields.OwnerDocument.CreateElement("field", ExcelPackage.schemaMain);
                             newElement.SetAttribute("x", field.Index.ToString());
@@ -804,17 +806,17 @@ namespace OfficeOpenXml.Table.PivotTable
                     index++;
                 }
 
-                var cacheRef = _pivotTable.CacheDefinition._cacheReference;
-                field._cacheField = cacheRef.AddDateGroupField(field, groupBy, startDate, endDate, interval);
+                var cacheRef = PivotTable.CacheDefinition._cacheReference;
+                field.CacheField = cacheRef.AddDateGroupField(field, groupBy, startDate, endDate, interval);
                 UpdatePivotTableGroupItems(field, cacheRef, false);
 
                 if (IsRowField)
                 {
-                    _pivotTable.RowFields.Insert(field, index);
+                    PivotTable.RowFields.Insert(field, index);
                 }
                 else
                 {
-                    _pivotTable.ColumnFields.Insert(field, index);
+                    PivotTable.ColumnFields.Insert(field, index);
                 }
 
                 return field;
@@ -823,8 +825,8 @@ namespace OfficeOpenXml.Table.PivotTable
             {
                 firstField = false;
                 Compact = false;
-                _cacheField.SetDateGroup(this, groupBy, startDate, endDate, interval);
-                UpdatePivotTableGroupItems(this, _pivotTable.CacheDefinition._cacheReference, true);
+                CacheField.SetDateGroup(this, groupBy, startDate, endDate, interval);
+                UpdatePivotTableGroupItems(this, PivotTable.CacheDefinition._cacheReference, true);
                 return this;
             }
         }
@@ -838,7 +840,7 @@ namespace OfficeOpenXml.Table.PivotTable
                     if(field.Index >= pt.Fields.Count)
                     {
                          var newField = pt.Fields.AddDateGroupField((int)f.Grouping.BaseIndex);
-                        newField._cacheField = f;
+                        newField.CacheField = f;
                     }
 
                     pt.Fields[field.Index].UpdateGroupItems(f, addTypeDefault);
@@ -883,7 +885,7 @@ namespace OfficeOpenXml.Table.PivotTable
             _items = null;
 
             bool firstField = true;
-            var fields = _pivotTable.Fields.Count;
+            var fields = PivotTable.Fields.Count;
             //Seconds
             if ((groupBy & eDateGroupBy.Seconds) == eDateGroupBy.Seconds)
             {
@@ -920,14 +922,14 @@ namespace OfficeOpenXml.Table.PivotTable
                 AddField(eDateGroupBy.Years, startDate, endDate, ref firstField);
             }
 
-            if (fields>_pivotTable.Fields.Count) _cacheField.SetXmlNodeString("d:fieldGroup/@par", (_pivotTable.Fields.Count-1).ToString());
+            if (fields>PivotTable.Fields.Count) CacheField.SetXmlNodeString("d:fieldGroup/@par", (PivotTable.Fields.Count-1).ToString());
             if (groupInterval != 1)
             {
-                _cacheField.SetXmlNodeString("d:fieldGroup/d:rangePr/@groupInterval", groupInterval.ToString());
+                CacheField.SetXmlNodeString("d:fieldGroup/d:rangePr/@groupInterval", groupInterval.ToString());
             }
             else
             {
-                _cacheField.DeleteNode("d:fieldGroup/d:rangePr/@groupInterval");
+                CacheField.DeleteNode("d:fieldGroup/d:rangePr/@groupInterval");
             }
         }
 
@@ -942,7 +944,7 @@ namespace OfficeOpenXml.Table.PivotTable
             {
                 throw (new Exception("Field must be a row or column field"));
             }
-            foreach (var field in _pivotTable.Fields)
+            foreach (var field in PivotTable.Fields)
             {
                 if (field.Grouping != null)
                 {
@@ -953,7 +955,7 @@ namespace OfficeOpenXml.Table.PivotTable
         internal string SaveToXml()
         {
             var sb = new StringBuilder();
-            var cacheLookup = _pivotTable.CacheDefinition._cacheReference.Fields[Index]._cacheLookup;
+            var cacheLookup = PivotTable.CacheDefinition._cacheReference.Fields[Index]._cacheLookup;
             if(AutoSort!=null)
             {
                 AutoSort.Conditions.UpdateXml();

--- a/src/EPPlus/Table/PivotTable/ExcelPivotTableFieldCollection.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotTableFieldCollection.cs
@@ -138,7 +138,7 @@ namespace OfficeOpenXml.Table.PivotTable
                 fieldNode.SetAttribute("dragToCol", "0");
                 fieldNode.SetAttribute("dragToRow", "0");
                 var field = new ExcelPivotTableField(_table.NameSpaceManager, fieldNode, pt, cacheField.Index, 0);
-                field._cacheField = cacheField;
+                field.CacheField = cacheField;
                 pt.Fields.AddInternal(field);
             }
             return _table.Fields[cacheField.Index];

--- a/src/EPPlus/Table/PivotTable/ExcelPivotTableFieldCollectionBase.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotTableFieldCollectionBase.cs
@@ -22,11 +22,11 @@ namespace OfficeOpenXml.Table.PivotTable
     public class ExcelPivotTableFieldItemsCollection : ExcelPivotTableFieldCollectionBase<ExcelPivotTableFieldItem>
     {
         ExcelPivotTableField _field;
-        private readonly ExcelPivotTableCacheField _cache;
+        //private readonly ExcelPivotTableCacheField _cache;
         internal ExcelPivotTableFieldItemsCollection(ExcelPivotTableField field) : base()
         {
             _field = field;
-            _cache = field.Cache;
+            //_cache = field.Cache;
         }
         /// <summary>
         /// It the object exists in the cache
@@ -35,7 +35,7 @@ namespace OfficeOpenXml.Table.PivotTable
         /// <returns></returns>
         public bool Contains(object value)
         {
-            return _cache._cacheLookup.ContainsKey(value);
+            return _field.Cache._cacheLookup.ContainsKey(value);
         }
         /// <summary>
         /// Get the item with the value supplied. If the value does not exist, null is returned.
@@ -44,7 +44,7 @@ namespace OfficeOpenXml.Table.PivotTable
         /// <returns>The pivot table field</returns>
         public ExcelPivotTableFieldItem GetByValue(object value)
         {
-            if(_cache._cacheLookup.TryGetValue(value, out int ix))
+            if(_field.Cache._cacheLookup.TryGetValue(value, out int ix))
             {
                 return _list[ix];
             }
@@ -57,7 +57,7 @@ namespace OfficeOpenXml.Table.PivotTable
         /// <returns>The index of the item</returns>
         public int GetIndexByValue(object value)
         {
-            if (_cache._cacheLookup.TryGetValue(value, out int ix))
+            if (_field.Cache._cacheLookup.TryGetValue(value, out int ix))
             {
                 return ix;
             }
@@ -118,7 +118,7 @@ namespace OfficeOpenXml.Table.PivotTable
         /// </summary>
         public void Refresh()
         {
-            _cache.Refresh();
+            _field.Cache.Refresh();
         }
     }
     /// <summary>

--- a/src/EPPlus/Table/PivotTable/Filter/ExcelPivotTableFilterBaseCollection.cs
+++ b/src/EPPlus/Table/PivotTable/Filter/ExcelPivotTableFilterBaseCollection.cs
@@ -44,7 +44,7 @@ namespace OfficeOpenXml.Table.PivotTable.Filter
         internal ExcelPivotTableFilterBaseCollection(ExcelPivotTableField field)
         {            
             _field = field;
-            _table = field._pivotTable;
+            _table = field.PivotTable;
 
             foreach(var filter in _table.Filters)
             {

--- a/src/EPPlus/Table/PivotTable/PivotArea/ExcelPivotAreaDataFieldReference.cs
+++ b/src/EPPlus/Table/PivotTable/PivotArea/ExcelPivotAreaDataFieldReference.cs
@@ -92,7 +92,7 @@ namespace OfficeOpenXml.Table.PivotTable
             {
                 throw new ArgumentNullException("The pivot table field must not be null.");
             }
-            if (field.Field._pivotTable != _pt)
+            if (field.Field.PivotTable != _pt)
             {
                 throw new ArgumentException("The pivot table field is from another pivot table.");
             }

--- a/src/EPPlus/Table/PivotTable/PivotArea/ExcelPivotAreaReferenceCollection.cs
+++ b/src/EPPlus/Table/PivotTable/PivotArea/ExcelPivotAreaReferenceCollection.cs
@@ -35,7 +35,7 @@ namespace OfficeOpenXml.Table.PivotTable
         /// <returns>The pivot area reference</returns>
         public ExcelPivotAreaReference Add(ExcelPivotTableField field)
         {
-            return Add(field._pivotTable, field.Index);
+            return Add(field.PivotTable, field.Index);
         }
         /// <summary>
         /// Adds a pivot table field to the collection. The field is usually a column or row field

--- a/src/EPPlus/Table/PivotTable/PivotTableCacheInternal.cs
+++ b/src/EPPlus/Table/PivotTable/PivotTableCacheInternal.cs
@@ -395,7 +395,7 @@ namespace OfficeOpenXml.Table.PivotTable
                         fld.PageFieldSettings.Index = ix;
                         fld.PageFieldSettings._field = fld;
                     }
-                    foreach(ExcelPivotTableAreaStyle s in f._pivotTable.Styles)
+                    foreach(ExcelPivotTableAreaStyle s in f.PivotTable.Styles)
                     {
                         if(s.FieldIndex==f.Index)
                         {

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -5650,5 +5650,61 @@ namespace EPPlusTest
                 Assert.AreEqual(2347400000d, sheet.Cells["A2"].Value);
             }
         }
+
+        [TestMethod]
+        public void issues()
+        {
+            //Inputs
+            string Path = @"C:\epplusTest\Workbooks\Pivot_Test_Input.xlsx";
+            string pivotTableWorksheetName = "Sheet3";
+            string NewSourceDataSheetName = "Sheet2";
+            string pivotTableName = "PivotTable1";
+            string NewInputRange = "M6:S16";
+
+            //Output
+            bool success = false;
+            string exc = "";
+            int pivotTableCount = 0;
+
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+
+            try
+            {
+                ExcelPackage package = new ExcelPackage(Path);
+                var pivotTableWorksheet = package.Workbook.Worksheets[pivotTableWorksheetName];
+                ExcelWorksheet ws = package.Workbook.Worksheets[NewSourceDataSheetName];
+
+                pivotTableCount = pivotTableWorksheet.PivotTables.Count;
+                if (pivotTableCount < 1)
+                {
+                    throw new Exception("No Pivot tables present in the given Pivot Worksheet");
+                }
+                else if (pivotTableName != "")
+                {
+                    pivotTableWorksheet.PivotTables[pivotTableName].CacheDefinition.SourceRange = ws.Cells[NewInputRange];
+                }
+                else
+                {
+                    for (int i = 0; i < pivotTableCount; i++)
+                    {
+                        pivotTableWorksheet.PivotTables[i].CacheDefinition.SourceRange = ws.Cells[NewInputRange];
+                    }
+                }
+                package.SaveAs(@"C:\epplusTest\Workbooks\Pivot_Result_Output.xlsx");
+                package.Dispose();
+                success = true;
+            }
+            catch (Exception e)
+            {
+                exc = "Failed. " + e.ToString();
+                success = false;
+            }
+            finally
+            {
+                System.GC.Collect();
+            }
+        }
+
+
     }
 }


### PR DESCRIPTION
When two pivot tables were pointing at the same source-range and the range was changed on one of them it would generate a corrupt workbook where the new pivotCacheDefintion11.xml file was missing SharedItems.

This was caused by a missmatch where [ExcelPivotTableFieldCollectionBase.cs](https://github.com/EPPlusSoftware/EPPlus/pull/1127/files#diff-63d2c30ca2dac7a0c0be7bf5e368dfeeb7912a067aa27fb2341bf9532d580664)._cache 
was not updated when the source-range was changed. 

While ExcelPivotCacheDefintion._CacheReference.Fields was updating its cache correctly.

Solution: Simplify ExcelPivotTableFieldCollectionBase by refering to _field where it previously referenced _cache and update the Cachefield for all fields on ExcelPivotCacheDefintion.PivoTable.Fields when source range is changed.

For readability also changed the _pivotTable and _cacheField variables in ExcelPivotTableField to properties PivotTable and CacheField