### PR TITLE
Bug/s554 rich text tab

### DIFF
--- a/src/EPPlus/ExcelWorkbook.cs
+++ b/src/EPPlus/ExcelWorkbook.cs
@@ -1368,9 +1368,7 @@ namespace OfficeOpenXml
 				SharedStringItem ssi = _sharedStrings[t];
 				if (ssi.isRichText)
 				{
-					cache.Append("<si>");
-					ConvertUtil.ExcelEncodeString(cache, t);
-					cache.Append("</si>");
+					cache.Append($"<si>{t}</si>");
 				}
 				else
 				{

--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -1805,7 +1805,7 @@ namespace OfficeOpenXml
             var v = ConvertUtil.GetValueFromType(xr, type, styleID, Workbook);
             if (type == "s" && v is int ix)
             {
-                SetValueInner(row, col, ConvertUtil.ExcelDecodeString(_package.Workbook._sharedStringsList[ix].Text));
+                SetValueInner(row, col, _package.Workbook._sharedStringsList[ix].Text);
                 if (_package.Workbook._sharedStringsList[ix].isRichText)
                 {
                     _flags.SetFlagValue(row, col, true, CellFlags.RichText);

--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -1805,7 +1805,7 @@ namespace OfficeOpenXml
             var v = ConvertUtil.GetValueFromType(xr, type, styleID, Workbook);
             if (type == "s" && v is int ix)
             {
-                SetValueInner(row, col, _package.Workbook._sharedStringsList[ix].Text);
+                SetValueInner(row, col, ConvertUtil.ExcelDecodeString(_package.Workbook._sharedStringsList[ix].Text));
                 if (_package.Workbook._sharedStringsList[ix].isRichText)
                 {
                     _flags.SetFlagValue(row, col, true, CellFlags.RichText);

--- a/src/EPPlus/Style/ExcelRichText.cs
+++ b/src/EPPlus/Style/ExcelRichText.cs
@@ -19,6 +19,7 @@ using System.Globalization;
 using OfficeOpenXml.Export.HtmlExport;
 using OfficeOpenXml.Drawing;
 using OfficeOpenXml.Drawing.Theme;
+using OfficeOpenXml.Utils;
 
 namespace OfficeOpenXml.Style
 {
@@ -48,13 +49,14 @@ namespace OfficeOpenXml.Style
 
             get
             {
-                return GetXmlNodeString(TEXT_PATH);
+                return ConvertUtil.ExcelDecodeString(GetXmlNodeString(TEXT_PATH));
             }
             set
             {
                 if (value == null) throw new InvalidOperationException("Text can't be null");
                 _collection.ConvertRichtext();
-                SetXmlNodeString(TEXT_PATH, value, false);
+                var encodedValue = ConvertUtil.ExcelEncodeString(value);
+                SetXmlNodeString(TEXT_PATH, encodedValue, false);
                 if (PreserveSpace)
                 {
                     XmlElement elem = TopNode.SelectSingleNode(TEXT_PATH, NameSpaceManager) as XmlElement;

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -5804,6 +5804,30 @@ namespace EPPlusTest
                 SaveAndCleanup(p);
             }
         }
+        [TestMethod]
+        public void s554()
+        {
+            string s = "captain \t cave \n\tman";
 
+            using (var package = OpenPackage("tabDecoding.xlsx", true))
+            {
+                var sheet = package.Workbook.Worksheets.Add("Sheety");
+                sheet.Cells["A1"].RichText.Add(s);
+                var richText = sheet.Cells["A1"].RichText;
+                //cell contains the expected \t character
+                package.Save();
+            }
+           
+            //Now read the excel, the Value contains  _x0009_ instead of \t
+            using (var package = OpenPackage("tabDecoding.xlsx"))
+            {
+                var sheet = package.Workbook.Worksheets[0];
+                var cell = sheet.Cells[1, 1];
+
+                string text = cell.Value.ToString();
+                Assert.AreEqual("captain \t cave \n\tman", text);
+                SaveAndCleanup(package);
+            }
+        }
     }
 }


### PR DESCRIPTION
Tabs were not decoded from shared string appropriately.

This encodes and decodes shared strings on set and get instead.