### PR TITLE
Ensured showTotal is inserted correctly

### DIFF
--- a/src/EPPlus/Table/ExcelTable.cs
+++ b/src/EPPlus/Table/ExcelTable.cs
@@ -788,7 +788,6 @@ namespace OfficeOpenXml.Table
                     if (value)
                     {
                         WorkSheet.Cells[Address._toRow + 1, Address._fromCol, Address._toRow + 1, Address._toCol].Clear();
-                        //InsertNormalRowUnderTable();
                         Address =new ExcelAddress(WorkSheet.Name, ExcelAddressBase.GetAddress(Address.Start.Row, Address.Start.Column, Address.End.Row+1, Address.End.Column));
                     }
                     else
@@ -1080,19 +1079,6 @@ namespace OfficeOpenXml.Table
             }
 
             return range;
-        }
-
-        private void InsertNormalRowUnderTable(int rows = 1)
-        {
-            int position = _address.Rows;
-            if (_address._fromRow + position + rows > ExcelPackage.MaxRows)
-            {
-                throw new InvalidOperationException("Insert will exceed the maximum number of rows in the worksheet");
-            }
-            var address = ExcelCellBase.GetAddress(_address._fromRow + position, _address._fromCol, _address._fromRow + position + rows - 1, _address._toCol);
-            var range = new ExcelRangeBase(WorkSheet, address);
-
-            WorksheetRangeInsertHelper.Insert(range, eShiftTypeInsert.Down, false, true);
         }
 
         private void ExtendCalculatedFormulas(ExcelRangeBase range)

--- a/src/EPPlus/Table/ExcelTable.cs
+++ b/src/EPPlus/Table/ExcelTable.cs
@@ -24,12 +24,9 @@ using System.Data;
 using OfficeOpenXml.Export.ToDataTable;
 using System.IO;
 using OfficeOpenXml.Style.Dxf;
-using OfficeOpenXml.Export.HtmlExport;
 using System.Globalization;
 using OfficeOpenXml.Sorting;
 using OfficeOpenXml.Export.HtmlExport.Interfaces;
-using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
-using System.Net;
 #if !NET35 && !NET40
 using System.Threading.Tasks;
 #endif
@@ -811,8 +808,11 @@ namespace OfficeOpenXml.Table
                     {
                         DeleteNode(TOTALSROWCOUNT_PATH);
                         DataStyle.SetStyle();
+                        WorksheetRangeDeleteHelper.Delete(WorkSheet.Cells[Address._toRow+1, Address._fromCol, Address._toRow + 1, Address._toCol], eShiftTypeDelete.Up);
+                        //WorkSheet.Cells[Address._toRow + 1, Address._toCol].Delete(eShiftTypeDelete.Up);
                     }
                     WriteAutoFilter(value);
+   
                 }
             }
         }

--- a/src/EPPlus/Table/ExcelTable.cs
+++ b/src/EPPlus/Table/ExcelTable.cs
@@ -787,7 +787,8 @@ namespace OfficeOpenXml.Table
                 {
                     if (value)
                     {
-                        InsertNormalRowUnderTable();
+                        WorkSheet.Cells[Address._toRow + 1, Address._fromCol, Address._toRow + 1, Address._toCol].Clear();
+                        //InsertNormalRowUnderTable();
                         Address =new ExcelAddress(WorkSheet.Name, ExcelAddressBase.GetAddress(Address.Start.Row, Address.Start.Column, Address.End.Row+1, Address.End.Column));
                     }
                     else
@@ -806,10 +807,9 @@ namespace OfficeOpenXml.Table
                     }
                     else
                     {
+                        WorkSheet.Cells[Address._toRow + 1, Address._fromCol, Address._toRow + 1, Address._toCol].Clear();
                         DeleteNode(TOTALSROWCOUNT_PATH);
                         DataStyle.SetStyle();
-                        WorksheetRangeDeleteHelper.Delete(WorkSheet.Cells[Address._toRow+1, Address._fromCol, Address._toRow + 1, Address._toCol], eShiftTypeDelete.Up);
-                        //WorkSheet.Cells[Address._toRow + 1, Address._toCol].Delete(eShiftTypeDelete.Up);
                     }
                     WriteAutoFilter(value);
    

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -36,6 +36,7 @@ using OfficeOpenXml.Drawing.Chart;
 using OfficeOpenXml.Drawing.Chart.Style;
 using OfficeOpenXml.Drawing.Slicer;
 using OfficeOpenXml.Drawing.Style.Coloring;
+using OfficeOpenXml.Export.HtmlExport;
 using OfficeOpenXml.Filter;
 using OfficeOpenXml.FormulaParsing;
 using OfficeOpenXml.Sparkline;
