### PR TITLE
Ensured evaluator handles text correctly

### DIFF
--- a/src/EPPlus/ExcelStyles.cs
+++ b/src/EPPlus/ExcelStyles.cs
@@ -1000,7 +1000,7 @@ namespace OfficeOpenXml
         {
             if (templateStyle == Table.TableStyles.Custom)
             {
-                throw new ArgumentException("Cant use template style Custom. To use a custom style, please use the ´PivotTableStyles?overload of this method.", nameof(templateStyle));
+                throw new ArgumentException("Cant use template style Custom. To use a custom style, please use the 'PivotTableStyles' overload of this method.", nameof(templateStyle));
             }
 
             var s = CreateTableAndPivotTableStyle(name);
@@ -1017,7 +1017,7 @@ namespace OfficeOpenXml
         {
             if (templateStyle == PivotTableStyles.Custom)
             {
-                throw new ArgumentException("Cant use template style Custom. To use a custom style, please use the ´ExcelTableNamedStyleBase?overload of this method.", nameof(templateStyle));
+                throw new ArgumentException("Cant use template style Custom. To use a custom style, please use the 'ExcelTableNamedStyleBase' overload of this method.", nameof(templateStyle));
             }
 
             var s = CreateTableAndPivotTableStyle(name);
@@ -1087,7 +1087,7 @@ namespace OfficeOpenXml
         {
             if(templateStyle==eSlicerStyle.Custom)
             {
-                throw new ArgumentException("Cant use template style Custom. To use a custom style, please use the ´ExcelSlicerNamedStyle?overload of this method.", nameof(templateStyle));
+                throw new ArgumentException("Cant use template style Custom. To use a custom style, please use the 'ExcelSlicerNamedStyle' overload of this method.", nameof(templateStyle));
             }
             var s = CreateSlicerStyle(name);
             s.SetFromTemplate(templateStyle);

--- a/src/EPPlus/ExcelStyles.cs
+++ b/src/EPPlus/ExcelStyles.cs
@@ -1000,7 +1000,7 @@ namespace OfficeOpenXml
         {
             if (templateStyle == Table.TableStyles.Custom)
             {
-                throw new ArgumentException("Cant use template style Custom. To use a custom style, please use the ´PivotTableStyles´ overload of this method.", nameof(templateStyle));
+                throw new ArgumentException("Cant use template style Custom. To use a custom style, please use the ´PivotTableStyles?overload of this method.", nameof(templateStyle));
             }
 
             var s = CreateTableAndPivotTableStyle(name);
@@ -1017,7 +1017,7 @@ namespace OfficeOpenXml
         {
             if (templateStyle == PivotTableStyles.Custom)
             {
-                throw new ArgumentException("Cant use template style Custom. To use a custom style, please use the ´ExcelTableNamedStyleBase´ overload of this method.", nameof(templateStyle));
+                throw new ArgumentException("Cant use template style Custom. To use a custom style, please use the ´ExcelTableNamedStyleBase?overload of this method.", nameof(templateStyle));
             }
 
             var s = CreateTableAndPivotTableStyle(name);
@@ -1087,7 +1087,7 @@ namespace OfficeOpenXml
         {
             if(templateStyle==eSlicerStyle.Custom)
             {
-                throw new ArgumentException("Cant use template style Custom. To use a custom style, please use the ´ExcelSlicerNamedStyle´ overload of this method.", nameof(templateStyle));
+                throw new ArgumentException("Cant use template style Custom. To use a custom style, please use the ´ExcelSlicerNamedStyle?overload of this method.", nameof(templateStyle));
             }
             var s = CreateSlicerStyle(name);
             s.SetFromTemplate(templateStyle);

--- a/src/EPPlus/FormulaParsing/Excel/Operators/Operators.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Operators/Operators.cs
@@ -38,4 +38,13 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
         Colon,
         Intersect
     }
+    public enum LimitedOperators
+    {
+        Equals = Operators.Equals,
+        GreaterThan = Operators.GreaterThan,
+        GreaterThanOrEqual = Operators.GreaterThanOrEqual,
+        LessThan = Operators.LessThan,
+        LessThanOrEqual = Operators.LessThanOrEqual,
+        NotEqualTo = Operators.NotEqualTo,
+    }
 }

--- a/src/EPPlus/FormulaParsing/ExcelUtilities/ExpressionEvaluator.cs
+++ b/src/EPPlus/FormulaParsing/ExcelUtilities/ExpressionEvaluator.cs
@@ -184,6 +184,10 @@ namespace OfficeOpenXml.FormulaParsing.ExcelUtilities
                         {
                             return op.Operator == Operators.NotEqualTo;
                         }
+                        if (rightIsNumeric == false && Enum.IsDefined(typeof(LimitedOperators), (LimitedOperators)op.Operator) == false)
+                        {
+                            return _wildCardValueMatcher.IsMatch(expression, left) == 0;
+                        }
                         return EvaluateOperator(left, right, op);
                     }
                 }

--- a/src/EPPlusTest/FormulaParsing/ExcelUtilities/ExpressionEvaluatorTests.cs
+++ b/src/EPPlusTest/FormulaParsing/ExcelUtilities/ExpressionEvaluatorTests.cs
@@ -100,6 +100,12 @@ namespace EPPlusTest
             var result = _evaluator.Evaluate(1d, "<>-1");
             Assert.IsTrue(result);
         }
+        [TestMethod]
+        public void NegativeNumerics()
+        {
+            var result = _evaluator.Evaluate(" -1", " -1");
+            Assert.IsTrue(result);
+        }
         #endregion
 
         #region Date tests
@@ -355,6 +361,12 @@ namespace EPPlusTest
             result = _evaluator.Evaluate("b", "< a");
             Assert.IsFalse(result);
         }
-#endregion
+        [TestMethod]
+        public void EvaluateShouldHandleNegativeSignsCorrectlyWithText()
+        {
+            var result = _evaluator.Evaluate(" -something", " -something");
+            Assert.IsTrue(result);
+        }
+        #endregion
     }
 }

--- a/src/EPPlusTest/Issues/LegacyTests/Issues.cs
+++ b/src/EPPlusTest/Issues/LegacyTests/Issues.cs
@@ -6082,6 +6082,5 @@ namespace EPPlusTest
 				SaveAndCleanup(p);
 			}
 		}
-
     }
 }

--- a/src/EPPlusTest/Issues/TableIssues.cs
+++ b/src/EPPlusTest/Issues/TableIssues.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using System.IO;
+using OfficeOpenXml.FormulaParsing;
+
+namespace EPPlusTest.Issues
+{
+    [TestClass]
+    public class TableIssues : TestBase
+    {
+        [TestMethod]
+        public void s594()
+        {
+            using (ExcelPackage package = OpenTemplatePackage("s594.xlsx"))
+            {
+                ExcelWorksheet worksheet = package.Workbook.Worksheets["dg"];
+
+                ExcelCalculationOption excelCalculationOption = new ExcelCalculationOption();
+                excelCalculationOption.AllowCircularReferences = true;
+                worksheet.Calculate(excelCalculationOption);
+
+                Assert.AreNotEqual(0, worksheet.Cells["A1"].Text);
+
+                package.Save();
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
text input such as " -ACat" that had a minus operator in it as criteria in e.g. a sum-if function resulted in faulty calculations.

This has been amended via a check for the limited operators that affect non Numeric inputs.