### PR TITLE
Added handling of extLst start+end node with no content

### DIFF
--- a/src/EPPlus/Core/Worksheet/XmlWriter/ExtLstHelper.cs
+++ b/src/EPPlus/Core/Worksheet/XmlWriter/ExtLstHelper.cs
@@ -15,6 +15,7 @@ using OfficeOpenXml.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace OfficeOpenXml.ExcelXMLWriter
 {
@@ -37,9 +38,19 @@ namespace OfficeOpenXml.ExcelXMLWriter
 
             bool isPlaceHolder = false;
 
-            if (!xml.Substring(start + 1, end - start - 1).Contains("<"))
+            var extNode = xml.Substring(start + 1, end - start - 1);
+            var containsEndNode = extNode.Contains("<");
+            if (containsEndNode == false)
             {
                 isPlaceHolder = true;
+            }
+            else
+            {
+                bool hasNoContent = extNode[extNode.IndexOf('<') - 1] == '>';
+                if(hasNoContent)
+                {
+                    isPlaceHolder = true;
+                }
             }
 
             //If the node isn't just a placeholder

--- a/src/EPPlus/Core/Worksheet/XmlWriter/ExtLstHelper.cs
+++ b/src/EPPlus/Core/Worksheet/XmlWriter/ExtLstHelper.cs
@@ -46,7 +46,8 @@ namespace OfficeOpenXml.ExcelXMLWriter
             }
             else
             {
-                bool hasNoContent = extNode[extNode.IndexOf('<') - 1] == '>';
+                var contentString = extNode.Substring(extNode.IndexOf('>'), extNode.LastIndexOf('<') - extNode.IndexOf('>') - 1);
+                bool hasNoContent = string.IsNullOrEmpty(contentString);
                 if(hasNoContent)
                 {
                     isPlaceHolder = true;


### PR DESCRIPTION
Added handling for placeholder "`<extLst></extLst>`" previous handling assumed placeholder node "`<extLst/>`"
This handles both.