### PR TITLE
Fixed issue #1389 & #1401

### DIFF
--- a/src/EPPlus/Drawing/Chart/ExcelChartAxis.cs
+++ b/src/EPPlus/Drawing/Chart/ExcelChartAxis.cs
@@ -238,7 +238,7 @@ namespace OfficeOpenXml.Drawing.Chart
             {
                 if (_textBody == null)
                 {
-                    _textBody = new ExcelTextBody(NameSpaceManager, TopNode, $"{_nsPrefix}:txPr/a:bodyPr", SchemaNodeOrder);
+                    _textBody = new ExcelTextBody(NameSpaceManager, TopNode, $"{_nsPrefix}:txPr/a:bodyPr", SchemaNodeOrder, Font.CreateTopNode);
                 }
                 return _textBody;
             }

--- a/src/EPPlus/Drawing/Chart/ExcelChartDataLabel.cs
+++ b/src/EPPlus/Drawing/Chart/ExcelChartDataLabel.cs
@@ -268,7 +268,7 @@ namespace OfficeOpenXml.Drawing.Chart
             {
                 if (_textBody == null)
                 {
-                    _textBody = new ExcelTextBody(NameSpaceManager, TopNode, $"{_nsPrefix}:txPr/a:bodyPr", SchemaNodeOrder);
+                    _textBody = new ExcelTextBody(NameSpaceManager, TopNode, $"{_nsPrefix}:txPr/a:bodyPr", SchemaNodeOrder, Font.CreateTopNode);
                 }
                 return _textBody;
             }

--- a/src/EPPlus/Drawing/ImageHandling/ImageReader.cs
+++ b/src/EPPlus/Drawing/ImageHandling/ImageReader.cs
@@ -256,7 +256,7 @@ namespace OfficeOpenXml.Drawing
                     while (ms.Position < ms.Length)
                     {
                         var id = GetUInt16BigEndian(br);
-                        var length = (int)GetInt16BigEndian(br);
+                        var length = (int)GetUInt16BigEndian(br);
                         switch (id)
                         {
                             case 0xFFE0:

--- a/src/EPPlus/Drawing/Style/Text/ExcelTextBody.cs
+++ b/src/EPPlus/Drawing/Style/Text/ExcelTextBody.cs
@@ -23,11 +23,13 @@ namespace OfficeOpenXml.Drawing
     public class ExcelTextBody : XmlHelper
     {
         private readonly string _path;
-        internal ExcelTextBody(XmlNamespaceManager ns, XmlNode topNode, string path, string[] schemaNodeOrder=null) :
+        private readonly Action _initXml;
+        internal ExcelTextBody(XmlNamespaceManager ns, XmlNode topNode, string path, string[] schemaNodeOrder=null, Action initXml=null) :
             base(ns, topNode)   
         {
             _path = path;
-            AddSchemaNodeOrder(schemaNodeOrder, new string[] { "ln", "noFill", "solidFill", "gradFill", "pattFill", "blipFill", "latin", "ea", "cs", "sym", "hlinkClick", "hlinkMouseOver", "rtl", "extLst", "highlight", "kumimoji", "lang", "altLang", "sz", "b", "i", "u", "strike", "kern", "cap", "spc", "normalizeH", "baseline", "noProof", "dirty", "err", "smtClean", "smtId", "bmk" });
+			_initXml = initXml;
+			AddSchemaNodeOrder(schemaNodeOrder, new string[] { "ln", "noFill", "solidFill", "gradFill", "pattFill", "blipFill", "latin", "ea", "cs", "sym", "hlinkClick", "hlinkMouseOver", "rtl", "extLst", "highlight", "kumimoji", "lang", "altLang", "sz", "b", "i", "u", "strike", "kern", "cap", "spc", "normalizeH", "baseline", "noProof", "dirty", "err", "smtClean", "smtId", "bmk" });
         }
         /// <summary>
         /// The anchoring position within the shape
@@ -40,7 +42,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeString($"{_path}/@anchor", value.TranslateTextAchoringText());
+                _initXml?.Invoke();
+				SetXmlNodeString($"{_path}/@anchor", value.TranslateTextAchoringText());
             }
         }
         /// <summary>
@@ -54,7 +57,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeBool($"{_path}/@anchorCtr", value, false);
+				_initXml?.Invoke();
+				SetXmlNodeBool($"{_path}/@anchorCtr", value, false);
             }
         }
         /// <summary>
@@ -74,7 +78,8 @@ namespace OfficeOpenXml.Drawing
                 }
                 else
                 {
-                    SetXmlNodeString($"{_path}/@u", value.TranslateUnderlineText());
+					_initXml?.Invoke();
+					SetXmlNodeString($"{_path}/@u", value.TranslateUnderlineText());
                 }
             }
         }
