### PR TITLE
#1187 - improved handling of negation of ranges in v7

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Operators/Operator.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Operators/Operator.cs
@@ -31,16 +31,16 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
     [DebuggerDisplay("Operator: {GetOperator()}")]
     public class Operator : IOperator
     {
-        private const int PrecedenceColon = 0;
-        private const int PrecedenceIntersect = 1;
-        private const int PrecedencePercent = 3;
-        private const int PrecedenceExp = 4;
-        private const int PrecedenceMultiplyDivide = 6;
-        private const int PrecedenceIntegerDivision = 8;
-        private const int PrecedenceModulus = 10;
-        private const int PrecedenceAddSubtract = 12;
-        private const int PrecedenceConcat = 15;
-        private const int PrecedenceComparison = 25;
+        internal const int PrecedenceColon = 0;
+        internal const int PrecedenceIntersect = 1;
+        internal const int PrecedencePercent = 3;
+        internal const int PrecedenceExp = 4;
+        internal const int PrecedenceMultiplyDivide = 6;
+        internal const int PrecedenceIntegerDivision = 8;
+        internal const int PrecedenceModulus = 10;
+        internal const int PrecedenceAddSubtract = 12;
+        internal const int PrecedenceConcat = 15;
+        internal const int PrecedenceComparison = 25;
 
         private Operator() { }
 

--- a/src/EPPlus/FormulaParsing/FormulaExpressions/FormulaExecutor.cs
+++ b/src/EPPlus/FormulaParsing/FormulaExpressions/FormulaExecutor.cs
@@ -75,8 +75,12 @@ namespace OfficeOpenXml.FormulaParsing.FormulaExpressions
                         if (operatorStack.Count > 0)
                         {
                             var o2 = operatorStack.Peek();
-                            while (o2.TokenType == TokenType.Operator &&
-                                operators[o2.Value].Precedence <= operators[token.Value].Precedence && token.TokenType != TokenType.Negator)
+                            while ((o2.TokenType == TokenType.Operator &&
+                                operators[o2.Value].Precedence <= operators[token.Value].Precedence) 
+                                || 
+                                (o2.TokenType == TokenType.Negator && 
+                                token.TokenType != TokenType.Negator && 
+                                operators[token.Value].Precedence > Operator.PrecedenceColon))
                             {
                                 expressions.Add(operatorStack.Pop());
                                 if (operatorStack.Count == 0) break;

--- a/src/EPPlusTest/FormulaParsing/NegatorTests.cs
+++ b/src/EPPlusTest/FormulaParsing/NegatorTests.cs
@@ -1,0 +1,181 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using OfficeOpenXml;
+using OfficeOpenXml.FormulaParsing.FormulaExpressions;
+
+namespace EPPlusTest.FormulaParsing
+{
+    [TestClass]
+    public class NegatorTests
+    {
+        [TestMethod]
+        public void NegateNamedRange()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                sheet1.Cells["A1"].Value = 123456;
+
+                sheet1.Names.Add("MyRange", sheet1.Cells["A1"]);
+
+                sheet1.Cells["C3"].Formula = "-MyRange";
+
+                pck.Workbook.Calculate();
+
+                Assert.AreEqual(-123456, sheet1.Cells["C3"].GetValue<double>(), 1E-5); //ERROR: evaluates to 123456
+            }
+        }
+        [TestMethod]
+        public void NegateNamedRangePlusNamedRange()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                sheet1.Cells["A1"].Value = 123456;
+                sheet1.Cells["B1"].Value = 3;
+
+                sheet1.Names.Add("MyRange", sheet1.Cells["A1"]);
+                sheet1.Names.Add("Another", sheet1.Cells["B1"]);
+
+                sheet1.Cells["C3"].Formula = "-MyRange+Another";
+
+                pck.Workbook.Calculate();
+
+                Assert.AreEqual(-123453, sheet1.Cells["C3"].GetValue<double>(), 1E-5); //ERROR: evaluates to 123459
+            }
+        }
+
+        [TestMethod]
+        public void NegateNamedRangePlusNamedRange_WithParenthesis()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                sheet1.Cells["A1"].Value = 123456;
+                sheet1.Cells["B1"].Value = 3;
+
+                sheet1.Names.Add("MyRange", sheet1.Cells["A1"]);
+                sheet1.Names.Add("Another", sheet1.Cells["B1"]);
+
+                sheet1.Cells["C3"].Formula = "-(MyRange+Another)";
+
+                pck.Workbook.Calculate();
+
+                Assert.AreEqual(-123459, sheet1.Cells["C3"].GetValue<double>(), 1E-5); //ERROR: evaluates to 123459
+            }
+        }
+
+        [TestMethod]
+        public void DoubleNegateNamedRangePlusNamedRange_WithParenthesis()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                sheet1.Cells["A1"].Value = 123456;
+                sheet1.Cells["B1"].Value = 3;
+
+                sheet1.Names.Add("MyRange", sheet1.Cells["A1"]);
+                sheet1.Names.Add("Another", sheet1.Cells["B1"]);
+
+                sheet1.Cells["C3"].Formula = "--(MyRange+Another)";
+
+                pck.Workbook.Calculate();
+
+                Assert.AreEqual(123459, sheet1.Cells["C3"].GetValue<double>(), 1E-5); //ERROR: evaluates to 123459
+            }
+        }
+
+        [TestMethod]
+        public void NegateMultiCellNamedRange()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                sheet1.Cells["A1"].Value = 1;
+                sheet1.Cells["B1"].Value = 2;
+                sheet1.Cells["A2"].Value = 3;
+                sheet1.Cells["B2"].Value = "abc";
+
+                sheet1.Names.Add("MyRange", sheet1.Cells["A1:B2"]);
+
+                sheet1.Cells["E4"].Formula = "-MyRange";
+
+                pck.Workbook.Calculate();
+
+                Assert.AreEqual(-1, sheet1.Cells["E4"].GetValue<double>(), 1E-5);
+                Assert.AreEqual(-2, sheet1.Cells["F4"].GetValue<double>(), 1E-5);
+                Assert.AreEqual(-3, sheet1.Cells["E5"].GetValue<double>(), 1E-5);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Value), sheet1.Cells["F5"].Value);
+            }
+        }
+
+        [TestMethod]
+        public void NegateMultiCellRange()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                sheet1.Cells["A1"].Value = 1;
+                sheet1.Cells["B1"].Value = 2;
+                sheet1.Cells["A2"].Value = 3;
+                sheet1.Cells["B2"].Value = 4;
+
+                sheet1.Cells["E4"].Formula = "-A1:B2";
+
+                pck.Workbook.Calculate();
+
+                Assert.AreEqual(-1, sheet1.Cells["E4"].GetValue<double>(), 1E-5);
+                Assert.AreEqual(-2, sheet1.Cells["F4"].GetValue<double>(), 1E-5);
+                Assert.AreEqual(-3, sheet1.Cells["E5"].GetValue<double>(), 1E-5);
+                Assert.AreEqual(-4, sheet1.Cells["F5"].GetValue<double>(), 1E-5);
+            }
+        }
+
+        [TestMethod]
+        public void DoubleNegateMultiCellRange()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                sheet1.Cells["A1"].Value = 1;
+                sheet1.Cells["B1"].Value = 2;
+                sheet1.Cells["A2"].Value = 3;
+                sheet1.Cells["B2"].Value = 4;
+
+                sheet1.Cells["E4"].Formula = "--A1:B2";
+
+                pck.Workbook.Calculate();
+
+                Assert.AreEqual(1, sheet1.Cells["E4"].GetValue<double>(), 1E-5);
+                Assert.AreEqual(2, sheet1.Cells["F4"].GetValue<double>(), 1E-5);
+                Assert.AreEqual(3, sheet1.Cells["E5"].GetValue<double>(), 1E-5);
+                Assert.AreEqual(4, sheet1.Cells["F5"].GetValue<double>(), 1E-5);
+            }
+        }
+
+        [TestMethod]
+        public void NegateMultiCellRange_WithString()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                sheet1.Cells["A1"].Value = 1;
+                sheet1.Cells["B1"].Value = 2;
+                sheet1.Cells["A2"].Value = 3;
+                sheet1.Cells["B2"].Value = "abc";
+
+                sheet1.Cells["E4"].Formula = "-A1:B2";
+
+                pck.Workbook.Calculate();
+
+                Assert.AreEqual(-1, sheet1.Cells["E4"].GetValue<double>(), 1E-5);
+                Assert.AreEqual(-2, sheet1.Cells["F4"].GetValue<double>(), 1E-5);
+                Assert.AreEqual(-3, sheet1.Cells["E5"].GetValue<double>(), 1E-5);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Value), sheet1.Cells["F5"].Value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Support for negations as below:

-A1:B2
-MyNamedRange
--(A1:B2+MyNamedRange)

@JanKallman have a look here https://github.com/EPPlusSoftware/EPPlus/blob/namedrange-negate-v7/src/EPPlus/FormulaParsing/FormulaExpressions/NamedValueExpression.cs#L69
Is it correct to return an AddressCompileResult with the original range's address?