### PR TITLE
Emergency fill fix

### DIFF
--- a/src/EPPlus/Export/HtmlExport/StyleCollectors/FillDxf.cs
+++ b/src/EPPlus/Export/HtmlExport/StyleCollectors/FillDxf.cs
@@ -34,6 +34,10 @@ namespace OfficeOpenXml.Export.HtmlExport.StyleCollectors
             {
                 if (_fill.HasValue)
                 {
+                    if(_fill.PatternType == null)
+                    {
+                        _fill.PatternType = ExcelFillStyle.Solid;
+                    }
                     return _fill.PatternType.Value;
                 }
 


### PR DESCRIPTION
In essence; when a conditional formatting is assigned a color but not directly assigned a pattern-type excel will apply "solid" as pattern type but the dxf style in the styles file will still have the default patterntype none which epplus reads in which causes crash.

Arguably this should be done in ConditionalFormattingRule instead?