### PR TITLE
s542 fix. Ensured copied workbook copies pivotTables correctly

### DIFF
--- a/src/EPPlus/ExcelWorkbook.cs
+++ b/src/EPPlus/ExcelWorkbook.cs
@@ -857,29 +857,6 @@ namespace OfficeOpenXml
         internal const double date1904Offset = 365.5 * 4;  // offset to fix 1900 and 1904 differences, 4 OLE years
         private bool? date1904Cache = null;
 
-        internal bool ExistsPivotCache(int cacheID, ref int newID)
-        {
-            newID = cacheID;
-            var ret = true;
-            foreach (var ws in Worksheets)
-            {
-                if (ws is ExcelChartsheet) continue;
-                foreach (var pt in ws.PivotTables)
-                {
-                    if (pt.CacheId == cacheID)
-                    {
-                        ret = false;
-                    }
-                    if (pt.CacheId >= newID)
-                    {
-                        newID = pt.CacheId + 1;
-                    }
-                }
-            }
-            if (ret) newID = cacheID;   //Not Found, return same ID
-            return ret;
-        }
-
         /// <summary>
         /// The date systems used by Microsoft Excel can be based on one of two different dates. By default, a serial number of 1 in Microsoft Excel represents January 1, 1900.
         /// The default for the serial number 1 can be changed to represent January 2, 1904.

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -57,6 +57,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
+using System.Xml;
 
 namespace EPPlusTest
 {
@@ -5520,6 +5521,25 @@ namespace EPPlusTest
             finally
             {
                 System.GC.Collect();
+            }
+        }
+
+        [TestMethod]
+        public void s542()
+        {
+            using (var sourcePackage = OpenTemplatePackage("s532_source.xlsx"))
+            {
+                ExcelPackage destinationpackage = OpenTemplatePackage("s532_destination.xlsx");
+                ExcelWorksheet sourceworksheet = sourcePackage.Workbook.Worksheets["Sheet3"];
+                var wscopied = destinationpackage.Workbook.Worksheets.Add("Pivot Data", sourceworksheet);
+
+                var nodes = wscopied.Workbook.WorkbookXml.SelectNodes("//d:pivotCache/@cacheId", wscopied.Workbook.NameSpaceManager);
+
+                Assert.AreEqual(nodes[0].Value, wscopied.PivotTables[0].CacheId.ToString());
+                Assert.AreEqual(nodes[1].Value, wscopied.PivotTables[1].CacheId.ToString());
+
+                sourcePackage.Dispose();
+                SaveAndCleanup(destinationpackage);
             }
         }
     }


### PR DESCRIPTION
- CacheIds betwen pivotTables.xml and Workbook.xml were inconsistent. This resolves the issue.
- Also made copied pivot tables sheets be deselected in the new copy to avoid unnecessary pop-up warning.
- Deleted unused pivotTable function.
