### PR TITLE
#1365 - NUMBERVALUE function returned #VALUE! instead of 0 when called with an empty string

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/NumberValue.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/NumberValue.cs
@@ -37,6 +37,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
         {
             ValidateArguments(arguments, 1);
             var arg = ArgToString(arguments, 0);
+            if(arg == null || arg.Length == 0 || arg.Trim().Length == 0)
+            {
+                return CreateResult(0d, DataType.Integer);
+            }
             SetArgAndPercentage(arg);
             if(!ValidateAndSetSeparators(arguments.ToArray()))
             {

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/TextFunctionsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/TextFunctionsTests.cs
@@ -305,6 +305,14 @@ namespace EPPlusTest.Excel.Functions.Text
         }
 
         [TestMethod]
+        public void NumberValueWithEmptyStringShouldReturn0()
+        {
+            var func = new NumberValue();
+            var result = func.Execute(FunctionsHelper.CreateArgs(""), _parsingContext);
+            Assert.AreEqual(0d, result.Result);
+        }
+
+        [TestMethod]
         public void NumberValueShouldCastIntegerValue()
         {
             var func = new NumberValue();


### PR DESCRIPTION
See #1365