@@ -89,7 +94,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeEmuToPt($"{_path}/@bIns", value);
+				_initXml?.Invoke();
+				SetXmlNodeEmuToPt($"{_path}/@bIns", value);
             }
         }
         /// <summary>
@@ -103,7 +109,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeEmuToPt($"{_path}/@tIns", value);
+				_initXml?.Invoke();
+				SetXmlNodeEmuToPt($"{_path}/@tIns", value);
             }
         }
         /// <summary>
@@ -117,7 +124,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeEmuToPt($"{_path}/@rIns", value);
+				_initXml?.Invoke();
+				SetXmlNodeEmuToPt($"{_path}/@rIns", value);
             }
         }
         /// <summary>
@@ -131,7 +139,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeEmuToPt($"{_path}/@lIns", value);
+				_initXml?.Invoke();
+				SetXmlNodeEmuToPt($"{_path}/@lIns", value);
             }
         }
         /// <summary>
@@ -145,7 +154,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeAngel($"{_path}/@rot", value, "Rotation", -100000, 100000);
+				_initXml?.Invoke();
+				SetXmlNodeAngel($"{_path}/@rot", value, "Rotation", -100000, 100000);
             }
         }
         /// <summary>
@@ -160,7 +170,8 @@ namespace OfficeOpenXml.Drawing
             set
             {
                 if (value < 0) throw new ArgumentOutOfRangeException("SpaceBetweenColumns", "Can't be negative");
-                SetXmlNodeEmuToPt($"{_path}/@spcCol", value);
+				_initXml?.Invoke();
+				SetXmlNodeEmuToPt($"{_path}/@spcCol", value);
             }
         }
 
@@ -175,7 +186,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeBool($"{_path}/@spcFirstLastPara", value);
+				_initXml?.Invoke();
+				SetXmlNodeBool($"{_path}/@spcFirstLastPara", value);
             }
         }
         /// <summary>
@@ -189,7 +201,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeBool($"{_path}/@upright", value);
+				_initXml?.Invoke();
+				SetXmlNodeBool($"{_path}/@upright", value);
             }
         }
         /// <summary>
@@ -203,7 +216,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeBool($"{_path}/@compatLnSpc", value);
+				_initXml?.Invoke();
+				SetXmlNodeBool($"{_path}/@compatLnSpc", value);
             }
         }
         /// <summary>
@@ -217,7 +231,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeBool($"{_path}/@forceAA", value);
+				_initXml?.Invoke();
+				SetXmlNodeBool($"{_path}/@forceAA", value);
             }
         }
         /// <summary>
@@ -231,7 +246,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeBool($"{_path}/@fromWordArt", value);
+				_initXml?.Invoke();
+				SetXmlNodeBool($"{_path}/@fromWordArt", value);
             }
         }
         /// <summary>
@@ -245,7 +261,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeString($"{_path}/@vert", value.TranslateTextVerticalText());
+				_initXml?.Invoke();
+				SetXmlNodeString($"{_path}/@vert", value.TranslateTextVerticalText());
             }
         }
         /// <summary>
@@ -259,7 +276,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeString($"{_path}/@horzOverflow", value.ToEnumString());
+				_initXml?.Invoke();
+				SetXmlNodeString($"{_path}/@horzOverflow", value.ToEnumString());
             }
         }
 
@@ -274,7 +292,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeString($"{_path}/@vertOverflow", value.ToEnumString());
+				_initXml?.Invoke();
+				SetXmlNodeString($"{_path}/@vertOverflow", value.ToEnumString());
             }
         }
         /// <summary>
@@ -288,7 +307,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                SetXmlNodeString($"{_path}/@wrap", value.ToEnumString());
+				_initXml?.Invoke();
+				SetXmlNodeString($"{_path}/@wrap", value.ToEnumString());
             }
         }
         /// <summary>
@@ -313,7 +333,8 @@ namespace OfficeOpenXml.Drawing
             }
             set
             {
-                switch (value)
+				_initXml?.Invoke();
+				switch (value)
                 {
                     case eTextAutofit.NormalAutofit:
                         if (value == TextAutofit) return;
@@ -347,7 +368,8 @@ namespace OfficeOpenXml.Drawing
             set
             {
                 if (TextAutofit != eTextAutofit.NormalAutofit) throw new ArgumentException("AutofitNormalFontScale", "TextAutofit must be set to NormalAutofit to use set this property");
-                SetXmlNodePercentage($"{_path}/a:normAutofit/@fontScale", value, false);
+				_initXml?.Invoke();
+				SetXmlNodePercentage($"{_path}/a:normAutofit/@fontScale", value, false);
             }
         }
         /// <summary>
@@ -363,7 +385,8 @@ namespace OfficeOpenXml.Drawing
             set
             {
                 if (TextAutofit != eTextAutofit.NormalAutofit) throw new ArgumentException("LineSpaceReduction", "TextAutofit must be set to NormalAutofit to use set this property");
-                SetXmlNodePercentage($"{_path}/a:normAutofit/@lnSpcReduction", value, false);
+				_initXml?.Invoke();
+				SetXmlNodePercentage($"{_path}/a:normAutofit/@lnSpcReduction", value, false);
             }
         }
         internal XmlElement PathElement

