### PR TITLE
Fix #1416 nullable members in LoadFromCollection()

### DIFF
--- a/src/EPPlus/LoadFunctions/ReflectionHelpers/TypeExtensions.cs
+++ b/src/EPPlus/LoadFunctions/ReflectionHelpers/TypeExtensions.cs
@@ -34,6 +34,7 @@ namespace OfficeOpenXml.LoadFunctions.ReflectionHelpers
 
         public static bool IsComplexType(this Type type)
         {
+            type = GetTypeOrUnderlyingType(type);
             return type != typeof(string) && (type.IsClass || type.IsInterface || type.IsGenericType);
         }
 

--- a/src/EPPlus/LoadFunctions/ReflectionHelpers/TypeExtensions.cs
+++ b/src/EPPlus/LoadFunctions/ReflectionHelpers/TypeExtensions.cs
@@ -29,6 +29,7 @@ namespace OfficeOpenXml.LoadFunctions.ReflectionHelpers
             {
                 t = ut;
             }
+
             return t;
         }
 

--- a/src/EPPlusTest/Issues/LegacyTests/Issues.cs
+++ b/src/EPPlusTest/Issues/LegacyTests/Issues.cs
@@ -6191,43 +6191,5 @@ namespace EPPlusTest
                 SaveAndCleanup(package);
             }
         }
-
-        [TestMethod]
-        public void i1416()
-        {
-            var epplusAssemblyVersion = typeof(ExcelPackage).Assembly.GetName().Version.ToString();
-            using(var excel = OpenPackage($@"issue-{epplusAssemblyVersion}.xlsx",true))
-            {
-                var tableRowAllMembers = typeof(TableRow).GetMembers().Where(m => m.MemberType == MemberTypes.Property).ToArray();
-                var tableData = new TableRow[]{
-            new TableRow{
-                EPPlusVersion = epplusAssemblyVersion,
-                NonNullableColumn=Int32.MaxValue,
-                NullableColumn=Int32.MaxValue,
-                MembersCount = tableRowAllMembers.Length
-            }
-        };
-
-                var sheet1 = excel.Workbook.Worksheets.Add("Default");
-                sheet1.Cells[1, 1].LoadFromCollection(tableData, PrintHeaders: true, TableStyle: TableStyles.Light1)
-                    .AutoFitColumns();
-
-                var sheet2 = excel.Workbook.Worksheets.Add("WithMembers");
-                sheet2.Cells[1, 1].LoadFromCollection(tableData, PrintHeaders: true, TableStyle: TableStyles.Light1,
-                    memberFlags: BindingFlags.Public | BindingFlags.Instance,
-                    Members: tableRowAllMembers)
-                    .AutoFitColumns();
-
-                SaveAndCleanup(excel);
-            }
-        }
-
-        public class TableRow
-        {
-            public String EPPlusVersion { get; set; }
-            public Int32 NonNullableColumn { get; set; }
-            public Int32? NullableColumn { get; set; }
-            public Int32 MembersCount { get; set; }
-        }
     }
 }

--- a/src/EPPlusTest/Issues/LegacyTests/Issues.cs
+++ b/src/EPPlusTest/Issues/LegacyTests/Issues.cs
@@ -6191,5 +6191,43 @@ namespace EPPlusTest
                 SaveAndCleanup(package);
             }
         }
