### PR TITLE
Fix for i1245. Cached expression issue

### DIFF
--- a/src/EPPlus/FormulaParsing/CalculateExtentions.cs
+++ b/src/EPPlus/FormulaParsing/CalculateExtentions.cs
@@ -66,6 +66,7 @@ namespace OfficeOpenXml
 
             var filterInfo = new FilterInfo(workbook);
             workbook.FormulaParser.InitNewCalc(filterInfo);
+
             if (workbook.FormulaParser.Logger != null)
             {
                 var msg = string.Format("Starting formula calculation.");

--- a/src/EPPlus/FormulaParsing/LexicalAnalysis/FormulaAddress.cs
+++ b/src/EPPlus/FormulaParsing/LexicalAnalysis/FormulaAddress.cs
@@ -272,12 +272,6 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
 
         private Dictionary<int, Expression> CloneExpressions(int row, int col)
         {
-            ////ISSUE HERE?
-            //if (row == StartRow && col == StartCol) 
-            //{
-            //    return _compiledExpressions;
-            //};
-            
             var l=new Dictionary<int, Expression>();
             foreach(var expression in _compiledExpressions)
             {

--- a/src/EPPlus/FormulaParsing/LexicalAnalysis/FormulaAddress.cs
+++ b/src/EPPlus/FormulaParsing/LexicalAnalysis/FormulaAddress.cs
@@ -272,7 +272,11 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
 
         private Dictionary<int, Expression> CloneExpressions(int row, int col)
         {
-            if (row == StartRow && col == StartCol) return _compiledExpressions;
+            ////ISSUE HERE?
+            //if (row == StartRow && col == StartCol) 
+            //{
+            //    return _compiledExpressions;
+            //};
             
             var l=new Dictionary<int, Expression>();
             foreach(var expression in _compiledExpressions)

--- a/src/EPPlusTest/FormulaParsing/RangeOperationsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/RangeOperationsTests.cs
@@ -238,5 +238,38 @@ namespace EPPlusTest.FormulaParsing
                 Assert.AreEqual("abcd", result);
             }
         }
+
+        [TestMethod]
+        public void CachedRangeExpressionShouldCalculateTwice()
+        {
+            using (var p = new ExcelPackage())
+            {
+                var workbook = p.Workbook;
+                var sheet = workbook.Worksheets.Add("ws");
+
+                for (int i = 3; i < 9; i++)
+                {
+                    sheet.Cells[i, 2].Value = i - 2.0d;
+                }
+
+                sheet.Cells["C3"].Formula = "B3*2";
+                sheet.Cells["C4:C8"].Formula = "B4*2";
+
+                workbook.Calculate();
+
+                Assert.AreEqual(1.0, sheet.Cells["B3"].Value);
+                Assert.AreEqual(2.0, sheet.Cells["C3"].Value);
+                Assert.AreEqual(2.0, sheet.Cells["B4"].Value);
+                Assert.AreEqual(4.0, sheet.Cells["C4"].Value);
+
+                sheet.Cells["B3"].Value = 300.0;
+                sheet.Cells["B4"].Value = 300.0;
+
+                workbook.Calculate();
+
+                Assert.AreEqual(600.0, sheet.Cells["C3"].Value);
+                Assert.AreEqual(600.0, sheet.Cells["C4"].Value);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -5,6 +5,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using OfficeOpenXml;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
+using OfficeOpenXml.FormulaParsing;
+using System.IO;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Information;
 
 namespace EPPlusTest.Issues
 {
@@ -88,5 +92,57 @@ namespace EPPlusTest.Issues
 				SaveAndCleanup(p);
 			}
 		}
-	}
+        [TestMethod]
+        public void i1244()
+        {
+            using (var p = OpenTemplatePackage("i1245.xlsx"))
+            {
+                var wbk = p.Workbook;
+                var sht = wbk.Worksheets["TestSheet"];
+
+                // Call calculate
+                wbk.Calculate();
+
+                // Check everything is initially in order
+                Assert.AreEqual(1.0, sht.Cells["B3"].Value);
+                Assert.AreEqual(2.0, sht.Cells["C3"].Value);
+                Assert.AreEqual(2.0, sht.Cells["B4"].Value);
+                Assert.AreEqual(4.0, sht.Cells["C4"].Value);
+
+                // Update the value of two cells
+                sht.Cells["B3"].Value = 500.0;
+                sht.Cells["B4"].Value = 500.0;
+                sht.Cells["B5"].Value = 600.0;
+                sht.Cells["B6"].Value = 700.0;
+                sht.Cells["B7"].Value = 800.0;
+
+
+                var form1 = sht.Cells["C3"].Formula;
+                var form2 = sht.Cells["C4"].Formula;
+
+                //// Output from the logger will be written to the following file
+                //var logfile = new FileInfo(@"C:\epplusTest\logfile.txt");
+                //// Attach the logger before the calculation is performed.
+                //p.Workbook.FormulaParserManager.AttachLogger(logfile);
+
+                // Call calculate again
+                wbk.Calculate();
+
+                //wbk.Calculate(new ExcelCalculationOption() { CacheExpressions = false });
+
+                //p.Workbook.FormulaParserManager.DetachLogger();
+
+				//for(int i = 3; i < 8; i++)
+				//{
+				//	var result = sht.Cells[i, 3].Value;
+    //            }
+
+                // C3 and C4 have formulae in them which double the value to their left
+                Assert.AreEqual(1000.0, sht.Cells["C3"].Value);
+                Assert.AreEqual(1000.0, sht.Cells["C4"].Value);
+
+                SaveAndCleanup(p);
+            }
+        }
+    }
 }

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -112,32 +112,13 @@ namespace EPPlusTest.Issues
                 // Update the value of two cells
                 sht.Cells["B3"].Value = 500.0;
                 sht.Cells["B4"].Value = 500.0;
-                sht.Cells["B5"].Value = 600.0;
-                sht.Cells["B6"].Value = 700.0;
-                sht.Cells["B7"].Value = 800.0;
 
 
                 var form1 = sht.Cells["C3"].Formula;
                 var form2 = sht.Cells["C4"].Formula;
 
-                //// Output from the logger will be written to the following file
-                //var logfile = new FileInfo(@"C:\epplusTest\logfile.txt");
-                //// Attach the logger before the calculation is performed.
-                //p.Workbook.FormulaParserManager.AttachLogger(logfile);
-
-                // Call calculate again
                 wbk.Calculate();
 
-                //wbk.Calculate(new ExcelCalculationOption() { CacheExpressions = false });
-
-                //p.Workbook.FormulaParserManager.DetachLogger();
-
-				//for(int i = 3; i < 8; i++)
-				//{
-				//	var result = sht.Cells[i, 3].Value;
-    //            }
-
-                // C3 and C4 have formulae in them which double the value to their left
                 Assert.AreEqual(1000.0, sht.Cells["C3"].Value);
                 Assert.AreEqual(1000.0, sht.Cells["C4"].Value);
 


### PR DESCRIPTION
A cached expression on the first address of a range expression was causing issues as we returned it instead of creating a new cloned expression.