### PR TITLE
Rich text blank issue

### DIFF
--- a/src/EPPlus/ExcelRangeBase.cs
+++ b/src/EPPlus/ExcelRangeBase.cs
@@ -1279,7 +1279,13 @@ namespace OfficeOpenXml
             get
             {
                 IsRangeValid("richtext");
-                return _worksheet._flags.GetFlagValue(_fromRow, _fromCol, CellFlags.RichText);
+                var isRt = _worksheet._flags.GetFlagValue(_fromRow, _fromCol, CellFlags.RichText);
+                if (isRt)
+                {
+					_rtc = _worksheet.GetRichText(_fromRow, _fromCol, this);
+                    return _rtc.Count>0;
+				}
+				return isRt;
             }
             set
             {

--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -1443,15 +1443,14 @@ namespace OfficeOpenXml
         internal ExcelRichTextCollection GetRichText(int row, int col, ExcelRangeBase r = null)
         {
             var v = GetCoreValueInner(row, col);
-            //var isRt = _flags.GetFlagValue(row, col, CellFlags.RichText);
-            //if (isRt && v._value is ExcelRichTextCollection rtc)
-            if (v._value is ExcelRichTextCollection rtc)
+            var isRt = _flags.GetFlagValue(row, col, CellFlags.RichText);
+            if (isRt && v._value is ExcelRichTextCollection rtc)
             {
                 return rtc;
             }
             else
             {
-                var text = ValueToTextHandler.GetFormattedText(v._value, Workbook, v._styleId, false);
+                var text = ValueToTextHandler.GetFormattedText(v._value, Workbook, v._styleId, false);                
                 if (string.IsNullOrEmpty(text))
                 {
                     var item = new ExcelRichTextCollection(Workbook, r);
@@ -2230,7 +2229,6 @@ namespace OfficeOpenXml
             var v = GetValueInner(Row, Column);
             if (v!=null)
             {
-                //var cell = ((ExcelCell)_cells[cellID]);
                 if (_flags.GetFlagValue(Row, Column, CellFlags.RichText))
                 {
                     return (object)Cells[Row, Column].RichText.Text;

--- a/src/EPPlus/Style/RichText/ExcelRichTextCollection.cs
+++ b/src/EPPlus/Style/RichText/ExcelRichTextCollection.cs
@@ -38,9 +38,10 @@ namespace OfficeOpenXml.Style
         {
             _wb = wb;
             _cells = cells;
-        }
+			_cells._worksheet._flags.SetFlagValue(_cells._fromRow, _cells._fromCol, true, CellFlags.RichText);
+		}
 
-        internal ExcelRichTextCollection(string s, ExcelRangeBase cells)
+		internal ExcelRichTextCollection(string s, ExcelRangeBase cells)
         {
             _wb = cells._workbook;
             _cells = cells;

--- a/src/EPPlusTest/Core/Range/RangeRichTextTests.cs
+++ b/src/EPPlusTest/Core/Range/RangeRichTextTests.cs
@@ -183,8 +183,18 @@ namespace EPPlusTest.Core.Range
 
             Thread.CurrentThread.CurrentCulture = ci;
         }
-
         [TestMethod]
+        public void VerifyRichTextIsBlankIfAccess()
+        {
+            using(var p=new ExcelPackage())
+            {
+                var ws = p.Workbook.Worksheets.Add("Sheet1");
+                var t = ws.Cells["A1"].RichText.Text;
+
+                Assert.AreEqual(string.Empty, ws.Cells["A1"].Value);
+			}
+        }
+		[TestMethod]
         public void ValidateRichText_TextIsReflectedOnRemove()
         {
             var package = new OfficeOpenXml.ExcelPackage();


### PR DESCRIPTION
Fixed an issue where ExcelRangeBase.Value returned the RichText object instead of an empty string  if the RichText collection was empty.