+
+        [TestMethod]
+        public void i1416()
+        {
+            var epplusAssemblyVersion = typeof(ExcelPackage).Assembly.GetName().Version.ToString();
+            using(var excel = OpenPackage($@"issue-{epplusAssemblyVersion}.xlsx",true))
+            {
+                var tableRowAllMembers = typeof(TableRow).GetMembers().Where(m => m.MemberType == MemberTypes.Property).ToArray();
+                var tableData = new TableRow[]{
+            new TableRow{
+                EPPlusVersion = epplusAssemblyVersion,
+                NonNullableColumn=Int32.MaxValue,
+                NullableColumn=Int32.MaxValue,
+                MembersCount = tableRowAllMembers.Length
+            }
+        };
+
+                var sheet1 = excel.Workbook.Worksheets.Add("Default");
+                sheet1.Cells[1, 1].LoadFromCollection(tableData, PrintHeaders: true, TableStyle: TableStyles.Light1)
+                    .AutoFitColumns();
+
+                var sheet2 = excel.Workbook.Worksheets.Add("WithMembers");
+                sheet2.Cells[1, 1].LoadFromCollection(tableData, PrintHeaders: true, TableStyle: TableStyles.Light1,
+                    memberFlags: BindingFlags.Public | BindingFlags.Instance,
+                    Members: tableRowAllMembers)
+                    .AutoFitColumns();
+
+                SaveAndCleanup(excel);
+            }
+        }
+
+        public class TableRow
+        {
+            public String EPPlusVersion { get; set; }
+            public Int32 NonNullableColumn { get; set; }
+            public Int32? NullableColumn { get; set; }
+            public Int32 MembersCount { get; set; }
+        }
     }
 }

--- a/src/EPPlusTest/LoadFunctions/LoadFromCollectionAttributesComplexTypeTests.cs
+++ b/src/EPPlusTest/LoadFunctions/LoadFromCollectionAttributesComplexTypeTests.cs
@@ -74,7 +74,7 @@ namespace EPPlusTest.LoadFunctions
                 NullableInt = 5,
                 NonNull = 15,
                 NullableDateTime = new DateTime(2021, 7, 1),
-                NestedNullableNullable = new NestedNullable { nullableValue = -2 },
+                NestedNullableNullable = new NestedNullable { NullableValue = -2 },
                 ExplicitlyNullableString = "I'm nullable"
             }) ;
         }
@@ -256,6 +256,7 @@ namespace EPPlusTest.LoadFunctions
             }
         }
 
+        //Testing i1416 I1416 Issue1416
         [TestMethod]
         public void NullablePropertiesShouldLoad()
         {
@@ -271,11 +272,19 @@ namespace EPPlusTest.LoadFunctions
 
                 var child0 = _collectionNoAttributes[0];
 
+                Assert.AreEqual("NullableInt", ws.Cells["A1"].Value);
+                Assert.AreEqual("NonNull", ws.Cells["B1"].Value);
+                Assert.AreEqual("NullableDateTime", ws.Cells["C1"].Value);
+                //Nested nullable table column with property gets the property name
+                Assert.AreEqual("NullableValue", ws.Cells["D1"].Value);
+                Assert.AreEqual("ExplicitlyNullableString", ws.Cells["E1"].Value);
+                Assert.IsNull(ws.Cells["F1"].Value);
+
                 Assert.AreEqual(child0.NullableInt.Value, ws.Cells["A2"].Value);
                 Assert.AreEqual(child0.NonNull, ws.Cells["B2"].Value);
                 Assert.AreEqual(child0.NullableDateTime.Value, ws.Cells["C2"].Value);
                 //Nested nullable table column with property
-                Assert.AreEqual(child0.NestedNullableNullable.nullableValue.Value, ws.Cells["D2"].Value);
+                Assert.AreEqual(child0.NestedNullableNullable.NullableValue.Value, ws.Cells["D2"].Value);
                 Assert.AreEqual(child0.ExplicitlyNullableString, ws.Cells["E2"].Value);
                 Assert.IsNull(ws.Cells["F2"].Value);
 

--- a/src/EPPlusTest/LoadFunctions/LoadFromCollectionAttributesComplexTypeTests.cs
+++ b/src/EPPlusTest/LoadFunctions/LoadFromCollectionAttributesComplexTypeTests.cs
@@ -9,16 +9,18 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using OfficeOpenXml.Table;
 
 namespace EPPlusTest.LoadFunctions
 {
     [TestClass]
-    public class LoadFromCollectionAttributesComplexTypeTests
+    public class LoadFromCollectionAttributesComplexTypeTests : TestBase
     {
         private List<Outer> _collection = new List<Outer>();
         private List<OuterWithHeaders> _collectionHeaders = new List<OuterWithHeaders>();
         private List<OuterReversedSortOrder> _collectionReversed = new List<OuterReversedSortOrder>();
         private List<OuterSubclass> _collectionInheritence = new List<OuterSubclass>();
+        private List<ColumnsWithoutAttributes> _collectionNoAttributes = new List<ColumnsWithoutAttributes>();
 
         [TestInitialize]
         public void Initialize()
@@ -67,6 +69,14 @@ namespace EPPlusTest.LoadFunctions
                 },
                 Acknowledged = true
             });
