### PR TITLE
Fixes #1343. Writing and loading pivot table attribute on CFs

### DIFF
--- a/docs/articles/fixedissues.md
+++ b/docs/articles/fixedissues.md
@@ -1,5 +1,11 @@
 
 # Features / Fixed issues - EPPlus 7
+## Version 7.1
+### Fixed issues 
+* Inserting rows would cause an exception to occur in formulas in rare cases.
+* Special signs such as `'` when last in a formula would throw an exception in rare cases.
+* Reading Conditional Formattings with property PivotTable = true failed to read in property.
+
 ## Version 7.0.10
 ### Fixed issues 
 * Having a workbook with group drawings in group drawings caused EPPlus to fail on load.

--- a/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
+++ b/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
@@ -49,6 +49,7 @@ namespace OfficeOpenXml.ConditionalFormatting
         internal void ReadRegularConditionalFormattings(XmlReader xr)
         {
             string address = null;
+            bool pivot = false;
             while (xr.ReadUntil(1, "conditionalFormatting", "sheetData", "dataValidations", "mergeCells", "hyperlinks", "rowBreaks", "colBreaks", "extLst", "pageMargins"))
             {
                 //string lastAddress = address.ToString();
@@ -61,6 +62,8 @@ namespace OfficeOpenXml.ConditionalFormatting
                         if (xr.LocalName == "conditionalFormatting")
                         {
                             address = xr.GetAttribute("sqref");
+
+                            pivot = xr.GetAttribute("pivot") == "1";
 
                             //Only happens if template node by user or a new worksheet.
                             if(address == null)
@@ -80,6 +83,8 @@ namespace OfficeOpenXml.ConditionalFormatting
                                 }
                                 address = address.Replace(' ', ',');
                                 var cf = ExcelConditionalFormattingRuleFactory.Create(new ExcelAddress(address), _ws, xr);
+
+                                cf.PivotTable = pivot;
 
                                 //If cf exists in both local and ExtLst spaces
                                 if(cf.IsExtLst && cf._uid != null)

--- a/src/EPPlus/Core/Worksheet/XmlWriter/WorksheetXmlWriter.cs
+++ b/src/EPPlus/Core/Worksheet/XmlWriter/WorksheetXmlWriter.cs
@@ -12,7 +12,6 @@
  *************************************************************************************************/
 using OfficeOpenXml.Compatibility;
 using OfficeOpenXml.ConditionalFormatting;
-using OfficeOpenXml.ConditionalFormatting.Contracts;
 using OfficeOpenXml.ConditionalFormatting.Rules;
 using OfficeOpenXml.Constants;
 using OfficeOpenXml.Core.CellStore;
@@ -20,12 +19,9 @@ using OfficeOpenXml.DataValidation;
 using OfficeOpenXml.DataValidation.Formulas;
 using OfficeOpenXml.DataValidation.Formulas.Contracts;
 using OfficeOpenXml.ExcelXMLWriter;
-using OfficeOpenXml.FormulaParsing.Excel.Functions.Information;
-using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
 using OfficeOpenXml.Metadata;
 using OfficeOpenXml.Packaging;
-using OfficeOpenXml.RichData;
 using OfficeOpenXml.Style;
 using OfficeOpenXml.Style.Dxf;
 using OfficeOpenXml.Style.XmlAccess;
@@ -34,7 +30,6 @@ using OfficeOpenXml.Utils.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Drawing.Drawing2D;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -1130,7 +1125,12 @@ namespace OfficeOpenXml.Core.Worksheet.XmlWriter
 
                         if (i == 0)
                         {
-                            cache.Append($"<{prefix}conditionalFormatting xmlns:xm=\"{ExcelPackage.schemaMainXm}\">");
+                            cache.Append($"<{prefix}conditionalFormatting xmlns:xm=\"{ExcelPackage.schemaMainXm}\"");
+                            if (format.PivotTable)
+                            {
+                                cache.Append($" pivot=\"1\"");
+                            }
+                            cache.Append($">");
                         }
 
                         string uid;
@@ -1590,7 +1590,12 @@ namespace OfficeOpenXml.Core.Worksheet.XmlWriter
 
                     if(i == 0)
                     {
-                        cache.Append($"<conditionalFormatting sqref=\"{conditionalFormat.Address.AddressSpaceSeparated}\">");
+                        cache.Append($"<conditionalFormatting sqref=\"{conditionalFormat.Address.AddressSpaceSeparated}\"");
+                        if (conditionalFormat.PivotTable)
+                        {
+                            cache.Append($" pivot=\"1\"");
+                        }
+                        cache.Append($">");
                     }
 
                     cache.Append($"<cfRule type=\"{conditionalFormat.GetAttributeType()}\" ");

--- a/src/EPPlusTest/ConditionalFormatting/ConditionalFormattingTests.cs
+++ b/src/EPPlusTest/ConditionalFormatting/ConditionalFormattingTests.cs
@@ -2053,5 +2053,63 @@ namespace EPPlusTest.ConditionalFormatting
                 SaveAndCleanup(package);
             }
         }
