### PR TITLE
Fixes issue #1335

### DIFF
--- a/src/EPPlus/FormulaParsing/LexicalAnalysis/SourceCodeTokenizer.cs
+++ b/src/EPPlus/FormulaParsing/LexicalAnalysis/SourceCodeTokenizer.cs
@@ -75,14 +75,22 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
             get { return new SourceCodeTokenizer(FunctionNameProvider.Empty, NameValueProvider.Empty, true, true); }
         }
 
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="functionRepository">A function name provider</param>
-        /// <param name="nameValueProvider">A name value provider</param>
-        /// <param name="r1c1">If true the tokenizer will use the R1C1 format</param>
-        /// <param name="keepWhitespace">If true whitspaces in formulas will be preserved</param>
-        public SourceCodeTokenizer(IFunctionNameProvider functionRepository, INameValueProvider nameValueProvider, bool r1c1 = false, bool keepWhitespace = false)
+		/// <summary>
+		/// The default tokenizer. This tokenizer will remove and ignore whitespaces.
+		/// </summary>
+		public static ISourceCodeTokenizer Default_KeepWhiteSpaces
+		{
+			get { return new SourceCodeTokenizer(FunctionNameProvider.Empty, NameValueProvider.Empty, false, true); }
+		}
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="functionRepository">A function name provider</param>
+		/// <param name="nameValueProvider">A name value provider</param>
+		/// <param name="r1c1">If true the tokenizer will use the R1C1 format</param>
+		/// <param name="keepWhitespace">If true whitspaces in formulas will be preserved</param>
+		public SourceCodeTokenizer(IFunctionNameProvider functionRepository, INameValueProvider nameValueProvider, bool r1c1 = false, bool keepWhitespace = false)
         {
             _r1c1 = r1c1;
             _keepWhitespace = keepWhitespace;
@@ -668,8 +676,15 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
                    pt.TokenType == TokenType.NameValue ||
                    pt.TokenType == TokenType.Function)
                 {
-                    l.Insert(l.Count - 1, new Token(Operator.IntersectIndicator, TokenType.Operator));
-                }
+                    if (_keepWhitespace && l.Count > 2 && l[l.Count - 2].TokenType==TokenType.WhiteSpace)
+                    {
+						l[l.Count-2] = new Token(Operator.IntersectIndicator, TokenType.Operator);
+					}
+					else
+                    {
+						l.Insert(l.Count - 1, new Token(Operator.IntersectIndicator, TokenType.Operator));
+					}
+				}
             }
 
             flags &= statFlags.isTableRef;

--- a/src/EPPlus/FormulaParsing/LexicalAnalysis/SourceCodeTokenizer.cs
+++ b/src/EPPlus/FormulaParsing/LexicalAnalysis/SourceCodeTokenizer.cs
@@ -678,7 +678,16 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
                 {
                     if (_keepWhitespace && l.Count > 2 && l[l.Count - 2].TokenType==TokenType.WhiteSpace)
                     {
-						l[l.Count-2] = new Token(Operator.IntersectIndicator, TokenType.Operator);
+                        var wsToken = l[l.Count - 2];
+						if (wsToken.Value.Length > 1) //Multiple white space?
+                        {
+                            wsToken.Value = wsToken.Value.Substring(0, wsToken.Value.Length);
+							l.Insert(l.Count - 1, new Token(Operator.IntersectIndicator, TokenType.Operator));
+						}
+                        else
+                        {
+							l[l.Count - 2] = new Token(Operator.IntersectIndicator, TokenType.Operator);
+						}
 					}
 					else
                     {

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -9,6 +9,7 @@ using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing;
 using System.IO;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Information;
+using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
 
 namespace EPPlusTest.Issues
 {
@@ -155,5 +156,16 @@ namespace EPPlusTest.Issues
                 SaveAndCleanup(p);
             }
         }
-    }
+		[TestMethod]
+		public void i1335()
+		{
+			var formula = "SUBTOTAL(109, Name1 Name2)";
+			var tokens = SourceCodeTokenizer.Default_KeepWhiteSpaces.Tokenize(formula);
+
+			Assert.AreEqual(9, tokens.Count);
+			Assert.AreEqual(TokenType.WhiteSpace, tokens[4].TokenType);
+			Assert.AreEqual(TokenType.Operator, tokens[6].TokenType);
+			Assert.AreEqual("isc", tokens[6].Value);
+		}
+	}
 }


### PR DESCRIPTION
When having the _keepWhitespaces flag set on the tokenizer, EPPlus incorrectly added both a white-space token and an intersect token.