### PR TITLE
#1187 - added support for negation of single cell named values

### DIFF
--- a/src/EPPlus/FormulaParsing/ExpressionGraph/ExpressionFactory.cs
+++ b/src/EPPlus/FormulaParsing/ExpressionGraph/ExpressionFactory.cs
@@ -73,7 +73,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
             }
             if (token.TokenTypeIsSet(TokenType.NameValue))
             {
-                return new NamedValueExpression(token.Value, _parsingContext);
+                return new NamedValueExpression(token.Value, _parsingContext, token.IsNegated);
             }
             return new StringExpression(token.Value);
         }

--- a/src/EPPlusTest/FormulaParsing/NamedRangeNegationTests.cs
+++ b/src/EPPlusTest/FormulaParsing/NamedRangeNegationTests.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using OfficeOpenXml;
+
+namespace EPPlusTest.FormulaParsing
+{
+    [TestClass]
+    public class NamedRangeNegationTests
+    {
+        [TestMethod]
+        public void MinusNamedRange()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                sheet1.Cells["A1"].Value = 123456;
+
+                sheet1.Names.Add("MyRange", sheet1.Cells["A1"]);
+
+                sheet1.Cells["C3"].Formula = "-MyRange";
+
+                pck.Workbook.Calculate();
+
+                Assert.AreEqual(-123456, sheet1.Cells["C3"].GetValue<double>(), 1E-5); //ERROR: evaluates to 123456
+            }
+        }
+        [TestMethod]
+        public void MinusNamedRangePlusNamedRange()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                sheet1.Cells["A1"].Value = 123456;
+                sheet1.Cells["B1"].Value = 3;
+
+                sheet1.Names.Add("MyRange", sheet1.Cells["A1"]);
+                sheet1.Names.Add("Another", sheet1.Cells["B1"]);
+
+                sheet1.Cells["C3"].Formula = "-MyRange+Another";
+
+                pck.Workbook.Calculate();
+
+                Assert.AreEqual(-123453, sheet1.Cells["C3"].GetValue<double>(), 1E-5); //ERROR: evaluates to 123459
+            }
+        }
+    }
+}


### PR DESCRIPTION
v6 didn't support negation of Named Values, ex:` -MyNamedValue`. Note that this fix only works on single cell values, it is not possible to replace Excels behaviour for multi cell ranges since v6 only returns a reference to the named range instead of a copy of it as in v7.