+            _collectionNoAttributes.Add(new ColumnsWithoutAttributes
+            {
+                NullableInt = 5,
+                NonNull = 15,
+                NullableDateTime = new DateTime(2021, 7, 1),
+                NestedNullableNullable = new NestedNullable { nullableValue = -2 },
+                ExplicitlyNullableString = "I'm nullable"
+            }) ;
         }
 
         [TestCleanup]
@@ -243,6 +253,33 @@ namespace EPPlusTest.LoadFunctions
                 Assert.AreEqual("Hidden 1", sheet.Cells[1, 3].Value);
                 Assert.IsFalse(sheet.Column(4).Hidden);
                 Assert.AreEqual("Name 1", sheet.Cells[1, 4].Value);
+            }
+        }
+
+        [TestMethod]
+        public void NullablePropertiesShouldLoad()
+        {
+            using (var package = OpenPackage("LoadFromCollectionNullables.xlsx",true))
+            {
+                var ws = package.Workbook.Worksheets.Add("test");
+
+                var allMembers = typeof(ColumnsWithoutAttributes).GetMembers().Where(m => m.MemberType == MemberTypes.Property).ToArray();
+
+                ws.Cells[1, 1].LoadFromCollection(_collectionNoAttributes, PrintHeaders: true, TableStyle: TableStyles.Light1,
+                    memberFlags: BindingFlags.Public | BindingFlags.Instance,
+                    Members: allMembers);
+
+                var child0 = _collectionNoAttributes[0];
+
+                Assert.AreEqual(child0.NullableInt.Value, ws.Cells["A2"].Value);
+                Assert.AreEqual(child0.NonNull, ws.Cells["B2"].Value);
+                Assert.AreEqual(child0.NullableDateTime.Value, ws.Cells["C2"].Value);
+                //Nested nullable table column with property
+                Assert.AreEqual(child0.NestedNullableNullable.nullableValue.Value, ws.Cells["D2"].Value);
+                Assert.AreEqual(child0.ExplicitlyNullableString, ws.Cells["E2"].Value);
+                Assert.IsNull(ws.Cells["F2"].Value);
+
+                SaveAndCleanup(package);
             }
         }
     }

--- a/src/EPPlusTest/LoadFunctions/LoadFromCollectionWithAttributeTestClasses.cs
+++ b/src/EPPlusTest/LoadFunctions/LoadFromCollectionWithAttributeTestClasses.cs
@@ -141,7 +141,7 @@ namespace EPPlusTest.LoadFunctions
 #nullable enable
     public class NestedNullable
     {
-        public int? nullableValue { get; set; }
+        public int? NullableValue { get; set; }
     }
 
     public class ColumnsWithoutAttributes

--- a/src/EPPlusTest/LoadFunctions/LoadFromCollectionWithAttributeTestClasses.cs
+++ b/src/EPPlusTest/LoadFunctions/LoadFromCollectionWithAttributeTestClasses.cs
@@ -138,4 +138,21 @@ namespace EPPlusTest.LoadFunctions
         [EpplusTableColumn(Header = "Name", Order = 4)]
         public string Name { get; set; }
     }
+#nullable enable
+    public class NestedNullable
+    {
+        public int? nullableValue { get; set; }
+    }
+
+    public class ColumnsWithoutAttributes
+    {
+        public int? NullableInt { get; set; }
+        public int NonNull { get; set; }
+        public DateTime? NullableDateTime { get; set; }
+        [EpplusNestedTableColumn]
+        public NestedNullable? NestedNullableNullable { get; set; }
+        public string? ExplicitlyNullableString { get; set; }
+        public int? IntThatIsNull = null;
+    }
+#nullable disable
 }


### PR DESCRIPTION
Nullable property members in a collection were not returned as columns due to being a "complex type" in TypeExtensions.IsComplexType.

IsComplexType now instead checks the underlying type of the nullable.