@@ -5804,6 +5805,5 @@ namespace EPPlusTest
                 SaveAndCleanup(p);
             }
         }
-
     }
 }

--- a/src/EPPlusTest/Table/TableInsertTests.cs
+++ b/src/EPPlusTest/Table/TableInsertTests.cs
@@ -107,6 +107,30 @@ namespace EPPlusTest.Table
             Assert.AreEqual("Don't Shift Me", ws.Cells["F5"].Value);
             Assert.AreEqual("Shift Me Down", ws.Cells["B106"].Value);
         }
+
+        //[TestMethod]
+        //public void TableBottowOnlyTotal()
+        //{
+        //    //Setup
+        //    var ws = _pck.Workbook.Worksheets.Add("TableInsertBottomTotal");
+        //    LoadTestdata(ws, 100, 2);
+        //    ws.Cells["B102"].Value = "Shift Me Down";
+        //    ws.Cells["F5"].Value = "Don't Shift Me";
+
+        //    var tbl = ws.Tables.Add(ws.Cells["B1:E100"], "TableInsertBottomTotal");
+        //    tbl.ShowTotal = true;
+        //    tbl.Columns[0].TotalsRowFunction = RowFunctions.Sum;
+        //    tbl.Columns[1].TotalsRowFunction = RowFunctions.Count;
+        //    tbl.Columns[2].TotalsRowFunction = RowFunctions.Average;
+        //    tbl.Columns[3].TotalsRowFunction = RowFunctions.CountNums;
+
+        //    Assert.AreEqual("B1:E102", tbl.Address.Address);
+        //    Assert.AreEqual("Shift Me Down", ws.Cells["B103"].Value);
+        //    //Assert.AreEqual("B1:E105", tbl.Address.Address);
+        //    //Assert.AreEqual("Don't Shift Me", ws.Cells["F5"].Value);
+        //    //Assert.AreEqual("Shift Me Down", ws.Cells["B106"].Value);
+        //}
+
         [TestMethod]
         public void TableInsertRowInside()
         {

--- a/src/EPPlusTest/Table/TableInsertTests.cs
+++ b/src/EPPlusTest/Table/TableInsertTests.cs
@@ -108,29 +108,6 @@ namespace EPPlusTest.Table
             Assert.AreEqual("Shift Me Down", ws.Cells["B106"].Value);
         }
 
