### PR TITLE
TableTotalBecomesDiv0

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Operators/Operators.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Operators/Operators.cs
@@ -38,4 +38,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
         Colon,
         Intersect
     }
+
+    public enum LimitedOperators
+    {
+        Equals = Operators.Equals,
+        GreaterThan = Operators.GreaterThan,
+        GreaterThanOrEqual = Operators.GreaterThanOrEqual,
+        LessThan = Operators.LessThan,
+        LessThanOrEqual = Operators.LessThanOrEqual,
+        NotEqualTo = Operators.NotEqualTo,
+    }
 }

--- a/src/EPPlus/FormulaParsing/ExcelUtilities/ExpressionEvaluator.cs
+++ b/src/EPPlus/FormulaParsing/ExcelUtilities/ExpressionEvaluator.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.DateAndTime;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Text;
 using OfficeOpenXml.FormulaParsing.Excel.Operators;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using OfficeOpenXml.Utils;
@@ -156,15 +157,15 @@ namespace OfficeOpenXml.FormulaParsing.ExcelUtilities
                     IOperator op;
                     if (OperatorsDict.Instance.TryGetValue(operatorCandidate, out op))
                     {
-                        string right;
-                        if (Enum.IsDefined(typeof(LimitedOperators), (LimitedOperators)op.Operator))
-                        {
-                            right = expression.Replace(operatorCandidate, string.Empty);
-                        }
-                        else
-                        {
-                            right = expression;
-                        }
+                        var right = expression.Replace(operatorCandidate, string.Empty);
+                        //if (Enum.IsDefined(typeof(LimitedOperators), (LimitedOperators)op.Operator))
+                        //{
+                        //    right = expression.Replace(operatorCandidate, string.Empty);
+                        //}
+                        //else
+                        //{
+                        //    right = expression;
+                        //}
                         
                         if (left == null && string.IsNullOrEmpty(right))
                         {
@@ -195,6 +196,10 @@ namespace OfficeOpenXml.FormulaParsing.ExcelUtilities
                         if (leftIsNumeric != rightIsNumeric)
                         {
                             return op.Operator == Operators.NotEqualTo;
+                        }
+                        if (rightIsNumeric == false && Enum.IsDefined(typeof(LimitedOperators), (LimitedOperators)op.Operator) == false)
+                        {
+                            return _wildCardValueMatcher.IsMatch(expression, left) == 0;
                         }
                         return EvaluateOperator(left, right, op);
                     }

--- a/src/EPPlus/FormulaParsing/ExcelUtilities/ExpressionEvaluator.cs
+++ b/src/EPPlus/FormulaParsing/ExcelUtilities/ExpressionEvaluator.cs
@@ -102,6 +102,7 @@ namespace OfficeOpenXml.FormulaParsing.ExcelUtilities
         /// <param name="left">The object to evaluate</param>
         /// <param name="expressions">The expressions to evaluate the object against</param>
         /// <returns>True if any of the supplied expressions evaluates to true</returns>
+        /// <param name="useLimitedOperators">If true only runs operator candidate check on a subset of operators</param>
         public bool Evaluate(object left, IEnumerable<string> expressions)
         {
             if (expressions == null || !expressions.Any()) return false;
@@ -119,6 +120,7 @@ namespace OfficeOpenXml.FormulaParsing.ExcelUtilities
         /// </summary>
         /// <param name="left">The object to evaluate</param>
         /// <param name="expression">The expressions to evaluate the object against</param>
+        /// <param name="useLimitedOperators">If true only runs operator candidate check on a subset of operators</param>
         /// <returns></returns>
         public bool Evaluate(object left, string expression)
         {
@@ -131,6 +133,7 @@ namespace OfficeOpenXml.FormulaParsing.ExcelUtilities
         /// <param name="left">The object to evaluate</param>
         /// <param name="expression">The expressions to evaluate the object against</param>
         /// <param name="convertNumericString">If true and <paramref name="left"/> is a numeric string it will be converted to a number</param>
+        /// <param name="useLimitedOperators">If true only runs operator candidate check on a subset of operators</param>
         /// <returns></returns>
         public bool Evaluate(object left, string expression, bool convertNumericString)
         {
@@ -153,7 +156,16 @@ namespace OfficeOpenXml.FormulaParsing.ExcelUtilities
                     IOperator op;
                     if (OperatorsDict.Instance.TryGetValue(operatorCandidate, out op))
                     {
-                        var right = expression.Replace(operatorCandidate, string.Empty);
+                        string right;
+                        if (Enum.IsDefined(typeof(LimitedOperators), (LimitedOperators)op.Operator))
+                        {
+                            right = expression.Replace(operatorCandidate, string.Empty);
+                        }
+                        else
+                        {
+                            right = expression;
+                        }
+                        
                         if (left == null && string.IsNullOrEmpty(right))
                         {
                             return op.Operator == Operators.Equals;

--- a/src/EPPlus/Table/ExcelTableColumn.cs
+++ b/src/EPPlus/Table/ExcelTableColumn.cs
@@ -82,6 +82,8 @@ namespace OfficeOpenXml.Table
             set
             {
                 var v = ConvertUtil.ExcelEncodeString(value);
+                _tbl.Columns.UpdateColName(Position, v);
+
                 SetXmlNodeString("@name", v);
                 if (_tbl.ShowHeader)
                 {

--- a/src/EPPlus/Table/ExcelTableColumnCollection.cs
+++ b/src/EPPlus/Table/ExcelTableColumnCollection.cs
@@ -97,6 +97,16 @@ namespace OfficeOpenXml.Table
             }
         }
 
+        internal void UpdateColName(int dictIndex, string newName)
+        {
+            var pair = _colNames.FirstOrDefault(t => t.Value == dictIndex);
+            if (pair.Key != null)
+            {
+                _colNames.Remove(pair.Key);
+                _colNames.Add(newName, dictIndex);
+            }
+        }
+
         IEnumerator<ExcelTableColumn> IEnumerable<ExcelTableColumn>.GetEnumerator()
         {
             return _cols.GetEnumerator();

--- a/src/EPPlusTest/FormulaParsing/ExcelUtilities/ExpressionEvaluatorTests.cs
+++ b/src/EPPlusTest/FormulaParsing/ExcelUtilities/ExpressionEvaluatorTests.cs
@@ -95,6 +95,12 @@ namespace EPPlusTest
             Assert.IsFalse(result);
         }
         [TestMethod]
+        public void EvaluateShouldHandleNegativeSignsCorrectly()
+        {
+            var result = _evaluator.Evaluate(" -1", " -1");
+            Assert.IsTrue(result);
+        }
+        [TestMethod]
         public void EvaluateShouldEvaluateToGreaterThanMinusOne ()
         {
             var result = _evaluator.Evaluate(1d, "<>-1");

--- a/src/EPPlusTest/FormulaParsing/ExcelUtilities/ExpressionEvaluatorTests.cs
+++ b/src/EPPlusTest/FormulaParsing/ExcelUtilities/ExpressionEvaluatorTests.cs
@@ -101,6 +101,12 @@ namespace EPPlusTest
             Assert.IsTrue(result);
         }
         [TestMethod]
+        public void EvaluateShouldHandleNegativeSignsCorrectlyWithText()
+        {
+            var result = _evaluator.Evaluate(" -something", " -something");
+            Assert.IsTrue(result);
+        }
+        [TestMethod]
         public void EvaluateShouldEvaluateToGreaterThanMinusOne ()
         {
             var result = _evaluator.Evaluate(1d, "<>-1");

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -155,5 +155,13 @@ namespace EPPlusTest.Issues
                 SaveAndCleanup(p);
             }
         }
+		[TestMethod]
+		public void ExpressionEvaluatorTextPotentialOperatorsShouldNotChangeExpression()
+		{
+			using (var p = new ExcelPackage())
+			{
+				var sheet = p.Workbook.Worksheets.Add("SumIfCheck");
+			}
+		}
     }
 }

--- a/src/EPPlusTest/Issues/NegationIssues.cs
+++ b/src/EPPlusTest/Issues/NegationIssues.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using System.IO;
+using OfficeOpenXml.FormulaParsing;
+
+namespace EPPlusTest.Issues
+{
+    [TestClass]
+    public class NegationIssues : TestBase
+    {
+        [TestMethod]
+        public void s594()
+        {
+            string filePath = "C:\\Users\\OssianEdström\\Downloads\\dg-error.xlsx";//dg.xlsx is ok
+            string sheetName = "dg";
+            using (ExcelPackage package = new ExcelPackage(new FileInfo(filePath)))
+            {
+                ExcelWorksheet worksheet = package.Workbook.Worksheets[sheetName];
+
+                ExcelCalculationOption excelCalculationOption = new ExcelCalculationOption();
+                excelCalculationOption.AllowCircularReferences = true;
+                worksheet.Calculate(excelCalculationOption);
+                var text = worksheet.Cells["A1"].Text;
+
+                package.Save();
+            }
+        }
+    }
+}


### PR DESCRIPTION
When referring to the last renamed column in a table it'd result in div0

For now added a bad solution. DO NOT MERGE until been discussed.