### PR TITLE
Resolved reading and writing issues for databar in some cases i1244

### DIFF
--- a/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
+++ b/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
@@ -82,7 +82,7 @@ namespace OfficeOpenXml.ConditionalFormatting
                                 var cf = ExcelConditionalFormattingRuleFactory.Create(new ExcelAddress(address), _ws, xr);
 
                                 //If cf exists in both local and ExtLst spaces
-                                if(cf.IsExtLst)
+                                if(cf.IsExtLst && cf._uid != null)
                                 {
                                     localAndExtDict.Add(cf._uid, cf);
                                 }
@@ -186,13 +186,14 @@ namespace OfficeOpenXml.ConditionalFormatting
                             if (dataBar.LowValue.HasValueOrFormula && xr.Name == "xm:f")
                             {
                                 xr.Read();
-                                if (dataBar.LowValue.Type == eExcelConditionalFormattingValueObjectType.Formula)
+                                var content = xr.ReadContentAsString();
+                                if (double.TryParse(content, NumberStyles.Any, CultureInfo.InvariantCulture, out double result))
                                 {
-                                    dataBar.LowValue.Formula = xr.ReadContentAsString();
+                                    dataBar.LowValue.Value = result;
                                 }
                                 else
                                 {
-                                    dataBar.LowValue.Value = double.Parse(xr.ReadContentAsString(), CultureInfo.InvariantCulture);
+                                    dataBar.LowValue.Formula = content;
                                 }
                                 xr.Read();
                                 xr.Read();
@@ -207,13 +208,14 @@ namespace OfficeOpenXml.ConditionalFormatting
                             if (dataBar.HighValue.HasValueOrFormula && xr.Name == "xm:f")
                             {
                                 xr.Read();
-                                if (dataBar.HighValue.Type == eExcelConditionalFormattingValueObjectType.Formula)
+                                var content = xr.ReadContentAsString();
+                                if (double.TryParse(content, NumberStyles.Any, CultureInfo.InvariantCulture, out double result))
                                 {
-                                    dataBar.HighValue.Formula = xr.ReadContentAsString();
+                                    dataBar.HighValue.Value = result;
                                 }
                                 else
                                 {
-                                    dataBar.HighValue.Value = double.Parse(xr.ReadContentAsString(), CultureInfo.InvariantCulture);
+                                    dataBar.HighValue.Formula = content;
                                 }
                                 xr.Read();
                                 xr.Read();

--- a/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
+++ b/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
@@ -187,7 +187,8 @@ namespace OfficeOpenXml.ConditionalFormatting
                             {
                                 xr.Read();
                                 var content = xr.ReadContentAsString();
-                                if (double.TryParse(content, NumberStyles.Any, CultureInfo.InvariantCulture, out double result))
+                                if (double.TryParse(content, NumberStyles.Any, CultureInfo.InvariantCulture, out double result)
+                                    && dataBar.LowValue.Type != eExcelConditionalFormattingValueObjectType.Formula)
                                 {
                                     dataBar.LowValue.Value = result;
                                 }
@@ -209,7 +210,8 @@ namespace OfficeOpenXml.ConditionalFormatting
                             {
                                 xr.Read();
                                 var content = xr.ReadContentAsString();
-                                if (double.TryParse(content, NumberStyles.Any, CultureInfo.InvariantCulture, out double result))
+                                if (double.TryParse(content, NumberStyles.Any, CultureInfo.InvariantCulture, out double result)
+                                    && dataBar.HighValue.Type != eExcelConditionalFormattingValueObjectType.Formula)
                                 {
                                     dataBar.HighValue.Value = result;
                                 }

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingDataBar.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingDataBar.cs
@@ -104,9 +104,13 @@ internal class ExcelConditionalFormattingDataBar : ExcelConditionalFormattingRul
 
             if(!string.IsNullOrEmpty(xr.GetAttribute("val")))
             {
-                if(highType != eExcelConditionalFormattingValueObjectType.Formula)
+                if (double.TryParse(xr.GetAttribute("val"), out double result))
                 {
-                    HighValue.Value = Double.Parse(xr.GetAttribute("val"), CultureInfo.InvariantCulture);
+                    HighValue.Value = result;
+                }
+                else
+                {
+                    HighValue.Formula = xr.GetAttribute("val");
                 }
             }
 
@@ -116,9 +120,13 @@ internal class ExcelConditionalFormattingDataBar : ExcelConditionalFormattingRul
 
             if (!string.IsNullOrEmpty(xr.GetAttribute("val")))
             {
-                if(lowType != eExcelConditionalFormattingValueObjectType.Formula)
+                if (double.TryParse(xr.GetAttribute("val"), out double result))
                 {
-                    LowValue.Value = Double.Parse(xr.GetAttribute("val"), CultureInfo.InvariantCulture);
+                    LowValue.Value = result;
+                }
+                else
+                {
+                    LowValue.Formula = xr.GetAttribute("val");
                 }
             }
 
@@ -130,6 +138,13 @@ internal class ExcelConditionalFormattingDataBar : ExcelConditionalFormattingRul
 
             //enter databar exit node ->(local) extLst -> ext -> id
             xr.Read();
+            if (xr.LocalName != "extLst")
+            {
+                _uid = null;
+                //Databar is local only/incorrectly written
+                //by an earlier version of Epplus. Escape.
+                return;
+            }
             xr.Read();
             xr.Read();
 

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingDataBar.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingDataBar.cs
@@ -104,7 +104,8 @@ internal class ExcelConditionalFormattingDataBar : ExcelConditionalFormattingRul
 
             if(!string.IsNullOrEmpty(xr.GetAttribute("val")))
             {
-                if (double.TryParse(xr.GetAttribute("val"), out double result))
+                if (double.TryParse(xr.GetAttribute("val"), out double result) && 
+                    HighValue.Type != eExcelConditionalFormattingValueObjectType.Formula)
                 {
                     HighValue.Value = result;
                 }
@@ -120,7 +121,8 @@ internal class ExcelConditionalFormattingDataBar : ExcelConditionalFormattingRul
 
             if (!string.IsNullOrEmpty(xr.GetAttribute("val")))
             {
-                if (double.TryParse(xr.GetAttribute("val"), out double result))
+                if (double.TryParse(xr.GetAttribute("val"), out double result) &&
+                    LowValue.Type != eExcelConditionalFormattingValueObjectType.Formula)
                 {
                     LowValue.Value = result;
                 }

--- a/src/EPPlus/Core/Worksheet/XmlWriter/WorksheetXmlWriter.cs
+++ b/src/EPPlus/Core/Worksheet/XmlWriter/WorksheetXmlWriter.cs
@@ -1193,22 +1193,22 @@ namespace OfficeOpenXml.Core.Worksheet.XmlWriter
                                 cache.Append("/>");
                             }
 
-                            if(dataBar.BorderColor != null)
+                            if (dataBar.BorderColor != null && dataBar.Border == true)
                             {
                                 WriteDxfColor(prefix, cache, dataBar.BorderColor, "borderColor");
                             }
 
-                            if(dataBar.NegativeFillColor != null) 
+                            if (dataBar.NegativeFillColor != null && dataBar.NegativeBarColorSameAsPositive == false)
                             {
                                 WriteDxfColor(prefix, cache, dataBar.NegativeFillColor, "negativeFillColor");
                             }
 
-                            if (dataBar.NegativeBorderColor != null)
+                            if (dataBar.NegativeBorderColor != null && dataBar.NegativeBarColorSameAsPositive == false && dataBar.Border == true)
                             {
                                 WriteDxfColor(prefix, cache, dataBar.NegativeBorderColor, "negativeBorderColor");
                             }
 
-                            if (dataBar.AxisColor != null)
+                            if (dataBar.AxisColor != null && dataBar.AxisPosition != eExcelDatabarAxisPosition.None)
                             {
                                 WriteDxfColor(prefix, cache, dataBar.AxisColor, "axisColor");
                             }

--- a/src/EPPlusTest/ConditionalFormatting/CF_DatabarTests.cs
+++ b/src/EPPlusTest/ConditionalFormatting/CF_DatabarTests.cs
@@ -362,8 +362,9 @@ namespace EPPlusTest.ConditionalFormatting
                 databar.Border = true;
                 databar.Direction = eDatabarDirection.RightToLeft;
 
-                //Ensure we read and write the color even if its not currently applied
-                databar.NegativeFillColor.Color = Color.DarkBlue;
+                //Do not do this. Excel will read wrong colors on other nodes in some cases.
+                /*////Ensure we read and write the color even if its not currently applied
+                //databar.NegativeFillColor.Color = Color.DarkBlue;*/
 
                 databar.NegativeBarColorSameAsPositive = true;
                 databar.NegativeBarBorderColorSameAsPositive = false;
@@ -382,8 +383,8 @@ namespace EPPlusTest.ConditionalFormatting
                 Assert.AreEqual(true, bar.NegativeBarColorSameAsPositive);
                 Assert.AreEqual(false, bar.NegativeBarBorderColorSameAsPositive);
                 Assert.AreEqual(eExcelDatabarAxisPosition.Middle, bar.AxisPosition);
-                //Ensure we read and write the color even if its not currently applied
-                Assert.AreEqual(Color.FromArgb(255, Color.DarkBlue), bar.NegativeFillColor.Color);
+                ////Do not do this
+                //*Assert.AreEqual(Color.FromArgb(255, Color.DarkBlue), bar.NegativeFillColor.Color);*/
             }
         }
     }

--- a/src/EPPlusTest/Issues/ConditionalFormattingIssues.cs
+++ b/src/EPPlusTest/Issues/ConditionalFormattingIssues.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EPPlusTest.Issues
+{
+    [TestClass]
+    public class ConditionalFormattingIssues : TestBase
+    {
+        [TestMethod]
+        public void DatabarNegativesAndFormulasTest()
+        {
+            var package = OpenTemplatePackage("i1244Databars.xlsm");
+            Assert.IsNotNull(package.Workbook);
+
+            SaveAndCleanup(package);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #1244 
We had next to no handling for formulas in setting databar high and low via formulas and addresses rather than values.

Both reading and writing was changed to appropriately read and save this data.

In addition we were unable to read faulty files from earlier versions of epplus that did not contain extLst information. We now handle this special case.

Also some nodes are not allowed to be written even as empty nodes by excel dependent on certain booleans doing so caused strange behaviour like using the color of the wrong node on the wrong attribute. bordercolor in fillcolor place e.g. This has been resolved with bool checks.