### PR TITLE
Bug/issue1441

### DIFF
--- a/src/EPPlus/Style/XmlAccess/ExcelFormatTranslator.cs
+++ b/src/EPPlus/Style/XmlAccess/ExcelFormatTranslator.cs
@@ -298,9 +298,10 @@ namespace OfficeOpenXml.Style.XmlAccess
                             {
                                 prevUnderScore = true;
                             }
-                            else if (c == '?')
+                            else 
+                            if (c == '?')
                             {
-                                sb.Append(' ');
+                                sb.Append('#');
                             }
                             else if (c == '/')
                             {

--- a/src/EPPlusTest/Core/Range/RangeTextTests.cs
+++ b/src/EPPlusTest/Core/Range/RangeTextTests.cs
@@ -198,7 +198,7 @@ namespace EPPlusTest.Core.Range
                 ws.Cells["A1:A4"].Style.Numberformat.Format = fmt;
 
                 Assert.AreEqual("5,555.00 kr", ws.Cells["A1"].Text);
-                Assert.AreEqual("-   kr", ws.Cells["A2"].Text);
+                Assert.AreEqual("- kr", ws.Cells["A2"].Text);
                 Assert.AreEqual("-5,555.00 kr", ws.Cells["A3"].Text);
                 Assert.AreEqual("Text", ws.Cells["A4"].Text);
             }

--- a/src/EPPlusTest/Issues/RangeTextIssues.cs
+++ b/src/EPPlusTest/Issues/RangeTextIssues.cs
@@ -22,17 +22,17 @@ namespace EPPlusTest.Issues
 
                  */
                 SwitchToCulture();
-                Assert.AreEqual("123-456", worksheet.Cells["A2"].Text);
-                Assert.AreEqual("456-789", worksheet.Cells["A3"].Text);
-                Assert.AreEqual("234-567", worksheet.Cells["A4"].Text);
+                Assert.AreEqual("123+456", worksheet.Cells["A2"].Text);
+                Assert.AreEqual("456+789", worksheet.Cells["A3"].Text);
+                Assert.AreEqual("234+567", worksheet.Cells["A4"].Text);
 
-                Assert.AreEqual("10-10-10", worksheet.Cells["B2"].Text);
-                Assert.AreEqual("11-11-11", worksheet.Cells["B3"].Text);
-                Assert.AreEqual("9-9-09", worksheet.Cells["B4"].Text);
+                Assert.AreEqual("10/10/10", worksheet.Cells["B2"].Text);
+                Assert.AreEqual("11/11/11", worksheet.Cells["B3"].Text);
+                Assert.AreEqual("9/9/09", worksheet.Cells["B4"].Text);
 
-                Assert.AreEqual("50.00 ", worksheet.Cells["C2"].Text);
-                Assert.AreEqual("25.00 ", worksheet.Cells["C3"].Text);
-                Assert.AreEqual("10.00 ", worksheet.Cells["C4"].Text);
+                Assert.AreEqual("50.00", worksheet.Cells["C2"].Text);
+                Assert.AreEqual("25.00", worksheet.Cells["C3"].Text);
+                Assert.AreEqual("10.00", worksheet.Cells["C4"].Text);
 
                 SwitchBackToCurrentCulture();
 

--- a/src/EPPlusTest/Issues/RangeTextIssues.cs
+++ b/src/EPPlusTest/Issues/RangeTextIssues.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using System.IO;
+using OfficeOpenXml.FormulaParsing;
+using System.Globalization;
+
+namespace EPPlusTest.Issues
+{
+    [TestClass]
+    public class RangeTextIssues : TestBase
+    {
+        [TestMethod]
+        public void s667()
+        {
+            using (ExcelPackage package = OpenTemplatePackage("s667.xlsx"))
+            {
+                ExcelWorksheet worksheet = package.Workbook.Worksheets[0];
+                /*
+                 123+456	10-10-10	50,00 
+                456+789	11-11-11	25,00 
+                234+567	9-9-09	10,00 
+
+                 */
+                SwitchToCulture();
+                Assert.AreEqual("123-456", worksheet.Cells["A2"].Text);
+                Assert.AreEqual("456-789", worksheet.Cells["A3"].Text);
+                Assert.AreEqual("234-567", worksheet.Cells["A4"].Text);
+
+                Assert.AreEqual("10-10-10", worksheet.Cells["B2"].Text);
+                Assert.AreEqual("11-11-11", worksheet.Cells["B3"].Text);
+                Assert.AreEqual("9-9-09", worksheet.Cells["B4"].Text);
+
+                Assert.AreEqual("50.00 ", worksheet.Cells["C2"].Text);
+                Assert.AreEqual("25.00 ", worksheet.Cells["C3"].Text);
+                Assert.AreEqual("10.00 ", worksheet.Cells["C4"].Text);
+
+                SwitchBackToCurrentCulture();
+
+                package.Save();
+
+            }
+        }
+ 
+    }
+}


### PR DESCRIPTION
Fixes issue #1441. EPPlus will now format "?" as "#", so no spaces will be added for insignificant zeros in the text output. 
