### PR TITLE
Bug/s542 Pivot table delete and copy fix

### DIFF
--- a/docs/articles/fixedissues.md
+++ b/docs/articles/fixedissues.md
@@ -1,4 +1,11 @@
 ﻿# Features / Fixed issues - EPPlus 7
+## Version 7.0.4
+### Minor Features
+* Added follow dependency-chain option which allows calculating the given cells without calculating dependent cells
+* 
+### Fixed issues 
+* Deleting pivot tables sometimes did not clear their pivotcaches.
+
 ## Version 7.0.3
 ### Minor Features
 * Added Alignment and Protection properties to ExcelDxfStyle - Affects Table and Pivot Table Stylings

--- a/src/EPPlus/Table/PivotTable/ExcelPivotTableCollection.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotTableCollection.cs
@@ -12,6 +12,7 @@
  *************************************************************************************************/
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Xml;
 
@@ -239,7 +240,24 @@ namespace OfficeOpenXml.Table.PivotTable
             }
             var pck = _ws._package.ZipPackage;
 
-            PivotTable.CacheDefinition._cacheReference._pivotTables.Remove(PivotTable);
+            var cacheReference = PivotTable.CacheDefinition._cacheReference;
+
+            cacheReference._pivotTables.Remove(PivotTable);
+
+            if (cacheReference._pivotTables.Count == 0)
+            {
+                var cacheAddress = cacheReference.GetSourceAddress();
+                var pivotCache = _ws.Workbook._pivotTableCaches[cacheAddress];
+                pivotCache.PivotCaches.Remove(cacheReference);
+                PivotTable.CacheDefinition._cacheReference.Delete();
+
+                if (pivotCache.PivotCaches.Count == 0)
+                {
+                    _ws.Workbook._pivotTableIds.Remove(cacheReference.CacheDefinitionUri);
+                    _ws.Workbook._pivotTableCaches.Remove(cacheAddress);
+                }
+            }
+
             pck.DeletePart(PivotTable.Part.Uri);
 
             _pivotTables.Remove(PivotTable);

--- a/src/EPPlus/Table/PivotTable/PivotArea/ExcelPivotAreaReference.cs
+++ b/src/EPPlus/Table/PivotTable/PivotArea/ExcelPivotAreaReference.cs
@@ -81,7 +81,7 @@ namespace OfficeOpenXml.Table.PivotTable
                 var items = Field.Items;
                 foreach (PivotItemReference r in Items)
                 {
-                    if (r.Index >= 0 && r.Index < items.Count && r.Value.Equals(items[r.Index]))
+                    if (r.Index >= 0 && r.Index < items.Count && r.Value != null && r.Value.Equals(items[r.Index]))
                     {
                         var n = (XmlElement)CreateNode("d:x", false, true);
                         n.SetAttribute("v", r.Index.ToString(CultureInfo.InvariantCulture));

--- a/src/EPPlus/Table/PivotTable/PivotArea/ExcelPivotAreaReference.cs
+++ b/src/EPPlus/Table/PivotTable/PivotArea/ExcelPivotAreaReference.cs
@@ -81,7 +81,7 @@ namespace OfficeOpenXml.Table.PivotTable
                 var items = Field.Items;
                 foreach (PivotItemReference r in Items)
                 {
-                    if (r.Index >= 0 && r.Index < items.Count && r.Value != null && r.Value.Equals(items[r.Index]))
+                    if (r.Index >= 0 && r.Index < items.Count && r.Value.Equals(items[r.Index]))
                     {
                         var n = (XmlElement)CreateNode("d:x", false, true);
                         n.SetAttribute("v", r.Index.ToString(CultureInfo.InvariantCulture));

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -5977,43 +5977,18 @@ namespace EPPlusTest
         [TestMethod]
         public void s542_2()
         {
-            //Inputs
-            string sourcePath = @"C:\Users\OssianEdström\Downloads\Source File.xlsx";
-            string destPath = @"C:\Users\OssianEdström\Downloads\Dest File.xlsx";
             string copySheet = "Summary";
             string destSheet = "Pivot Data";
 
-            //Outputs
-            bool success = false;
-            string exc = "";
+            ExcelPackage Destinationpackage = OpenTemplatePackage("s542_Dest_File.xlsx");
+            var sheet = Destinationpackage.Workbook.Worksheets.GetByName(destSheet);
+            Destinationpackage.Workbook.Worksheets.Delete(destSheet);
 
-            try
-            {
-                ExcelPackage Destinationpackage = new ExcelPackage(destPath);
-                var sheet = Destinationpackage.Workbook.Worksheets.GetByName(destSheet);
-                Destinationpackage.Workbook.Worksheets.Delete(destSheet);
+            ExcelPackage Sourcepackage = OpenTemplatePackage("s542_Source_File.xlsx");
+            ExcelWorksheet Sourceworksheet = Sourcepackage.Workbook.Worksheets[copySheet];
+            Destinationpackage.Workbook.Worksheets.Add(destSheet, Sourceworksheet);
 
-                ExcelPackage Sourcepackage = new ExcelPackage(sourcePath);
-                ExcelWorksheet Sourceworksheet = Sourcepackage.Workbook.Worksheets[copySheet];
-                Destinationpackage.Workbook.Worksheets.Add(destSheet, Sourceworksheet);
-                //Destinationpackage.Workbook.Worksheets.Add("NewSheet.xlsx");
-
-                Destinationpackage.Save();
-                Destinationpackage.Dispose();
-                Sourcepackage.Dispose();
-                success = true;
-            }
-
-            catch (Exception e)
-            {
-                exc = "Failed. " + e.ToString();
-                success = false;
-            }
-
-            finally
-            {
-                System.GC.Collect();
-            }
+            SaveAndCleanup(Destinationpackage);
         }
     }
 }

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -5974,5 +5974,46 @@ namespace EPPlusTest
                 SaveAndCleanup(p);
             }
         }
+        [TestMethod]
+        public void s542_2()
+        {
+            //Inputs
+            string sourcePath = @"C:\Users\OssianEdström\Downloads\Source File.xlsx";
+            string destPath = @"C:\Users\OssianEdström\Downloads\Dest File.xlsx";
+            string copySheet = "Summary";
+            string destSheet = "Pivot Data";
+
+            //Outputs
+            bool success = false;
+            string exc = "";
+
+            try
+            {
+                ExcelPackage Destinationpackage = new ExcelPackage(destPath);
+                var sheet = Destinationpackage.Workbook.Worksheets.GetByName(destSheet);
+                Destinationpackage.Workbook.Worksheets.Delete(destSheet);
+
+                ExcelPackage Sourcepackage = new ExcelPackage(sourcePath);
+                ExcelWorksheet Sourceworksheet = Sourcepackage.Workbook.Worksheets[copySheet];
+                Destinationpackage.Workbook.Worksheets.Add(destSheet, Sourceworksheet);
+                //Destinationpackage.Workbook.Worksheets.Add("NewSheet.xlsx");
+
+                Destinationpackage.Save();
+                Destinationpackage.Dispose();
+                Sourcepackage.Dispose();
+                success = true;
+            }
+
+            catch (Exception e)
+            {
+                exc = "Failed. " + e.ToString();
+                success = false;
+            }
+
+            finally
+            {
+                System.GC.Collect();
+            }
+        }
     }
 }


### PR DESCRIPTION
problem:
Deleting a sheet containing a pivot table would leave its cache causing future copied sheets to use a faulty cache.
Fixed by properly deleting cache and cache files when appropriate.