### PR TITLE
Resolved bug when adding same image twice

### DIFF
--- a/src/EPPlus/Drawing/ExcelPicture.cs
+++ b/src/EPPlus/Drawing/ExcelPicture.cs
@@ -148,9 +148,10 @@ namespace OfficeOpenXml.Drawing
             IPictureContainer container = this;
             container.UriPic = ii.Uri;
             string relId;
+            Part = ii.Part;
+
             if (!pc.Hashes.ContainsKey(ii.Hash))
             {
-                Part = ii.Part;
                 container.RelPic = _drawings.Part.CreateRelationship(UriHelper.GetRelativeUri(_drawings.UriDrawing, ii.Uri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/image");
                 relId = container.RelPic.Id;
                 pc.Hashes.Add(ii.Hash, new HashInfo(relId));

--- a/src/EPPlus/Export/HtmlExport/HtmlExportImageUtil.cs
+++ b/src/EPPlus/Export/HtmlExport/HtmlExportImageUtil.cs
@@ -40,7 +40,8 @@ namespace OfficeOpenXml.Export.HtmlExport
 
         internal static string GetPictureName(HtmlImage p)
         {
-            var hash = ((IPictureContainer)p.Picture).ImageHash;
+            var container = (IPictureContainer)p.Picture;
+            var hash = container.ImageHash;
             var fi = new FileInfo(p.Picture.Part.Uri.OriginalString);
             var name = fi.Name.Substring(0, fi.Name.Length - fi.Extension.Length);
 


### PR DESCRIPTION
Adding an excelimage with the same path resulted in crash due to the copy's "part" being null.
Resolved via creating pointer to part even in the copy.