### PR TITLE
Fixes issue #1143,  #1145 #1146 and #1103. Updated referencing library

### DIFF
--- a/src/EPPlus/Drawing/Vml/ExcelVmlDrawingBaseCollection.cs
+++ b/src/EPPlus/Drawing/Vml/ExcelVmlDrawingBaseCollection.cs
@@ -18,6 +18,8 @@ using System.Collections;
 using OfficeOpenXml.Utils;
 using System.IO;
 using OfficeOpenXml.Constants;
+using OfficeOpenXml.Drawing.Interfaces;
+using OfficeOpenXml.Packaging;
 
 namespace OfficeOpenXml.Drawing.Vml
 {
@@ -72,7 +74,7 @@ namespace OfficeOpenXml.Drawing.Vml
         internal string RelId { get; set; }
         internal Packaging.ZipPackagePart Part { get; set; }
         internal XmlNamespaceManager NameSpaceManager { get; set; }
-        internal void CreateVmlPart()
+        internal void CreateVmlPart(bool save)
         {
             if (Uri == null)
             {
@@ -86,8 +88,10 @@ namespace OfficeOpenXml.Drawing.Vml
                 _ws.SetXmlNodeString("d:legacyDrawing/@r:id", rel.Id);
                 RelId = rel.Id;
             }
-
-            VmlDrawingXml.Save(Part.GetStream(FileMode.Create));
+            if (save)
+            {
+                VmlDrawingXml.Save(Part.GetStream(FileMode.Create));
+            }
         }
     }
 }

--- a/src/EPPlus/Drawing/Vml/ExcelVmlDrawingCollection.cs
+++ b/src/EPPlus/Drawing/Vml/ExcelVmlDrawingCollection.cs
@@ -148,7 +148,7 @@ namespace OfficeOpenXml.Drawing.Vml
         }
         private XmlNode AddCommentDrawing(ExcelRangeBase cell)
         {
-            CreateVmlPart(); //Create the vml part to be able to create related parts (like blip fill images).
+            CreateVmlPart(false); //Create the vml part to be able to create related parts (like blip fill images).
             int row = cell.Start.Row, col = cell.Start.Column;
             var node = VmlDrawingXml.CreateElement("v", "shape", ExcelPackage.schemaMicrosoftVml);
 
@@ -202,7 +202,7 @@ namespace OfficeOpenXml.Drawing.Vml
         }
         private XmlNode AddControlDrawing(ExcelControl ctrl, string name)
         {
-            CreateVmlPart(); //Create the vml part to be able to create related parts (like blip fill images).
+            CreateVmlPart(false); //Create the vml part to be able to create related parts (like blip fill images).
             var shapeElement = VmlDrawingXml.CreateElement("v", "shape", ExcelPackage.schemaMicrosoftVml);
 
             VmlDrawingXml.DocumentElement.AppendChild(shapeElement);

--- a/src/EPPlus/Drawing/Vml/ExcelVmlDrawingPicture.cs
+++ b/src/EPPlus/Drawing/Vml/ExcelVmlDrawingPicture.cs
@@ -343,7 +343,7 @@ namespace OfficeOpenXml.Drawing.Vml
         {
             get
             {
-                return _worksheet.VmlDrawings;
+                return _worksheet.HeaderFooter._vmlDrawingsHF;
             }
         }
 
@@ -351,11 +351,11 @@ namespace OfficeOpenXml.Drawing.Vml
         Uri UriPic { get; set; }
         Packaging.ZipPackageRelationship RelPic { get; set; }
 
-        IPictureRelationDocument IPictureContainer.RelationDocument => throw new NotImplementedException();
+        IPictureRelationDocument IPictureContainer.RelationDocument => _worksheet.HeaderFooter._vmlDrawingsHF;
 
-        string IPictureContainer.ImageHash { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        Uri IPictureContainer.UriPic { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        Packaging.ZipPackageRelationship IPictureContainer.RelPic { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        string IPictureContainer.ImageHash { get; set; }
+        Uri IPictureContainer.UriPic { get; set; }
+        Packaging.ZipPackageRelationship IPictureContainer.RelPic { get; set; }
 
         void IPictureContainer.RemoveImage()
         {

--- a/src/EPPlus/Drawing/Vml/ExcelVmlDrawingPictureCollection.cs
+++ b/src/EPPlus/Drawing/Vml/ExcelVmlDrawingPictureCollection.cs
@@ -17,15 +17,18 @@ using System.Xml;
 using System.Collections;
 using System.Globalization;
 using OfficeOpenXml.Utils;
+using OfficeOpenXml.Drawing.Interfaces;
+using OfficeOpenXml.Packaging;
 
 namespace OfficeOpenXml.Drawing.Vml
 {
     /// <summary>
     /// A collection of vml drawings used for header and footer picturess
     /// </summary>
-    public class ExcelVmlDrawingPictureCollection : ExcelVmlDrawingBaseCollection, IEnumerable
+    public class ExcelVmlDrawingPictureCollection : ExcelVmlDrawingBaseCollection, IEnumerable, IPictureRelationDocument
     {
         internal List<ExcelVmlDrawingPicture> _images;
+        Dictionary<string, HashInfo> _hashes = new Dictionary<string, HashInfo>();
         internal ExcelVmlDrawingPictureCollection(ExcelWorksheet ws, Uri uri) :
             base(ws, uri, "d:legacyDrawingHF/@r:id")
         {            
@@ -149,5 +152,12 @@ namespace OfficeOpenXml.Drawing.Vml
         }
 
         #endregion
+        ExcelPackage IPictureRelationDocument.Package => _package;
+
+        Dictionary<string, HashInfo> IPictureRelationDocument.Hashes => _hashes;
+
+        ZipPackagePart IPictureRelationDocument.RelatedPart => Part;
+
+        Uri IPictureRelationDocument.RelatedUri => Uri;
     }
 }

--- a/src/EPPlus/EPPlus.csproj
+++ b/src/EPPlus/EPPlus.csproj
@@ -509,7 +509,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.30" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.32" />
     <PackageReference Include="System.ComponentModel.Annotations">
       <Version>5.0.0</Version>
     </PackageReference>
@@ -528,7 +528,7 @@
     <PackageReference Include="System.ComponentModel.Annotations">
       <Version>5.0.0</Version>
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.4" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream">
 			<Version>2.3.2</Version>
@@ -540,7 +540,7 @@
     <PackageReference Include="System.ComponentModel.Annotations">
       <Version>5.0.0</Version>
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.3" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
 	  <PackageReference Include="Microsoft.IO.RecyclableMemoryStream">
 		  <Version>2.3.2</Version>

--- a/src/EPPlus/ExcelHeaderFooter.cs
+++ b/src/EPPlus/ExcelHeaderFooter.cs
@@ -131,7 +131,7 @@ namespace OfficeOpenXml
             var imgBytes=new byte[PictureStream.Length];
             PictureStream.Seek(0, SeekOrigin.Begin);
             PictureStream.Read(imgBytes,0, imgBytes.Length);
-            var ii = _ws.Workbook._package.PictureStore.AddImage(imgBytes,null, pictureType);
+            var ii = _ws.Workbook._package.PictureStore.AddImage(imgBytes, null, pictureType);
 
             return AddImage(id, ii);
         }
@@ -429,7 +429,7 @@ namespace OfficeOpenXml
                 return _firstFooter; 
             } 
         }
-        private ExcelVmlDrawingPictureCollection _vmlDrawingsHF = null;
+        internal ExcelVmlDrawingPictureCollection _vmlDrawingsHF = null;
         /// <summary>
         /// Vml drawings. Underlaying object for Header footer images
         /// </summary>

--- a/src/EPPlus/ExcelPackage.cs
+++ b/src/EPPlus/ExcelPackage.cs
@@ -842,7 +842,8 @@ namespace OfficeOpenXml
             {
                 if (_isExternalStream == false && _stream != null && (_stream.CanRead || _stream.CanWrite))
                 {
-                    CloseStream();
+                    _stream.Close();
+                    _stream.Dispose();
                 }
                 _zipPackage.Close();
                 if (_workbook != null)

--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -973,7 +973,7 @@ namespace OfficeOpenXml
             }
             set
             {
-                SetXmlNodeString(codeModuleNamePath, value);
+                SetXmlNodeString(codeModuleNamePath, value, true);
             }
         }
         internal void CodeNameChange(string value)
@@ -2620,7 +2620,7 @@ namespace OfficeOpenXml
                 }
                 else
                 {
-                    _vmlDrawings.CreateVmlPart();
+                    _vmlDrawings.CreateVmlPart(true);
                 }
             }
         }

