### PR TITLE
Added update to colName when Name property on tableColumn is changed

### DIFF
--- a/docs/articles/fixedissues.md
+++ b/docs/articles/fixedissues.md
@@ -1,4 +1,9 @@
 ﻿# Features / Fixed issues - EPPlus 7
+
+## Version 7.0.8
+### Fixed issues
+* Changing the property ExcelTable.Columns[x].Name after adding a new column would sometimes result in div/0 in totalrow after Calculate()
+
 ## Version 7.0.7
 ### Fixed issues 
 * Implicit intersection in formulas with full row or full column addresses incorrectly calculated to #VALUE!.

--- a/src/EPPlus/Table/ExcelTableColumn.cs
+++ b/src/EPPlus/Table/ExcelTableColumn.cs
@@ -82,7 +82,14 @@ namespace OfficeOpenXml.Table
             set
             {
                 var v = ConvertUtil.ExcelEncodeString(value);
+
+                if(ExistsNode("@name"))
+                {
+                    _tbl.Columns.UpdateColName(Name, v);
+                }
+
                 SetXmlNodeString("@name", v);
+
                 if (_tbl.ShowHeader)
                 {
                     var cellValue = _tbl.WorkSheet.GetValue(_tbl.Address._fromRow, _tbl.Address._fromCol + Position);

--- a/src/EPPlus/Table/ExcelTableColumnCollection.cs
+++ b/src/EPPlus/Table/ExcelTableColumnCollection.cs
@@ -220,5 +220,19 @@ namespace OfficeOpenXml.Table
             }
         }
 
+        internal void UpdateColName(string oldName, string newName)
+        {
+            if(_colNames.ContainsKey(oldName))
+            {
+                var columnIndex = _colNames[oldName];
+                _colNames.Remove(oldName);
+                _colNames.Add(newName, columnIndex);
+            }
+        }
+
+        internal int GetIndexOfColName(string name)
+        {
+            return _colNames[name];
+        }
     }
 }


### PR DESCRIPTION
Updating a columns Name property did not update _colNames in ExcelTableColumnCollection.

Resolved that issue.