+
+        [TestMethod]
+        public void PivotTableFlagShouldStickWhenReadIn()
+        {
+            using (var package = OpenPackage("CF_pivotFlag.xlsx", true))
+            {
+                var ws = package.Workbook.Worksheets.Add("pivotWorksheet");
+
+                for (int i = 1; i < 10; i++)
+                {
+                    ws.Cells[i, 1].Value = i;
+                    ws.Cells[i, 2].Value = i - 2;
+                    ws.Cells[i, 3].Value = i - 5;
+                }
+
+                var pivotRange = ws.Cells["E1:F10"];
+
+                ws.PivotTables.Add(pivotRange, ws.Cells["A1:B10"], "SmallPivot");
+
+                var formulaValue = 5;
+
+                var cond = ws.ConditionalFormatting.AddEqual(pivotRange);
+                cond.PivotTable = true;
+                cond.Formula = formulaValue.ToString();
+                cond.Priority = 1;
+                cond.Style.Fill.PatternType = ExcelFillStyle.Solid;
+                cond.Style.Fill.BackgroundColor.SetColor(Color.BlueViolet);
+
+                var cond2 = ws.ConditionalFormatting.AddThreeColorScale(pivotRange);
+                cond2.PivotTable = true;
+
+                if (formulaValue == 9999)
+                    cond.Style.Font.Color.SetColor(Color.BlueViolet);
+                else
+                    cond.Style.Font.Color.SetColor(Color.DarkRed);
+
+                SaveAndCleanup(package);
+
+                using (var readPackage = OpenPackage("CF_pivotFlag.xlsx", false))
+                {
+                    var cfCollection = readPackage.Workbook.Worksheets[0].ConditionalFormatting;
+                    Assert.IsTrue(cfCollection[0].PivotTable);
+                    Assert.IsTrue(cfCollection[1].PivotTable);
+
+                    SaveAndCleanup(readPackage);
+                }
+
+                //Read in again just in case
+                using (var beltAndBraces = OpenPackage("CF_pivotFlag.xlsx", false))
+                {
+                    var cfCollection = beltAndBraces.Workbook.Worksheets[0].ConditionalFormatting;
+                    Assert.IsTrue(cfCollection[0].PivotTable);
+                    Assert.IsTrue(cfCollection[1].PivotTable);
+
+                    SaveAndCleanup(beltAndBraces);
+                }
+            }
+        }
     }
 }

--- a/src/EPPlusTest/Table/TableTests.cs
+++ b/src/EPPlusTest/Table/TableTests.cs
@@ -833,31 +833,31 @@ namespace EPPlusTest.Table
                 wks.Cells["C1"].Value = "Col3";
                 wks.Cells["A2"].Value = 1;
                 wks.Cells["B2"].Value = 2;
-                var table1 = wks.Tables.Add(wks.Cells["A1:C2"], "Table1");
+                var table1 = wks.Tables.Add(wks.Cells["A1:C5"], "Table1");
                 var formula = "Table1[[#This Row],[Col1]]+Table1[[#This Row],[Col2]]";
                 table1.Columns[2].CalculatedColumnFormula = formula;
                 wks.Calculate();
 
                 // Add a style to the cell containing the formula
-                wks.Cells["C2"].Style.Font.Bold = true;
-                wks.Cells["C2"].Style.Font.Size = 16;
-                wks.Cells["C2"].Style.Font.Color.SetColor(eThemeSchemeColor.Text2);
-                wks.Cells["C2"].Style.Font.Color.Tint = 0.39997558519241921m;
+                wks.Cells["B2:C3"].Style.Font.Bold = true;
+                wks.Cells["B2:C3"].Style.Font.Size = 16;
+                wks.Cells["B2:C3"].Style.Font.Color.SetColor(eThemeSchemeColor.Text2);
+                wks.Cells["B2:C3"].Style.Font.Color.Tint = 0.39997558519241921m;
 
                 // Check the style has been applied
-                Assert.AreEqual(true, wks.Cells["C2"].Style.Font.Bold);
-                Assert.AreEqual(16, wks.Cells["C2"].Style.Font.Size, 1E-3);
-                Assert.AreEqual(eThemeSchemeColor.Text2, wks.Cells["C2"].Style.Font.Color.Theme);
-                Assert.AreEqual(0.39997558519241921m, wks.Cells["C2"].Style.Font.Color.Tint);
+                Assert.AreEqual(true, wks.Cells["B3"].Style.Font.Bold);
+                Assert.AreEqual(16, wks.Cells["B3"].Style.Font.Size, 1E-3);
+                Assert.AreEqual(eThemeSchemeColor.Text2, wks.Cells["B3"].Style.Font.Color.Theme);
+                Assert.AreEqual(0.39997558519241921m, wks.Cells["B3"].Style.Font.Color.Tint);
 
                 // Remove the calculated column formula from the table
                 table1.Columns["Col3"].CalculatedColumnFormula = "";
 
                 // Check the style hasn't changed
-                Assert.AreEqual(true, wks.Cells["C2"].Style.Font.Bold);
-                Assert.AreEqual(16, wks.Cells["C2"].Style.Font.Size, 1E-3);
-                Assert.AreEqual(eThemeSchemeColor.Text2, wks.Cells["C2"].Style.Font.Color.Theme);
-                Assert.AreEqual(0.39997558519241921m, wks.Cells["C2"].Style.Font.Color.Tint);
+                Assert.AreEqual(true, wks.Cells["B3"].Style.Font.Bold);
+                Assert.AreEqual(16, wks.Cells["B3"].Style.Font.Size, 1E-3);
+                Assert.AreEqual(eThemeSchemeColor.Text2, wks.Cells["B3"].Style.Font.Color.Theme);
+                Assert.AreEqual(0.39997558519241921m, wks.Cells["B3"].Style.Font.Color.Tint);
             }
         }
     }


### PR DESCRIPTION
An attribute on the parent node of a collection of conditionalformattings had been missed in read-write operations.
This adds them in.