### PR TITLE
#1365 - Added unit test for NUMBERVALUE function called with an empty string

### DIFF
--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/TextFunctionsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/TextFunctionsTests.cs
@@ -308,6 +308,14 @@ namespace EPPlusTest.Excel.Functions.Text
         }
 
         [TestMethod]
+        public void NumberValueWithEmptyStringShouldReturn0()
+        {
+            var func = new NumberValue();
+            var result = func.Execute(FunctionsHelper.CreateArgs(""), _parsingContext);
+            Assert.AreEqual(0d, result.Result);
+        }
+
+        [TestMethod]
         public void NumberValueShouldCastIntegerValue()
         {
             var func = new NumberValue();


### PR DESCRIPTION
Worked as expected in v7, but added a test (this was a bug in v6, see #1365)