--- a/src/EPPlus/ExcelWorksheets.cs
+++ b/src/EPPlus/ExcelWorksheets.cs
@@ -187,6 +187,10 @@ namespace OfficeOpenXml
                     _pck.Workbook.VbaProject.Modules.Add(new ExcelVBAModule(worksheet.CodeNameChange) { Name = name, Code = "", Attributes = _pck.Workbook.VbaProject.GetDocumentAttributes(Name, "0{00020820-0000-0000-C000-000000000046}"), Type = eModuleType.Document, HelpContext = 0 });
                     worksheet.CodeModuleName = name;
                 }
+                else
+                {
+                    worksheet.CodeModuleName = null;
+                }
 
                 return worksheet;
             }

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -5711,5 +5711,31 @@ namespace EPPlusTest
                 SaveAndCleanup(pck);
             }
         }
+        [TestMethod]
+        public void GroupDrawingIssue()
+        {
+            using (var p = OpenTemplatePackage("pic_shape_grouped2.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                var grpSp = (ExcelGroupShape)ws.Drawings[0];
+                var d = grpSp.Drawings[0];
+
+                p.Workbook.Worksheets.Add("Sheet2", ws);
+                SaveAndCleanup(p);
+            }
+        }
+        [TestMethod]
+        public void i1146()
+        {
+            using (var p1 = OpenTemplatePackage("HeaderFooterTest.xlsx"))
+            {
+                using (var p2 = new ExcelPackage())
+                {
+                    var ws = p1.Workbook.Worksheets[0];
+                    p2.Workbook.Worksheets.Add("sheet1", ws);
+                    SaveWorkbook("HeaderFooterSaved.xlsx", p2);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
* Images in headers and footers was not copied when the copying worksheet was from another package.
* Copying pictures in in a group shape did not copy the relations properly.
* Worksheet modules names was copied even when a workbook didn't have a VBA project.
* Fixed Disposal of MemoryStreams in a few places..