-        //[TestMethod]
-        //public void TableBottowOnlyTotal()
-        //{
-        //    //Setup
-        //    var ws = _pck.Workbook.Worksheets.Add("TableInsertBottomTotal");
-        //    LoadTestdata(ws, 100, 2);
-        //    ws.Cells["B102"].Value = "Shift Me Down";
-        //    ws.Cells["F5"].Value = "Don't Shift Me";
-
-        //    var tbl = ws.Tables.Add(ws.Cells["B1:E100"], "TableInsertBottomTotal");
-        //    tbl.ShowTotal = true;
-        //    tbl.Columns[0].TotalsRowFunction = RowFunctions.Sum;
-        //    tbl.Columns[1].TotalsRowFunction = RowFunctions.Count;
-        //    tbl.Columns[2].TotalsRowFunction = RowFunctions.Average;
-        //    tbl.Columns[3].TotalsRowFunction = RowFunctions.CountNums;
-
-        //    Assert.AreEqual("B1:E102", tbl.Address.Address);
-        //    Assert.AreEqual("Shift Me Down", ws.Cells["B103"].Value);
-        //    //Assert.AreEqual("B1:E105", tbl.Address.Address);
-        //    //Assert.AreEqual("Don't Shift Me", ws.Cells["F5"].Value);
-        //    //Assert.AreEqual("Shift Me Down", ws.Cells["B106"].Value);
-        //}
-
         [TestMethod]
         public void TableInsertRowInside()
         {

--- a/src/EPPlusTest/Table/TableTests.cs
+++ b/src/EPPlusTest/Table/TableTests.cs
@@ -726,52 +726,9 @@ namespace EPPlusTest.Table
                 sheet.Cells["D3:E3"].Value = 4;
                 sheet.Cells["E10"].Value = 5;
 
-                sheet.Cells["F11"].Value = 11;
-
-                table.ShowTotal = true;
-                table.Columns[2].TotalsRowFunction = RowFunctions.Sum;
-
-                sheet.Calculate();
-
-                //Assert.AreEqual(sheet.Cells["A10"].Value, "Number:9");
-                //Assert.AreEqual(sheet.Cells["A11"].Value, null);
-                //Assert.AreEqual(sheet.Cells["A12"].Value, "Number:10");
-                //Assert.AreEqual(sheet.Cells["F11"].Value, 11);
-
-                SaveAndCleanup(package);
-            }
-        }
-
-        [TestMethod]
-        public void ShowTotalWhenValueBelowItNoHeader()
-        {
-            using (var package = OpenPackage("ShowTotalInsertNoHeader.xlsx", true))
-            {
-                var sheet = package.Workbook.Worksheets.Add("Tables");
-
-                //Cause of issue. (Specifically sheet.cells[11,1]
-                for (int i = 1; i < 25; i++)
-                {
-                    sheet.Cells[1 + i, 1].Formula = $"\"Number:{i}\"";
-                }
-
-                sheet.Cells["A1"].Value = "Month";
-                sheet.Cells["B1"].Value = "Sales";
-                sheet.Cells["C1"].Value = "VAT";
-                sheet.Cells["D1"].Value = "Total";
-
-                var table = sheet.Tables.Add(new ExcelAddress("A1:E10"), "testTable");
-                table.ShowHeader = false;
-                table.ShowFirstColumn = true;
-                table.TableStyle = TableStyles.Dark2;
-
-                sheet.Cells["A1"].Value = "testStuff";
-
-                sheet.Cells["C3:C5"].Value = 3;
-                sheet.Cells["D3:E3"].Value = 4;
-                sheet.Cells["E10"].Value = 5;
-
-                sheet.Cells["F11"].Value = 11;
+                sheet.Cells["F11"].Value = "Don't clear me";
+                var noHeader = package.Workbook.Worksheets.Add("noHeader", sheet);
+                var stackTest = package.Workbook.Worksheets.Add("stackTest", sheet);
 
                 table.ShowTotal = true;
                 table.Columns[2].TotalsRowFunction = RowFunctions.Sum;
@@ -780,60 +737,35 @@ namespace EPPlusTest.Table
 
                 Assert.AreEqual(sheet.Cells["A10"].Value, "Number:9");
                 Assert.AreEqual(sheet.Cells["A11"].Value, null);
-                Assert.AreEqual(sheet.Cells["A12"].Value, "Number:10");
-                Assert.AreEqual(sheet.Cells["F11"].Value, 11);
+                Assert.AreEqual(sheet.Cells["A12"].Value, "Number:11");
+                Assert.AreEqual(sheet.Cells["F11"].Value, "Don't clear me");
 
-                SaveAndCleanup(package);
-            }
-        }
+                noHeader.Tables[0].ShowHeader = false;
+                noHeader.Tables[0].ShowTotal = true;
+                noHeader.Tables[0].Columns[2].TotalsRowFunction = RowFunctions.Sum;
 
-        [TestMethod]
-        public void EnsureShowTotalNonStacking()
-        {
-            using (var package = OpenPackage("showTotal.xlsx", true))
-            {
-                var sheet = package.Workbook.Worksheets.Add("Tables");
+                noHeader.Calculate();
 
-                //Cause of issue. (Specifically sheet.cells[11,1]
-                for (int i = 1; i < 25; i++)
-                {
-                    sheet.Cells[1 + i, 1].Formula = $"\"Number:{i}\"";
-                }
+                Assert.AreEqual(noHeader.Cells["A10"].Value, "Number:9");
+                Assert.AreEqual(noHeader.Cells["A11"].Value, null);
+                Assert.AreEqual(noHeader.Cells["A12"].Value, "Number:11");
+                Assert.AreEqual(noHeader.Cells["F11"].Value, "Don't clear me");
 
-                sheet.Cells["A1"].Value = "Month";
-                sheet.Cells["B1"].Value = "Sales";
-                sheet.Cells["C1"].Value = "VAT";
-                sheet.Cells["D1"].Value = "Total";
+                stackTest.Tables[0].ShowTotal = true;
+                stackTest.Tables[0].ShowTotal = false;
+                stackTest.Tables[0].ShowTotal = true;
+                stackTest.Tables[0].ShowTotal = false;
+                stackTest.Tables[0].ShowTotal = true;
+                stackTest.Tables[0].ShowTotal = false;
+                stackTest.Tables[0].ShowTotal = true;
+                stackTest.Tables[0].ShowTotal = false;
 
-                var table = sheet.Tables.Add(new ExcelAddress("A1:E10"), "testTable");
-                table.ShowHeader = false;
-                table.ShowFirstColumn = true;
-                table.TableStyle = TableStyles.Dark2;
+                stackTest.Calculate();
 
-                sheet.Cells["A1"].Value = "testStuff";
-
-                sheet.Cells["C3:C5"].Value = 3;
-                sheet.Cells["D3:E3"].Value = 4;
-                sheet.Cells["E10"].Value = 5;
-
-                sheet.Cells["F11"].Value = 11;
-
-                table.ShowTotal = true;
-                table.ShowTotal = false;
-                table.ShowTotal = true;
-                table.ShowTotal = false;
-                table.ShowTotal = true;
-                table.ShowTotal = false;
-                table.ShowTotal = true;
-
-                table.Columns[2].TotalsRowFunction = RowFunctions.Sum;
-
-                sheet.Calculate();
-
-                //Assert.AreEqual(sheet.Cells["A10"].Value, "Number:9");
-                //Assert.AreEqual(sheet.Cells["A11"].Value, "Number:10");
-                //Assert.AreEqual(sheet.Cells["A12"].Value, "Number:11");
-                //Assert.AreEqual(sheet.Cells["F11"].Value, 11);
+                Assert.AreEqual(stackTest.Cells["A10"].Value, "Number:9");
+                Assert.AreEqual(stackTest.Cells["A11"].Value, null);
+                Assert.AreEqual(stackTest.Cells["A12"].Value, "Number:11");
+                Assert.AreEqual(stackTest.Cells["F11"].Value, "Don't clear me");
 
                 SaveAndCleanup(package);
             }

--- a/src/EPPlusTest/Table/TableTests.cs
+++ b/src/EPPlusTest/Table/TableTests.cs
@@ -733,10 +733,10 @@ namespace EPPlusTest.Table
 
                 sheet.Calculate();
 
-                Assert.AreEqual(sheet.Cells["A10"].Value, "Number:9");
-                Assert.AreEqual(sheet.Cells["A11"].Value, null);
-                Assert.AreEqual(sheet.Cells["A12"].Value, "Number:10");
-                Assert.AreEqual(sheet.Cells["F11"].Value, 11);
+                //Assert.AreEqual(sheet.Cells["A10"].Value, "Number:9");
+                //Assert.AreEqual(sheet.Cells["A11"].Value, null);
+                //Assert.AreEqual(sheet.Cells["A12"].Value, "Number:10");
+                //Assert.AreEqual(sheet.Cells["F11"].Value, 11);
 
                 SaveAndCleanup(package);
             }
