### PR TITLE
Fix/i1238 slow opening7

### DIFF
--- a/docs/articles/fixedissues.md
+++ b/docs/articles/fixedissues.md
@@ -1,4 +1,8 @@
 ﻿# Features / Fixed issues - EPPlus 7
+## Version 7.0.6
+### Fixed issues 
+* Improved performance when opening files with many defined names in excel.
+
 ## Version 7.0.5
 ### Fixed issues 
 * Calculating formulas with expressions that had double cell negations, returned an incorrect result.

--- a/src/EPPlus/ExcelWorkbook.cs
+++ b/src/EPPlus/ExcelWorkbook.cs
@@ -1445,9 +1445,12 @@ namespace OfficeOpenXml
 				{
 					var result = x.Name.CompareTo(y.Name);
 
-                    if (result == 0 && x.LocalSheetId != -1 && y.LocalSheetId != -1)
+                    if (result == 0)
 					{
-						result = x.LocalSheet.Name.CompareTo(y.LocalSheet.Name);
+						var nameX = x.LocalSheetId <= -1 ? "" : x.LocalSheet.Name;
+						var nameY = y.LocalSheetId <= -1 ? "" : y.LocalSheet.Name;
+
+                        result = nameX.CompareTo(nameY);
                     }
 					return result; 
 				});

--- a/src/EPPlus/ExcelWorkbook.cs
+++ b/src/EPPlus/ExcelWorkbook.cs
@@ -1398,7 +1398,7 @@ namespace OfficeOpenXml
 		}
 
 		SortedList<string, List<ExcelNamedRange>> sortedNames = new SortedList<string, List<ExcelNamedRange>>();
-        //List<ExcelNamedRange> nameList = new List<ExcelNamedRange>();
+        List<ExcelNamedRange> nameList = new List<ExcelNamedRange>();
 
         private void UpdateDefinedNamesXml()
 		{
@@ -1426,27 +1426,8 @@ namespace OfficeOpenXml
 
 					foreach (ExcelNamedRange name in _names)
 					{
-                        if (sortedNames.ContainsKey(name.Name))
-						{
-							sortedNames[name.Name].Add(name);
-						}
-						else
-						{
-							sortedNames.Add(name.Name, new List<ExcelNamedRange>() { name });
-						}
-						//nameList.Add(name);
+						nameList.Add(name);
 					}
-
-                    //foreach (ExcelNamedRange name in _names)
-                    //{
-
-                    //	XmlElement elem = WorkbookXml.CreateElement("definedName", ExcelPackage.schemaMain);
-                    //	top.AppendChild(elem);
-                    //	elem.SetAttribute("name", name.Name);
-                    //	if (name.IsNameHidden) elem.SetAttribute("hidden", "1");
-                    //	if (!string.IsNullOrEmpty(name.NameComment)) elem.SetAttribute("comment", name.NameComment);
-                    //	SetNameElement(name, elem, nsf);
-                    //}
                 }
 
 				foreach (ExcelWorksheet ws in _worksheets)
@@ -1455,105 +1436,36 @@ namespace OfficeOpenXml
 					{
 						foreach (ExcelNamedRange name in ws.Names)
 						{
-                            if (sortedNames.ContainsKey(name.Name))
-                            {
-                                sortedNames[name.Name].Add(name);
-                            }
-                            else
-                            {
-                                sortedNames.Add(name.Name, new List<ExcelNamedRange>() { name });
-                            }
-                            //nameList.Add(name);
+                            nameList.Add(name);
                         }
 					}
 				}
 
-				//nameList.OrderBy(x => x.Name)/*.ThenBy(x => x.LocalSheet.Name)*/;
-
-				//foreach(var name in nameList)
-				//{
-				//                XmlElement elem = WorkbookXml.CreateElement("definedName", ExcelPackage.schemaMain);
-				//	top.AppendChild(elem);
-				//	elem.SetAttribute("name", name.Name);
-				//                if (name.LocalSheetId != -1)
-				//                {
-				//                    elem.SetAttribute("localSheetId", name.LocalSheetId.ToString());
-				//                }
-				//	if (name.IsNameHidden) elem.SetAttribute("hidden", "1");
-				//	if (!string.IsNullOrEmpty(name.NameComment)) elem.SetAttribute("comment", name.NameComment);
-				//	SetNameElement(name, elem, nsf);
-				//}
-
-				for (int i= 0; i< sortedNames.Keys.Count; i++)
+				nameList.Sort(delegate(ExcelNamedRange x, ExcelNamedRange y) 
 				{
-					var definedName = sortedNames.Keys[i];
-                    sortedNames[definedName] = sortedNames[definedName].OrderBy(x => x.LocalSheet.Name).ToList();
+					var result = x.Name.CompareTo(y.Name);
 
-					foreach(var name in sortedNames[definedName])
+                    if (result == 0 && x.LocalSheetId != -1 && y.LocalSheetId != -1)
 					{
-						XmlElement elem = WorkbookXml.CreateElement("definedName", ExcelPackage.schemaMain);
-						top.AppendChild(elem);
-						elem.SetAttribute("name", name.Name);
-						if (name.LocalSheetId != -1)
-						{
-							elem.SetAttribute("localSheetId", name.LocalSheetId.ToString());
-						}
-						if (name.IsNameHidden) elem.SetAttribute("hidden", "1");
-						if (!string.IsNullOrEmpty(name.NameComment)) elem.SetAttribute("comment", name.NameComment);
-						SetNameElement(name, elem, nsf);
+						result = x.LocalSheet.Name.CompareTo(y.LocalSheet.Name);
+                    }
+					return result; 
+				});
+
+				foreach (var name in nameList)
+				{
+					XmlElement elem = WorkbookXml.CreateElement("definedName", ExcelPackage.schemaMain);
+					top.AppendChild(elem);
+					elem.SetAttribute("name", name.Name);
+					if (name.LocalSheetId != -1)
+					{
+						elem.SetAttribute("localSheetId", name.LocalSheetId.ToString());
 					}
+					if (name.IsNameHidden) elem.SetAttribute("hidden", "1");
+					if (!string.IsNullOrEmpty(name.NameComment)) elem.SetAttribute("comment", name.NameComment);
+					SetNameElement(name, elem, nsf);
 				}
