### PR TITLE
Bug/s566 Ensured null or empty values on autofilter sets blank6

### DIFF
--- a/src/EPPlus/Filter/ExcelValueFilterCollection.cs
+++ b/src/EPPlus/Filter/ExcelValueFilterCollection.cs
@@ -24,7 +24,7 @@ namespace OfficeOpenXml.Filter
         /// <summary>
         /// The calendar to be used. To be implemented
         /// </summary>
-        internal eCalendarType? CalendarTyp{get;set;}
+        internal eCalendarType? CalendarType{get;set;}
         /// <summary>
         /// Add a Date filter item. 
         /// </summary>
@@ -42,7 +42,7 @@ namespace OfficeOpenXml.Filter
         /// <returns>The filter value item</returns>
         public ExcelFilterValueItem Add(ExcelFilterValueItem item)
         {
-            _list.Add(item);
+            AddOrSetBlank(item);
             return item;
         }
         /// <summary>
@@ -53,8 +53,19 @@ namespace OfficeOpenXml.Filter
         public ExcelFilterValueItem Add(string value)
         {
             var v = new ExcelFilterValueItem(value);
-            _list.Add(v);
+            AddOrSetBlank(v);
             return v;
+        }
+        internal void AddOrSetBlank(ExcelFilterValueItem item)
+        {
+            if (string.IsNullOrEmpty(item.Value))
+            {
+                Blank = true;
+            }
+            else
+            {
+                _list.Add(item);
+            }
         }
         /// <summary>
         /// Clears the collection

--- a/src/EPPlus/Filter/ExcelValueFilterColumn.cs
+++ b/src/EPPlus/Filter/ExcelValueFilterColumn.cs
@@ -83,6 +83,17 @@ namespace OfficeOpenXml.Filter
         internal override bool Match(object value, string valueText)
         {
             var match = true;
+
+            //Handle when Only Blanks filter
+            if (Filters.Count == 0 && Filters.Blank)
+            {
+                if (string.IsNullOrEmpty(valueText))
+                {
+                    return true;
+                }
+                return false;
+            }
+
             foreach (var filter in Filters)
             {
                 if(filter is ExcelFilterDateGroupItem d)
@@ -110,7 +121,7 @@ namespace OfficeOpenXml.Filter
             var node = (XmlElement)CreateNode("d:filters");
             node.RemoveAll();
             if (Filters.Blank) (node).SetAttribute("blank", "1");
-            if (Filters.CalendarTyp.HasValue) (node).SetAttribute("calendarType", Filters.CalendarTyp.Value.ToEnumString());
+            if (Filters.CalendarType.HasValue) (node).SetAttribute("calendarType", Filters.CalendarType.Value.ToEnumString());
             foreach(var f in Filters)
             {
                 if(f is ExcelFilterDateGroupItem d)

--- a/src/EPPlusTest/Filter/AutoFilterReadWriteTest.cs
+++ b/src/EPPlusTest/Filter/AutoFilterReadWriteTest.cs
@@ -357,5 +357,39 @@ namespace EPPlusTest.Filter
             col.IconSet = OfficeOpenXml.ConditionalFormatting.eExcelconditionalFormattingIconsSetType.ThreeTrafficLights1;
             col.IconId = 1;
         }
+
+        [TestMethod]
+        public void ValuesFilterBlankOnlyTest()
+        {
+            var pck = OpenPackage("AutofilterValuesWithBlanks.xlsx", true);
+            var ws = pck.Workbook.Worksheets.Add("Values");
+            LoadTestdata(ws);
+
+            ws.Cells["B3"].Value = null;
+            ws.Cells["B10"].Value = "";
+
+            ws.Cells["C3"].Value = "";
+
+            ws.AutoFilterAddress = ws.Cells["A1:D100"];
+            var col = ws.AutoFilter.Columns.AddValueFilterColumn(1);
+            col.Filters.Blank = true;
+
+            var col2 = ws.AutoFilter.Columns.AddValueFilterColumn(2);
+            col2.Filters.Blank = true;
+
+            ws.AutoFilter.ApplyFilter();
+
+            Assert.IsFalse(ws.Row(3).Hidden);
+
+            for (int i = 2; i < 100; i++)
+            {
+                if (i != 3)
+                {
+                    Assert.IsTrue(ws.Row(i).Hidden);
+                }
+            }
+
+            SaveAndCleanup(pck);
+        }
     }
 }

--- a/src/EPPlusTest/Filter/ValueFilterTest.cs
+++ b/src/EPPlusTest/Filter/ValueFilterTest.cs
@@ -33,6 +33,7 @@ using OfficeOpenXml;
 using OfficeOpenXml.Filter;
 using System.Globalization;
 using System.Threading;
+using System.Linq;
 
 namespace EPPlusTest.Filter
 {
@@ -258,6 +259,64 @@ namespace EPPlusTest.Filter
 
             Thread.CurrentThread.CurrentCulture= currentCulture;
         }
+        [TestMethod]
+        public void ValuesFilterAddingEmpty()
+        {
+            using (var package = OpenPackage("AutoFilterAddEmpty.xlsx", true))
+            {
+                var ws = package.Workbook.Worksheets.Add("NewAutoFilter");
 
+                ExcelRangeBase range = ws.Cells["A1:A5"];
+
+                ws.Cells["A1:E5"].Formula = "Row()";
+
+                ws.Cells["A1:C3"].Value = null;
+
+                range.AutoFilter = true;
+                var colCompany = ws.AutoFilter.Columns.AddValueFilterColumn(0);
+                colCompany.Filters.Add("");
+                ws.AutoFilter.ApplyFilter(true);
+
+                Assert.AreEqual(0, colCompany.Filters.Count());
+                Assert.IsTrue(colCompany.Filters.Blank);
+
+                Assert.IsTrue(ws.Row(4).Hidden);
+                Assert.IsTrue(ws.Row(5).Hidden);
+                for (int i = 1; i < 4; i++)
+                {
+                    Assert.IsFalse(ws.Row(i).Hidden);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ValuesFilterAddingNullItem()
+        {
+            using (var package = OpenPackage("autofilterwithNulls.xlsx", true))
+            {
+                var ws = package.Workbook.Worksheets.Add("NewAutoFilter");
+
+                ExcelRangeBase range = ws.Cells["A1:E5"];
+
+                ws.Cells["A1:E5"].Formula = "Row()";
+
+                ws.Cells["A1:C3"].Value = null;
+
+                range.AutoFilter = true;
+                var colCompany = ws.AutoFilter.Columns.AddValueFilterColumn(2);
+                colCompany.Filters.Add(new ExcelFilterValueItem(null));
+                ws.AutoFilter.ApplyFilter(true);
+
+                Assert.AreEqual(0, colCompany.Filters.Count());
+                Assert.IsTrue(colCompany.Filters.Blank);
+
+                Assert.IsTrue(ws.Row(4).Hidden);
+                Assert.IsTrue(ws.Row(5).Hidden);
+                for (int i = 1; i < 4; i++)
+                {
+                    Assert.IsFalse(ws.Row(i).Hidden);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Setting blank or string empty value autofilter no longer results in corrupt worksheets.

Same as  #1179 for develop6