### PR TITLE
#1332 - Intersect operator was replaced with 'isc' when copying cells

### DIFF
--- a/src/EPPlus/ExcelCellBase.cs
+++ b/src/EPPlus/ExcelCellBase.cs
@@ -19,6 +19,7 @@ using OfficeOpenXml.Core;
 using System.Text;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
 using System.Collections.Specialized;
+using OfficeOpenXml.FormulaParsing.Excel.Operators;
 
 namespace OfficeOpenXml
 {
@@ -1008,7 +1009,7 @@ namespace OfficeOpenXml
             {
                 if (tokens == null)
                 {
-                    tokens = tokens = SourceCodeTokenizer.Default.Tokenize(formula);
+                    tokens = SourceCodeTokenizer.Default.Tokenize(formula);
                 }
                 var f = "";
                 //string wsName = "";
@@ -1108,7 +1109,14 @@ namespace OfficeOpenXml
                     }
                     else
                     {
-                        f += t.Value;
+                        if(t.TokenType == TokenType.Operator && t.Value == Operator.IntersectIndicator)
+                        {
+                            f += " ";
+                        }
+                        else
+                        {
+                            f += t.Value;
+                        }
                     }
                 }
                 return f;

--- a/src/EPPlus/FormulaParsing/Excel/Operators/Operator.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Operators/Operator.cs
@@ -41,6 +41,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
         internal const int PrecedenceAddSubtract = 12;
         internal const int PrecedenceConcat = 15;
         internal const int PrecedenceComparison = 25;
+        internal const string IntersectIndicator = "isc";
 
         private Operator() { }
 

--- a/src/EPPlus/FormulaParsing/Excel/Operators/OperatorsDict.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Operators/OperatorsDict.cs
@@ -34,7 +34,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
             Add("<>", Operator.NotEqualsTo);
             Add("&", Operator.Concat);
             Add(":", Operator.Colon);
-            Add("isc", Operator.Intersect);
+            Add(Operator.IntersectIndicator, Operator.Intersect);
         }
 
         private static IDictionary<string, IOperator> _instance;

--- a/src/EPPlus/FormulaParsing/LexicalAnalysis/SourceCodeTokenizer.cs
+++ b/src/EPPlus/FormulaParsing/LexicalAnalysis/SourceCodeTokenizer.cs
@@ -1,5 +1,6 @@
 ﻿using OfficeOpenXml.FormulaParsing.Excel.Functions;
 using OfficeOpenXml.FormulaParsing.Exceptions;
+using OfficeOpenXml.FormulaParsing.Excel.Operators;
 using OfficeOpenXml.Utils;
 using System;
 using System.Collections.Generic;
@@ -65,6 +66,15 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
         {
             get { return new SourceCodeTokenizer(FunctionNameProvider.Empty, NameValueProvider.Empty, false, false); }
         }
+
+        /// <summary>
+        /// The default tokenizer. This tokenizer will keep whitespaces and add them as tokens.
+        /// </summary>
+        public static ISourceCodeTokenizer DefaultPreserveWhiteSpace
+        {
+            get { return new SourceCodeTokenizer(FunctionNameProvider.Empty, NameValueProvider.Empty, false, true); }
+        }
+
         /// <summary>
         /// The tokenizer used for r1c1 format. This tokenizer will keep whitespaces and add them as tokens.
         /// </summary>
@@ -455,7 +465,7 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
                     if (c == '[' ||
                         c == '(')
                     {
-                        l.Add(new Token("isc", TokenType.Operator));
+                        l.Add(new Token(Operator.IntersectIndicator, TokenType.Operator));
                     }
                 }
 
@@ -651,7 +661,7 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
                    pt.TokenType == TokenType.NameValue ||
                    pt.TokenType == TokenType.Function)
                 {
-                    l.Insert(l.Count - 1, new Token("isc", TokenType.Operator));
+                    l.Insert(l.Count - 1, new Token(Operator.IntersectIndicator, TokenType.Operator));
                 }
             }
 

--- a/src/EPPlus/FormulaParsing/LexicalAnalysis/SourceCodeTokenizer.cs
+++ b/src/EPPlus/FormulaParsing/LexicalAnalysis/SourceCodeTokenizer.cs
@@ -68,14 +68,6 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
         }
 
         /// <summary>
-        /// The default tokenizer. This tokenizer will keep whitespaces and add them as tokens.
-        /// </summary>
-        public static ISourceCodeTokenizer DefaultPreserveWhiteSpace
-        {
-            get { return new SourceCodeTokenizer(FunctionNameProvider.Empty, NameValueProvider.Empty, false, true); }
-        }
-
-        /// <summary>
         /// The tokenizer used for r1c1 format. This tokenizer will keep whitespaces and add them as tokens.
         /// </summary>
         public static ISourceCodeTokenizer R1C1
@@ -83,6 +75,13 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
             get { return new SourceCodeTokenizer(FunctionNameProvider.Empty, NameValueProvider.Empty, true, true); }
         }
 
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="functionRepository">A function name provider</param>
+        /// <param name="nameValueProvider">A name value provider</param>
+        /// <param name="r1c1">If true the tokenizer will use the R1C1 format</param>
+        /// <param name="keepWhitespace">If true whitspaces in formulas will be preserved</param>
         public SourceCodeTokenizer(IFunctionNameProvider functionRepository, INameValueProvider nameValueProvider, bool r1c1 = false, bool keepWhitespace = false)
         {
             _r1c1 = r1c1;
@@ -117,6 +116,14 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
             isExponential = 0x2000,
             isLastCharQuote = 0x4000
         }
+
+        /// <summary>
+        /// Split the input string into tokens used by the formula parser
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="worksheet"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidFormulaException"></exception>
         public IList<Token> Tokenize(string input, string worksheet)
         {
             var l = new List<Token>();

--- a/src/EPPlusTest/Issues/CopyIssues.cs
+++ b/src/EPPlusTest/Issues/CopyIssues.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EPPlusTest.Issues
+{
+    [TestClass]
+    public class CopyIssues : TestBase
+    {
+        [TestMethod]
+        public void Issue1332()
+        {
+            // the error in this issue was that the intersect operator (SPACE)
+            // was replaced with "isc" when a formulas was copied to a new destination
+            using var package = new ExcelPackage();
+            var sheet = package.Workbook.Worksheets.Add("Sheet1");
+            sheet.Cells["A1"].Formula = "SUBTOTAL(109, _DATA _Quantity)";
+            sheet.Cells["A1"].Copy(sheet.Cells["B1"]);
+            Assert.AreEqual("SUBTOTAL(109,_DATA _Quantity)", sheet.Cells["B1"].Formula);
+        }
+    }
+}


### PR DESCRIPTION
Also replaced the hard coded string `"isc"` with a constant string variable: `Operator.IntersectIndicator`

See #1332