--- a/src/EPPlus/Style/ExcelTextFont.cs
+++ b/src/EPPlus/Style/ExcelTextFont.cs
@@ -103,7 +103,7 @@ namespace OfficeOpenXml.Style
                 _initXml?.Invoke();
                 CreateNode(_path);
                 TopNode = _rootNode.SelectSingleNode(_path, NameSpaceManager);
-                CreateNode("../../../a:bodyPr");
+                CreateNode("../../../a:bodyPr") ;
                 CreateNode("../../../a:lstStyle");
             }
             else if (TopNode.ParentNode?.ParentNode?.ParentNode?.LocalName == "rich")

--- a/src/EPPlusTest/Issues/ChartIssues.cs
+++ b/src/EPPlusTest/Issues/ChartIssues.cs
@@ -1,10 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using OfficeOpenXml;
 using OfficeOpenXml.Drawing;
 using OfficeOpenXml.Drawing.Chart;
 namespace EPPlusTest.Issues

--- a/src/EPPlusTest/Issues/ChartIssues.cs
+++ b/src/EPPlusTest/Issues/ChartIssues.cs
@@ -168,5 +168,32 @@ namespace EPPlusTest.Issues
 				SaveWorkbook("s643.xlsx", p);
 			}
 		}
+		[TestMethod]
+		public void i1401()
+		{
+			using (var p = OpenPackage("i1401.xlsx", true))
+			{
+				var chartWorksheet = p.Workbook.Worksheets.Add("Sheet1");
+				LoadTestdata(chartWorksheet);
+				var chart = chartWorksheet.Drawings.AddBarChart("chart1", eBarChartType.ColumnClustered);
+				chart.Series.Add("B1:B100", "A1:A100");
+				chart.SetPosition(1, 10, 12, 0);
+				chart.SetSize(1200, 580);
+				chart.Legend.Remove();
+				chart.Title.Text = "t";
+				chart.Title.Font.Bold = true;
+				chart.Title.Font.UnderLine = OfficeOpenXml.Style.eUnderLineType.Single;
+				chart.Title.Font.Size = 16;
+
+				chart.XAxis.LabelPosition = eTickLabelPosition.NextTo;
+				chart.XAxis.TextBody.WrapText = eTextWrappingType.Square;
+				chart.XAxis.TextBody.Rotation = 45D;
+				chart.DataLabel.ShowValue = true;
+				chart.DataLabel.Position = eLabelPosition.OutEnd;
+				chart.DataLabel.TextBody.Rotation = 45D; //<= This line causes the error.
+			
+				SaveAndCleanup(p);
+			}
+		}
 	}
 }

--- a/src/EPPlusTest/Issues/PictureIssues.cs
+++ b/src/EPPlusTest/Issues/PictureIssues.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml.Drawing;
+using OfficeOpenXml.Drawing.Chart;
+using System.Drawing;
+using System.IO;
+using System.Xml.Linq;
+namespace EPPlusTest.Issues
+{
+	[TestClass]
+	public class PictureIssues : TestBase
+
+	{
+		[ClassInitialize]
+		public static void Init(TestContext context)
+		{
+		}
+		[ClassCleanup]
+		public static void Cleanup()
+		{
+		}
+		[TestInitialize]
+		public void Initialize()
+		{
+		}
+		[TestMethod]
+		public void i1389()
+		{
+			using (var p = OpenPackage("i1389.xlsx", true))
+			{
+				p.Settings.ImageSettings.PrimaryImageHandler = new GenericImageHandler();
+				var ws = p.Workbook.Worksheets.Add("Sheet1");
+				var stream = GetImageMemoryStream("i1389.jpg");
+				ExcelPicture pic = ws.Drawings.AddPicture("s", stream);
+				SaveAndCleanup(p);
+			}
+		}
+	}
+}


### PR DESCRIPTION
The GenericImageReader failed to read Jpg images if the length of the record was larger that 32K.
Fix for #1401 - Setting TextBody properties on data labels causes a corrupt workbook, if not text or font properties are set.