-
-                //bool sortNames = true;
-                //foreach (ExcelWorksheet ws in _worksheets)
-                //{
-                //	if (!(ws is ExcelChartsheet))
-                //	{
-
-                //		foreach (ExcelNamedRange name in ws.Names)
-                //		{
-                //			if (sortNames)
-                //			{
-                //				if (sortedNames.ContainsKey(name.Name))
-                //				{
-                //					sortedNames[name.Name].Add(name);
-
-                //				}
-                //				else
-                //				{
-                //					sortedNames.Add(name.Name, new List<ExcelNamedRange>() { name });
-                //				}
-                //			}
-                //			else
-                //			{
-                //				XmlElement elem = WorkbookXml.CreateElement("definedName", ExcelPackage.schemaMain);
-                //				top.AppendChild(elem);
-                //				elem.SetAttribute("name", name.Name);
-                //				elem.SetAttribute("localSheetId", name.LocalSheetId.ToString());
-                //				if (name.IsNameHidden) elem.SetAttribute("hidden", "1");
-                //				if (!string.IsNullOrEmpty(name.NameComment)) elem.SetAttribute("comment", name.NameComment);
-                //				SetNameElement(name, elem, nsf);
-                //			}
-                //		}
-                //	}
-                //}
-                //if (sortedNames.Count != 0)
-                //{
-                //	foreach (var nameList in sortedNames.Keys)
-                //	{
-                //		foreach (var name in sortedNames[nameList])
-                //		{
-                //			XmlElement elem = WorkbookXml.CreateElement("definedName", ExcelPackage.schemaMain);
-                //			top.AppendChild(elem);
-                //			elem.SetAttribute("name", name.Name);
-                //			elem.SetAttribute("localSheetId", name.LocalSheetId.ToString());
-                //			if (name.IsNameHidden) elem.SetAttribute("hidden", "1");
-                //			if (!string.IsNullOrEmpty(name.NameComment)) elem.SetAttribute("comment", name.NameComment);
-                //			SetNameElement(name, elem, nsf);
-                //		}
-                //	}
-                //}
-            }
+			}
             catch (Exception ex)
 			{
 				throw new Exception("Internal error updating named ranges ", ex);

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -6060,16 +6060,6 @@ namespace EPPlusTest
             }            
         }
         [TestMethod]
-        public void I1238()
-        {
-            using (var p = OpenTemplatePackage("I1238SlowWorkbook.xlsx"))
-            {
-                var ws = p.Workbook.Worksheets[0];
-                ws.Cells["A1"].Value = 1;
-                SaveAndCleanup(p);
-            }
-        }
-        [TestMethod]
         public void VBA_ModuleName()
         {
             using (var p = OpenTemplatePackage("VBAModuleName.xlsm"))

--- a/src/EPPlusTest/Issues.cs
+++ b/src/EPPlusTest/Issues.cs
@@ -6060,6 +6060,16 @@ namespace EPPlusTest
             }            
         }
         [TestMethod]
+        public void I1238()
+        {
+            using (var p = OpenTemplatePackage("I1238SlowWorkbook.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                ws.Cells["A1"].Value = 1;
+                SaveAndCleanup(p);
+            }
+        }
+        [TestMethod]
         public void VBA_ModuleName()
         {
             using (var p = OpenTemplatePackage("VBAModuleName.xlsm"))

--- a/src/EPPlusTest/Issues/DefinedNameIssues.cs
+++ b/src/EPPlusTest/Issues/DefinedNameIssues.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EPPlusTest.Issues
+{
+    [TestClass]
+    public class DefinedNameIssues : TestBase
+    {
+    }
+}

--- a/src/EPPlusTest/Issues/DefinedNameIssues.cs
+++ b/src/EPPlusTest/Issues/DefinedNameIssues.cs
@@ -8,5 +8,15 @@ namespace EPPlusTest.Issues
     [TestClass]
     public class DefinedNameIssues : TestBase
     {
+        [TestMethod]
+        public void I1238()
+        {
+            using (var p = OpenTemplatePackage("I1238SlowWorkbook.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                ws.Cells["A1"].Value = 1;
+                SaveAndCleanup(p);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix for #1238
workbook.xml order of defined names matters for performance when opening the file in Excel. This ensures Epplus saves our defined names in excel format.