@@ -782,6 +782,58 @@ namespace EPPlusTest.Table
                 Assert.AreEqual(sheet.Cells["A11"].Value, null);
                 Assert.AreEqual(sheet.Cells["A12"].Value, "Number:10");
                 Assert.AreEqual(sheet.Cells["F11"].Value, 11);
+
+                SaveAndCleanup(package);
+            }
+        }
+
+        [TestMethod]
+        public void EnsureShowTotalNonStacking()
+        {
+            using (var package = OpenPackage("showTotal.xlsx", true))
+            {
+                var sheet = package.Workbook.Worksheets.Add("Tables");
+
+                //Cause of issue. (Specifically sheet.cells[11,1]
+                for (int i = 1; i < 25; i++)
+                {
+                    sheet.Cells[1 + i, 1].Formula = $"\"Number:{i}\"";
+                }
+
+                sheet.Cells["A1"].Value = "Month";
+                sheet.Cells["B1"].Value = "Sales";
+                sheet.Cells["C1"].Value = "VAT";
+                sheet.Cells["D1"].Value = "Total";
+
+                var table = sheet.Tables.Add(new ExcelAddress("A1:E10"), "testTable");
+                table.ShowHeader = false;
+                table.ShowFirstColumn = true;
+                table.TableStyle = TableStyles.Dark2;
+
+                sheet.Cells["A1"].Value = "testStuff";
+
+                sheet.Cells["C3:C5"].Value = 3;
+                sheet.Cells["D3:E3"].Value = 4;
+                sheet.Cells["E10"].Value = 5;
+
+                sheet.Cells["F11"].Value = 11;
+
+                table.ShowTotal = true;
+                table.ShowTotal = false;
+                table.ShowTotal = true;
+                table.ShowTotal = false;
+                table.ShowTotal = true;
+                table.ShowTotal = false;
+                table.ShowTotal = true;
+
+                table.Columns[2].TotalsRowFunction = RowFunctions.Sum;
+
+                sheet.Calculate();
+
+                //Assert.AreEqual(sheet.Cells["A10"].Value, "Number:9");
+                //Assert.AreEqual(sheet.Cells["A11"].Value, "Number:10");
+                //Assert.AreEqual(sheet.Cells["A12"].Value, "Number:11");
+                //Assert.AreEqual(sheet.Cells["F11"].Value, 11);
 
                 SaveAndCleanup(package);
             }


### PR DESCRIPTION
Having a formula value on the row below a table and then setting Table.ShowTotal = true
Resulted in corrupt workbook as formula remained on line while also being set by excel.

Now resolved by clearing the line under the table before showing the total