### PR TITLE
Fix for issue #1493 and #1504

### DIFF
--- a/src/EPPlus/EPPlus.csproj
+++ b/src/EPPlus/EPPlus.csproj
@@ -600,5 +600,6 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <Folder Include="FormulaParsing\FormulaExpressions\Variables\" />
+	  <Folder Include="Settings\" />
 	</ItemGroup>
 </Project>

--- a/src/EPPlus/ExcelPackageSettings.cs
+++ b/src/EPPlus/ExcelPackageSettings.cs
@@ -11,6 +11,8 @@
   09/10/2020         EPPlus Software AB       Initial release EPPlus 5
  *************************************************************************************************/
 using OfficeOpenXml.Utils;
+using System.Collections.Generic;
+using System;
 
 namespace OfficeOpenXml
 {
@@ -19,6 +21,15 @@ namespace OfficeOpenXml
     /// </summary>
     public class ExcelPackageSettings
     {
+        /// <summary>
+        /// Culture specific number formats for the build-in number formats ranging from 14-47.
+        /// As some build-in number formats are culture specific, this collection adds the pi
+        /// </summary>
+        public static Dictionary<string, Dictionary<int, string>> CultureSpecificBuildInNumberFormats
+        {
+            get;
+        } = new Dictionary<string, Dictionary<int, string>>(StringComparer.InvariantCultureIgnoreCase);
+
         internal ExcelPackageSettings()
         {
 
@@ -58,7 +69,6 @@ namespace OfficeOpenXml
                 return _imageSettings;
             }
         }
-
         /// <summary>
         /// Any auto- or table- filters created will be applied on save.
         /// In the case you want to handle this manually, set this property to true.

--- a/src/EPPlus/ExcelRangeBase.cs
+++ b/src/EPPlus/ExcelRangeBase.cs
@@ -806,13 +806,23 @@ namespace OfficeOpenXml
         {
             get
             {
+
+                object value;
                 if (IsSingleCell || IsName)
                 {
-                    return ValueToTextHandler.GetFormattedText(Value, _workbook, StyleID, false);
+                    value = Value;
                 }
                 else
                 {
-                    return ValueToTextHandler.GetFormattedText(_worksheet.GetValue(_fromRow, _fromCol), _workbook, StyleID, false);
+                    value = _worksheet.GetValue(_fromRow, _fromCol);
+                }
+                if (_workbook.NumberFormatToTextHandler == null)
+                {
+                    return ValueToTextHandler.GetFormattedText(value, _workbook, StyleID, false);
+                }
+                else
+                {
+                    return _workbook.NumberFormatToTextHandler(new NumberFormatToTextNumberFormatToText(_worksheet, _fromRow, _fromCol, value, StyleID));
                 }
             }
         }

--- a/src/EPPlus/ExcelRangeBase.cs
+++ b/src/EPPlus/ExcelRangeBase.cs
@@ -822,7 +822,7 @@ namespace OfficeOpenXml
                 }
                 else
                 {
-                    return _workbook.NumberFormatToTextHandler(new NumberFormatToTextNumberFormatToText(_worksheet, _fromRow, _fromCol, value, StyleID));
+                    return _workbook.NumberFormatToTextHandler(new NumberFormatToTextArgs(_worksheet, _fromRow, _fromCol, value, StyleID));
                 }
             }
         }

--- a/src/EPPlus/ExcelWorkbook.cs
+++ b/src/EPPlus/ExcelWorkbook.cs
@@ -1969,5 +1969,7 @@ namespace OfficeOpenXml
 				return _richData;
 			}
 		}
-	} // end Workbook
+
+        public Func<NumberFormatToTextNumberFormatToText, string> NumberFormatToTextHandler { get; internal set; }
+    } // end Workbook
 }

--- a/src/EPPlus/ExcelWorkbook.cs
+++ b/src/EPPlus/ExcelWorkbook.cs
@@ -1970,6 +1970,6 @@ namespace OfficeOpenXml
 			}
 		}
 
-        public Func<NumberFormatToTextNumberFormatToText, string> NumberFormatToTextHandler { get; internal set; }
+        public Func<NumberFormatToTextArgs, string> NumberFormatToTextHandler { get; internal set; }
     } // end Workbook
 }

--- a/src/EPPlus/FormulaParsing/Excel/Operators/RangeOperationsOperator.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Operators/RangeOperationsOperator.cs
@@ -277,8 +277,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
             }
             if(left.DataType == DataType.ExcelRange && right.DataType == DataType.ExcelRange)
             {
-                InMemoryRange resultRange = ApplyRanges(left, right, op, context);
-                return new CompileResult(resultRange, DataType.ExcelRange);
+                var interSectAddress = left.Address?.GetIntersectingRowOrColumns(right.Address);
+                InMemoryRange resultRange = ApplyRanges(left, right, op, context, interSectAddress);
+                return new AddressCompileResult(resultRange, DataType.ExcelRange, interSectAddress);
             }
             return CompileResult.Empty;
         }
@@ -329,12 +330,12 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
             return resultRange;
         }
 
-        private static InMemoryRange ApplyRanges(CompileResult left, CompileResult right, Operators op, ParsingContext context)
+        private static InMemoryRange ApplyRanges(CompileResult left, CompileResult right, Operators op, ParsingContext context, FormulaRangeAddress intersectAddress)
         {
             var lr = left.Result as IRangeInfo;
             var rr = right.Result as IRangeInfo;
 
-            var resultRange = CreateRange(lr, rr, null);
+            var resultRange = CreateRange(lr, rr, intersectAddress);
             var shouldUseSingleCol = ShouldUseSingleCol(lr.Size, rr.Size);
             var shouldUseSingleRow = ShouldUseSingleRow(lr.Size, rr.Size);
             var shouldUseSingleCell = ShouldUseSingleCell(lr.Size, rr.Size);

--- a/src/EPPlus/FormulaParsing/LexicalAnalysis/FormulaAddress.cs
+++ b/src/EPPlus/FormulaParsing/LexicalAnalysis/FormulaAddress.cs
@@ -906,6 +906,32 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
                 return ri;
             }
         }
+
+        internal FormulaRangeAddress GetIntersectingRowOrColumns(FormulaRangeAddress address)
+        {
+            if (address == null || WorksheetIx != address.WorksheetIx) return null;
+
+            var fromRow = FromRow > address.FromRow ? FromRow : address.FromRow;
+            var toRow = ToRow < address.ToRow ? ToRow : address.ToRow;
+            var fromCol = FromCol > address.FromCol ? FromCol : address.FromCol;
+            var toCol = ToCol < address.ToCol ? ToCol : address.ToCol;
+
+            if (fromCol > toCol)
+            {
+                return new FormulaRangeAddress(_context, WorksheetIx, fromRow, 0, toRow, 0); // return intersect on columns. Rows does not intersect so return 0 for the row 
+            }
+            else if (fromRow > toRow)
+            {
+                return new FormulaRangeAddress(_context, WorksheetIx, 0, fromCol, 0, toCol); // return intersect on rows. Columns does not intersect so return 0 for the row 
+            }
+            else if (fromCol > toCol && fromRow > toRow)
+            {
+                return null;
+            }
+
+            return new FormulaRangeAddress(_context, WorksheetIx, fromRow, fromCol, toRow, toCol);
+        }
+
         /// <summary>
         /// Address
         /// </summary>

--- a/src/EPPlus/NumberFormatToText.cs
+++ b/src/EPPlus/NumberFormatToText.cs
@@ -1,0 +1,71 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  06/27/2024         EPPlus Software AB       Initial release EPPlus 5
+ *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Text;
+using OfficeOpenXml.Style;
+using OfficeOpenXml.Style.XmlAccess;
+using OfficeOpenXml.Utils;
+
+namespace OfficeOpenXml
+{
+    /// <summary>
+    /// Numberformat settings used in the <see cref=""/>
+    /// </summary>
+    public class NumberFormatToTextNumberFormatToText
+    {
+        internal int _styleId;
+        internal NumberFormatToTextNumberFormatToText(ExcelWorksheet ws, int row, int column, object value, int styleId)
+        {
+            Worksheet = ws;
+            Row = row;
+            Column = column;
+            Value = value;
+            _styleId = styleId;            
+        }
+        /// <summary>
+        /// The worksheet of the cell.
+        /// </summary>
+        public ExcelWorksheet Worksheet { get; }
+        /// <summary>
+        /// The Row of the cell.
+        /// </summary>
+        public int Row { get; }
+        /// <summary>
+        /// The column of the cell.
+        /// </summary>
+        public int Column { get;  }
+        /// <summary>
+        /// The number format settings for the cell
+        /// </summary>
+        public ExcelNumberFormatXml NumberFormat 
+        { 
+            get 
+            {
+                return ValueToTextHandler.GetNumberFormat(_styleId, Worksheet.Workbook.Styles);
+            } 
+        } 
+        /// <summary>
+        /// The value of the cell to be formatted
+        /// </summary>
+        public object Value { get; }
+        /// <summary>
+        /// The text formatted by EPPlus
+        /// </summary>
+        public string Text
+        {
+            get
+            { 
+                return ValueToTextHandler.GetFormattedText(Value, Worksheet.Workbook, _styleId, false);
+            }
+        }
+    }
+}

--- a/src/EPPlus/NumberFormatToTextArgs.cs
+++ b/src/EPPlus/NumberFormatToTextArgs.cs
@@ -20,10 +20,10 @@ namespace OfficeOpenXml
     /// <summary>
     /// Numberformat settings used in the <see cref=""/>
     /// </summary>
-    public class NumberFormatToTextNumberFormatToText
+    public class NumberFormatToTextArgs
     {
         internal int _styleId;
-        internal NumberFormatToTextNumberFormatToText(ExcelWorksheet ws, int row, int column, object value, int styleId)
+        internal NumberFormatToTextArgs(ExcelWorksheet ws, int row, int column, object value, int styleId)
         {
             Worksheet = ws;
             Row = row;

--- a/src/EPPlus/Style/ExcelNumberFormat.cs
+++ b/src/EPPlus/Style/ExcelNumberFormat.cs
@@ -18,6 +18,7 @@ using System.Globalization;
 using System.Linq;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Information;
 using static OfficeOpenXml.Style.ExcelNumberFormat;
+using OfficeOpenXml.Style.XmlAccess;
 
 namespace OfficeOpenXml.Style
 {
@@ -77,6 +78,15 @@ namespace OfficeOpenXml.Style
 
         internal static string GetFromBuildInFromID(int _numFmtId)
         {
+            //First check if we have custom formats.
+            if(ExcelPackageSettings.CultureSpecificBuildInNumberFormats.TryGetValue(CultureInfo.CurrentCulture.Name, out var customFormats))
+            {
+                if(customFormats.TryGetValue(_numFmtId, out var customFormat))
+                {
+                    return customFormat;
+                }
+            }
+
             switch (_numFmtId)
             {
                 case 0:
@@ -132,7 +142,7 @@ namespace OfficeOpenXml.Style
                 case 47:
                     return "mmss.0";
                 case 48:
-                    return "##0.0";
+                    return "##0.0E+0";
                 case 49:
                     return "@";
                 default:
@@ -141,6 +151,15 @@ namespace OfficeOpenXml.Style
         }
         internal static int GetFromBuildIdFromFormat(string format)
         {
+            if (ExcelPackageSettings.CultureSpecificBuildInNumberFormats.TryGetValue(CultureInfo.CurrentCulture.Name, out var customFormats))
+            {
+                var id = customFormats.Where(x => x.Value.Equals(format, StringComparison.OrdinalIgnoreCase)); //We scan the values here. Not the fastest way,but we avoid having two dictionaries.
+                if(id.Any())
+                {
+                    return id.First().Key;
+                }
+            }
+            
             switch (format)
             {
                 case "General":
@@ -196,7 +215,7 @@ namespace OfficeOpenXml.Style
                     return 46;
                 case "mmss.0":
                     return 47;
-                case "##0.0":
+                case "##0.0E+0":
                     return 48;
                 case "@":
                     return 49;

--- a/src/EPPlus/Style/XmlAccess/ExcelFormatTranslator.cs
+++ b/src/EPPlus/Style/XmlAccess/ExcelFormatTranslator.cs
@@ -14,13 +14,18 @@ namespace OfficeOpenXml.Style.XmlAccess
     /// </summary>
     internal class ExcelFormatTranslator
     {
+        [Flags]
         internal enum eSystemDateFormat
         {
-            None,
-            SystemLongDate,
-            SystemLongTime,
-            Conditional,
-            SystemShortDate,
+            None=0,
+            General=1,
+            SystemLongDate=2,
+            SystemLongTime=4,
+            Conditional=8,
+            SystemShortDate=0x10,
+            AllHours = 0x11,
+            AllMinutes=0x12,
+            AllSeconds = 0x14
         }
         internal class FormatPart
         {
@@ -58,8 +63,9 @@ namespace OfficeOpenXml.Style.XmlAccess
             }
             else if (format.Equals("general", StringComparison.OrdinalIgnoreCase))
             {
-                f.NetFormat = f.NetFormatForWidth = "0.#########";
+                f.NetFormat = f.NetFormatForWidth = "G10";
                 DataType = eFormatType.Number;
+                f.SpecialDateFormat = eSystemDateFormat.General;
             }
             else
             {
@@ -77,7 +83,13 @@ namespace OfficeOpenXml.Style.XmlAccess
         {
             get
             {
-                return _ci ?? CultureInfo.CurrentCulture;
+                if(_ci == null )
+                {
+                    _ci = (CultureInfo)CultureInfo.CurrentCulture.Clone();
+                    _ci.DateTimeFormat.AMDesignator = "AM";
+                    _ci.DateTimeFormat.PMDesignator = "PM";
+                }
+                return _ci;
             }
             set
             {
@@ -161,7 +173,9 @@ namespace OfficeOpenXml.Style.XmlAccess
                                     {
                                         try
                                         {
-                                            Culture = CultureInfo.GetCultureInfo(num & 0xFFFF);
+                                            Culture = (CultureInfo)CultureInfo.GetCultureInfo(num & 0xFFFF).Clone();
+                                            Culture.DateTimeFormat.AMDesignator = "AM";
+                                            Culture.DateTimeFormat.PMDesignator = "PM";
                                         }
                                         catch
                                         {
@@ -172,7 +186,9 @@ namespace OfficeOpenXml.Style.XmlAccess
                                     {
                                         try
                                         {
-                                            Culture = CultureInfo.GetCultureInfo(li[1]);
+                                            Culture = (CultureInfo)CultureInfo.GetCultureInfo(li[1]).Clone();
+                                            Culture.DateTimeFormat.AMDesignator = "AM";
+                                            Culture.DateTimeFormat.PMDesignator = "PM";
                                         }
                                         catch
                                         {
@@ -186,6 +202,21 @@ namespace OfficeOpenXml.Style.XmlAccess
                                     bracketText.StartsWith("=")) //Conditional
                             {
                                 f.SpecialDateFormat = eSystemDateFormat.Conditional;
+                            }
+                            else if (bracketText.ContainsOnlyCharacter('h'))
+                            {                                
+                                f.SpecialDateFormat = eSystemDateFormat.AllHours;
+                                sb.Append("[h]");
+                            }
+                            else if (bracketText.ContainsOnlyCharacter('m'))
+                            {
+                                f.SpecialDateFormat = eSystemDateFormat.AllMinutes;
+                                sb.Append("[m]");
+                            }
+                            else if (bracketText.ContainsOnlyCharacter('s'))
+                            {
+                                f.SpecialDateFormat = eSystemDateFormat.AllSeconds;
+                                sb.Append("[s]");
                             }
                             else
                             {
@@ -285,7 +316,7 @@ namespace OfficeOpenXml.Style.XmlAccess
                             }
                             else if (clc == 'm')
                             {
-                                if (useMinute)
+                                if (useMinute || NextCharIsTimeOperator(ExcelFormat, pos)) //Excel uses m for both month and minutes, so we need to check if the previous operator is 
                                 {
                                     sb.Append('m');
                                 }
@@ -371,6 +402,24 @@ namespace OfficeOpenXml.Style.XmlAccess
             f.SetFormat(sb.ToString(), containsAmPm, forColWidth);
         }
 
+        private bool NextCharIsTimeOperator(string excelFormat, int pos)
+        {
+            var i = pos + 1;
+            while (i < excelFormat.Length)
+            {
+                if (excelFormat[i] == ':'  || excelFormat[i] == 's')
+                {
+                    return true;
+                }
+                if(excelFormat[i] != 'm' && excelFormat[i] != 'M' && excelFormat[i] != '.')
+                {
+                    break;
+                }
+                i++;
+            }
+            return false;
+        }
+
         private static void SetDecimal(List<int> lstDec, StringBuilder sb)
         {
             if (lstDec.Count > 1)
@@ -386,9 +435,6 @@ namespace OfficeOpenXml.Style.XmlAccess
         internal string FormatFraction(double d, FormatPart f)
         {
             int numerator, denomerator;
-
-            int intPart = (int)d;
-
             string[] fmt = f.FractionFormat.Split('/');
 
             int fixedDenominator;
@@ -410,7 +456,19 @@ namespace OfficeOpenXml.Style.XmlAccess
             }
 
             int maxDigits = fmt[1].Length;
-            string sign = d < 0 ? "-" : "";
+            //string sign;
+            //if (d < 0D)
+            //{
+            //    sign = "-"; 
+            //    d=Math.Abs(d);
+            //}
+            //else
+            //{
+            //    sign = "";
+            //}
+            
+            int intPart = (int)d;
+            int intPartAbs = Math.Abs(intPart);
             if (fixedDenominator == 0)
             {
                 List<double> numerators = new List<double>() { 1, 0 };
@@ -427,7 +485,7 @@ namespace OfficeOpenXml.Style.XmlAccess
                     maxNum += 9 * (int)(Math.Pow((double)10, (double)i));
                 }
 
-                double divRes = 1 / ((double)Math.Abs(d) - intPart);
+                double divRes = 1 / ((double)Math.Abs(d) - intPartAbs);
                 double result, prevResult = double.NaN;
                 int listPos = 2, index = 1;
                 while (true)
@@ -469,15 +527,15 @@ namespace OfficeOpenXml.Style.XmlAccess
             if (numerator == denomerator || numerator == 0)
             {
                 if (numerator == denomerator) intPart++;
-                return sign + intPart.ToString(f.NetFormat).Replace("?", new string(' ', f.FractionFormat.Length));
+                return intPart.ToString(f.NetFormat).Replace("?", new string(' ', f.FractionFormat.Length));
             }
             else if (intPart == 0)
             {
-                return sign + FmtInt(numerator, fmt[0]) + "/" + FmtInt(denomerator, fmt[1]);
+                return FmtInt(numerator, fmt[0]) + "/" + FmtInt(denomerator, fmt[1]);
             }
             else
             {
-                return sign + intPart.ToString(f.NetFormat).Replace("?", FmtInt(numerator, fmt[0]) + "/" + FmtInt(denomerator, fmt[1]));
+                return intPart.ToString(f.NetFormat).Replace("?", FmtInt(numerator, fmt[0]) + "/" + FmtInt(denomerator, fmt[1]));
             }
         }
 
@@ -503,7 +561,7 @@ namespace OfficeOpenXml.Style.XmlAccess
         }
 
         internal FormatPart GetFormatPart(object value)
-        {
+        {            
             if (Formats.Count > 1)
             {
                 if (ConvertUtil.IsNumericOrDate(value))
@@ -534,9 +592,29 @@ namespace OfficeOpenXml.Style.XmlAccess
                     }
                 }
             }
+            else if (Formats[0].SpecialDateFormat==eSystemDateFormat.General)
+            {
+                var d = ConvertUtil.GetValueDouble(value);
+                Formats[0].NetFormat = Formats[0].NetFormatForWidth = GetGeneralFormatFromDoubleValue(d);
+
+            }
+
+            return Formats[0];
+        }
+
+        internal static string GetGeneralFormatFromDoubleValue(double d)
+        {
+            if (d > -999999999D || d < 999999999)
+            {
+                return "G10";
+            }
+            else if (d > -9999999999D || d < 9999999999)
+            {
+                return "G11";
+            }
             else
             {
-                return Formats[0];
+                return "G12";
             }
         }
     }

--- a/src/EPPlus/Style/XmlAccess/ExcelFormatTranslator.cs
+++ b/src/EPPlus/Style/XmlAccess/ExcelFormatTranslator.cs
@@ -389,14 +389,7 @@ namespace OfficeOpenXml.Style.XmlAccess
                 }
             }
 
-            //Add qoutes
             if (DataType == eFormatType.DateTime) SetDecimal(lstDec, sb); //Remove?
-
-
-            //if (format == "")
-            //    format = sb.ToString();
-            //else
-            //    text = sb.ToString();
 
             // AM/PM format
             f.SetFormat(sb.ToString(), containsAmPm, forColWidth);
@@ -455,18 +448,7 @@ namespace OfficeOpenXml.Style.XmlAccess
                 }
             }
 
-            int maxDigits = fmt[1].Length;
-            //string sign;
-            //if (d < 0D)
-            //{
-            //    sign = "-"; 
-            //    d=Math.Abs(d);
-            //}
-            //else
-            //{
-            //    sign = "";
-            //}
-            
+            int maxDigits = fmt[1].Length;           
             int intPart = (int)d;
             int intPartAbs = Math.Abs(intPart);
             if (fixedDenominator == 0)

--- a/src/EPPlus/Style/XmlAccess/ExcelNumberFormatXml.cs
+++ b/src/EPPlus/Style/XmlAccess/ExcelNumberFormatXml.cs
@@ -1,4 +1,4 @@
-/*************************************************************************************************
+﻿/*************************************************************************************************
   Required Notice: Copyright (C) EPPlus Software AB. 
   This software is licensed under PolyForm Noncommercial License 1.0.0 
   and may only be used for noncommercial purposes 
@@ -17,24 +17,32 @@ using System.Xml;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using OfficeOpenXml.Utils;
+using System.Runtime.InteropServices;
 
 namespace OfficeOpenXml.Style.XmlAccess
 {
     /// <summary>
-    /// Xml access class for number formats
+    /// Xml access class for number customFormats
     /// </summary>
     public sealed class ExcelNumberFormatXml : StyleXmlHelper
     {
+
         internal ExcelNumberFormatXml(XmlNamespaceManager nameSpaceManager) : base(nameSpaceManager)
         {
-            
-        }        
-        internal ExcelNumberFormatXml(XmlNamespaceManager nameSpaceManager, bool buildIn): base(nameSpaceManager)
+
+        }
+        internal ExcelNumberFormatXml(XmlNamespaceManager nameSpaceManager, bool buildIn) : base(nameSpaceManager)
         {
             BuildIn = buildIn;
         }
+        internal ExcelNumberFormatXml(XmlNamespaceManager nameSpaceManager, bool buildIn, int numFmtId, string format) : base(nameSpaceManager)
+        {
+            BuildIn = buildIn;
+            _numFmtId = numFmtId;
+            _format = format;
+        }
         internal ExcelNumberFormatXml(XmlNamespaceManager nsm, XmlNode topNode) :
-            base(nsm, topNode)
+        base(nsm, topNode)
         {
             _numFmtId = GetXmlNodeInt("@numFmtId");
             _format = GetXmlNodeString("@formatCode");
@@ -114,46 +122,63 @@ namespace OfficeOpenXml.Style.XmlAccess
             }
         }
         internal string GetNewID(int NumFmtId, string Format)
-        {            
+        {
             if (NumFmtId < 0)
             {
-                NumFmtId = ExcelNumberFormat.GetFromBuildIdFromFormat(Format);                
+                NumFmtId = ExcelNumberFormat.GetFromBuildIdFromFormat(Format);
             }
             return NumFmtId.ToString();
         }
 
         internal static void AddBuildIn(XmlNamespaceManager NameSpaceManager, ExcelStyleCollection<ExcelNumberFormatXml> NumberFormats)
         {
-            NumberFormats.Add("General",new ExcelNumberFormatXml(NameSpaceManager,true){NumFmtId=0,Format="General"});
-            NumberFormats.Add("0", new ExcelNumberFormatXml(NameSpaceManager,true) { NumFmtId = 1, Format = "0" });
-            NumberFormats.Add("0.00", new ExcelNumberFormatXml(NameSpaceManager,true) { NumFmtId = 2, Format = "0.00" });
-            NumberFormats.Add("#,##0", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 3, Format = "#,##0" });
-            NumberFormats.Add("#,##0.00", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 4, Format = "#,##0.00" });
-            NumberFormats.Add("0%", new ExcelNumberFormatXml(NameSpaceManager,true) { NumFmtId = 9, Format = "0%" });
-            NumberFormats.Add("0.00%", new ExcelNumberFormatXml(NameSpaceManager,true) { NumFmtId = 10, Format = "0.00%" });
-            NumberFormats.Add("0.00E+00", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 11, Format = "0.00E+00" });
-            NumberFormats.Add("# ?/?", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 12, Format = "# ?/?" });
-            NumberFormats.Add("# ??/??", new ExcelNumberFormatXml(NameSpaceManager,true) { NumFmtId = 13, Format = "# ??/??" });
-            NumberFormats.Add("mm-dd-yy", new ExcelNumberFormatXml(NameSpaceManager,true) { NumFmtId = 14, Format = "mm-dd-yy" });
-            NumberFormats.Add("d-mmm-yy", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 15, Format = "d-mmm-yy" });
-            NumberFormats.Add("d-mmm", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 16, Format = "d-mmm" });
-            NumberFormats.Add("mmm-yy", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 17, Format = "mmm-yy" });
-            NumberFormats.Add("h:mm AM/PM", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 18, Format = "h:mm AM/PM" });
-            NumberFormats.Add("h:mm:ss AM/PM", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 19, Format = "h:mm:ss AM/PM" });
-            NumberFormats.Add("h:mm", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 20, Format = "h:mm" });
-            NumberFormats.Add("h:mm:ss", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 21, Format = "h:mm:ss" });
-            NumberFormats.Add("m/d/yy h:mm", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 22, Format = "m/d/yy h:mm" });
-            NumberFormats.Add("#,##0 ;(#,##0)", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 37, Format = "#,##0 ;(#,##0)" });
-            NumberFormats.Add("#,##0 ;[Red](#,##0)", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 38, Format = "#,##0 ;[Red](#,##0)" });
-            NumberFormats.Add("#,##0.00;(#,##0.00)", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 39, Format = "#,##0.00;(#,##0.00)" });
-            NumberFormats.Add("#,##0.00;[Red](#,##0.00)", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 40, Format = "#,##0.00;[Red](#,##0.00)" });
-            NumberFormats.Add("mm:ss", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 45, Format = "mm:ss" });
-            NumberFormats.Add("[h]:mm:ss", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 46, Format = "[h]:mm:ss" });
-            NumberFormats.Add("mmss.0", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 47, Format = "mmss.0" });
-            NumberFormats.Add("##0.0", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 48, Format = "##0.0" });
-            NumberFormats.Add("@", new ExcelNumberFormatXml(NameSpaceManager, true) { NumFmtId = 49, Format = "@" });
+            var customFormats = ExcelPackageSettings.CultureSpecificBuildInNumberFormats.ContainsKey(CultureInfo.CurrentCulture.Name) ? ExcelPackageSettings.CultureSpecificBuildInNumberFormats[CultureInfo.CurrentCulture.Name] : null;
 
-            NumberFormats.NextId = 164; //Start for custom formats.
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 0, "General");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 1, "0");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 2,"0.00");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 3, "#,##0");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 4, "#,##0.00");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 9, "0%");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 10, "0.00%");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 11, "0.00E+00");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 12, "# ?/?");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 13, "# ??/??");
+
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 14, "mm-dd-yy");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 15, "d-mmm-yy");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 16, "d-mmm");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 17, "mmm-yy");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 18, "h:mm AM/PM");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 19, "h:mm:ss AM/PM");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 20, "h:mm");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 21, "h:mm:ss");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 22, "m/d/yy h:mm");
+
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 37, "#,##0 ;(#,##0)");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 38, "#,##0 ;[Red](#,##0)");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 39, "#,##0.00;(#,##0.00)");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 40, "#,##0.00;[Red](#,##0.00)");
+
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 45, "mm:ss");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 46, "[h]:mm:ss");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 47, "mmss.0");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 48,"##0.0E+0");
+            AddLocalizedFormat(NameSpaceManager, NumberFormats, customFormats, 49, "@");
+
+            NumberFormats.NextId = 164; //Start for custom customFormats.
+        }
+
+        private static void AddLocalizedFormat(XmlNamespaceManager nameSpaceManager, ExcelStyleCollection<ExcelNumberFormatXml> numberFormats, Dictionary<int, string> customFormats, int numFmtId, string format)
+        {
+            if (customFormats != null && customFormats.TryGetValue(numFmtId, out string customFormat))
+            {
+                numberFormats.Add(customFormat, new ExcelNumberFormatXml(nameSpaceManager, true, numFmtId, customFormat));
+            }
+            else
+            {
+                numberFormats.Add(format, new ExcelNumberFormatXml(nameSpaceManager, true, numFmtId, format));
+            }
         }
 
         internal override XmlNode CreateXmlNode(XmlNode topNode)

--- a/src/EPPlus/Table/PivotTable/ExcelPivotCacheDefinition.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotCacheDefinition.cs
@@ -85,7 +85,10 @@ namespace OfficeOpenXml.Table.PivotTable
             var rel = pivotTable.Part.CreateRelationship(UriHelper.ResolvePartUri(pivotTable.PivotTableUri, _cacheReference.CacheDefinitionUri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/pivotCacheDefinition");
         }
 
-        internal void Refresh()
+        /// <summary>
+        /// Refreshes the pivot tables cache.
+        /// </summary>
+        public void Refresh()
         {
             _cacheReference.RefreshFields();
         }

--- a/src/EPPlus/Table/PivotTable/ExcelPivotTableField.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotTableField.cs
@@ -624,6 +624,7 @@ namespace OfficeOpenXml.Table.PivotTable
                 }
                 _items.AddInternal(item);
             }
+
             Cache.UpdateSubTotalItems(Items._list, _subTotalFunctions);
         }
 
@@ -1024,7 +1025,7 @@ namespace OfficeOpenXml.Table.PivotTable
                     }
                     else
                     {
-                        item.X = -1;                        
+                        item.X = -1;
                     }
                     item.GetXmlString(sb);
                 }

--- a/src/EPPlus/Table/PivotTable/ExcelPivotTableFieldCollectionBase.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotTableFieldCollectionBase.cs
@@ -92,7 +92,8 @@ namespace OfficeOpenXml.Table.PivotTable
         /// <returns>The index of the item</returns>
         public int GetIndexByValue(object value)
         {
-			var cl = _field.Cache.GetCacheLookup();
+            if (value == null) return -1; 
+            var cl = _field.Cache.GetCacheLookup();
 			if (cl.TryGetValue(value, out int ix))
             {
                 if(_cacheDictionary.TryGetValue(ix, out int i))
@@ -104,14 +105,16 @@ namespace OfficeOpenXml.Table.PivotTable
         }
         internal void MatchValueToIndex()
         {
-            var cacheLookup = _field.Cache.GetCacheLookup();
+            var cache = _field.Cache;
+            var isGroup = cache.Grouping != null;
+            var cacheLookup = cache.GetCacheLookup();
             foreach (var item in _list)
             {
                 var v = item.Value ?? ExcelPivotTable.PivotNullValue;
                 if (item.Type == eItemType.Data && cacheLookup.TryGetValue(v, out int x))
                 {
                     item.X = cacheLookup[v];
-                }
+                }                
                 else
                 {
                     item.X = -1;
@@ -209,7 +212,7 @@ namespace OfficeOpenXml.Table.PivotTable
 
 			public int Compare(ExcelPivotTableFieldItem x, ExcelPivotTableFieldItem y)
 			{
-                if (x.Type == eItemType.Data)
+                if (x.Type == eItemType.Data && y.Type == eItemType.Data)
                 {
                     var xText = GetTextValue(x);
                     var yText = GetTextValue(y);
@@ -217,7 +220,7 @@ namespace OfficeOpenXml.Table.PivotTable
                 }
                 else
                 {
-					return 1;
+					return x.Type == eItemType.Data ? -1 : 1;
 				}
 			}
 

--- a/src/EPPlus/Table/PivotTable/ExcelPivotTablePageFieldSettings.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotTablePageFieldSettings.cs
@@ -94,6 +94,11 @@ namespace OfficeOpenXml.Table.PivotTable
                 }
             }
         }
+        internal object SelectedValue
+        {
+            get;
+            set;
+        }
         /// <summary>
         /// The index of the OLAP hierarchy to which this page field belongs
         /// </summary>

--- a/src/EPPlus/Table/PivotTable/PivotTableCacheInternal.cs
+++ b/src/EPPlus/Table/PivotTable/PivotTableCacheInternal.cs
@@ -233,6 +233,7 @@ namespace OfficeOpenXml.Table.PivotTable
 
         internal void RefreshFields()
         {
+            UpdatePageFieldValues();
             var tableFields = GetTableFields();
             var fields = new List<ExcelPivotTableCacheField>();
             var r = SourceRange;
@@ -292,6 +293,20 @@ namespace OfficeOpenXml.Table.PivotTable
             
             RefreshPivotTableItems();
             Records.CreateRecords();
+        }
+
+        private void UpdatePageFieldValues()
+        {
+            foreach(var pt in _pivotTables)
+            {
+                foreach(var pf in pt.PageFields)
+                {
+                    if (pf.PageFieldSettings.SelectedItem>=0 && pf.PageFieldSettings.SelectedItem < pf.Items.Count)
+                    {
+                        pf.PageFieldSettings.SelectedValue = pf.Items[pf.PageFieldSettings.SelectedItem].Value;
+                    }
+                }
+            }
         }
 
         private void RemoveDeletedFields(ExcelRangeBase r)
@@ -466,7 +481,15 @@ namespace OfficeOpenXml.Table.PivotTable
 
                     for(int i=0;i < fieldCount;i++)
                     {
-                        pt.Fields[i].Items.Refresh();
+                        var field = pt.Fields[i];
+                        field.Items.Refresh();
+                        if(field.IsPageField && field.PageFieldSettings.SelectedItem > -1)
+                        {
+                            if (field.Items.Count <= field.PageFieldSettings.SelectedItem)
+                            {
+                                field.PageFieldSettings.SelectedItem = field.Items.GetIndexByValue(field.PageFieldSettings.SelectedValue);
+                            }
+                        }
                     }
                 }
             }

--- a/src/EPPlus/Utils/RecyclableMemory.cs
+++ b/src/EPPlus/Utils/RecyclableMemory.cs
@@ -50,7 +50,7 @@ namespace OfficeOpenXml.Utils
 			}
 			set
 			{
-				RecyclableMemory.UseRecyclableMemory = value; ;
+				RecyclableMemory.UseRecyclableMemory = value;
             } 
 		}
 	}

--- a/src/EPPlus/Utils/StringExtensions.cs
+++ b/src/EPPlus/Utils/StringExtensions.cs
@@ -22,5 +22,23 @@
 
             return string.Empty;
         }
+        internal static bool ContainsOnlyCharacter(this string s, char theCharacter, bool ignoreCase=true)
+        {
+            if (string.IsNullOrEmpty(s)) return false;
+            if (ignoreCase)
+            {
+                s = s.ToLower();
+                theCharacter = char.ToLower(theCharacter);
+            }
+
+            foreach(var c in s)
+            {
+                if(c != theCharacter)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 }

--- a/src/EPPlus/Utils/ValueToTextHandler.cs
+++ b/src/EPPlus/Utils/ValueToTextHandler.cs
@@ -28,23 +28,30 @@ namespace OfficeOpenXml.Utils
             object v = Value;
             if (v == null) return "";
             var styles = wb.Styles;
+            ExcelFormatTranslator nf = GetNumberFormat(styleId, styles).FormatTranslator;
+
+            return FormatValue(v, forWidthCalc, nf, cultureInfo);
+        }
+
+        internal static ExcelNumberFormatXml GetNumberFormat(int styleId, ExcelStyles styles)
+        {
             var nfID = styles.CellXfs[styleId].NumberFormatId;
             ExcelFormatTranslator nf = null;
             for (int i = 0; i < styles.NumberFormats.Count; i++)
             {
                 if (nfID == styles.NumberFormats[i].NumFmtId)
                 {
-                    nf = styles.NumberFormats[i].FormatTranslator;
-                    break;
+                    return styles.NumberFormats[i];
                 }
             }
             if (nf == null)
             {
-                nf = styles.NumberFormats[0].FormatTranslator;  //nf should never be null. If so set to General, Issue 173
+                return styles.NumberFormats[0];  //nf should never be null. If so set to General, Issue 173
             }
 
-            return FormatValue(v, forWidthCalc, nf, cultureInfo);
+            return null;
         }
+
         internal static string FormatValue(object v, bool forWidthCalc, ExcelFormatTranslator nf, CultureInfo overrideCultureInfo)
         {
             var f = nf.GetFormatPart(v);
@@ -108,7 +115,8 @@ namespace OfficeOpenXml.Utils
                 {
                     if(format.IndexOf("{0}")>=0)
                     {
-                        return string.Format(format, d);
+                        var fmt = ExcelFormatTranslator.GetGeneralFormatFromDoubleValue(d);
+                        return string.Format(format, d.ToString(fmt));
                     }
                     else
                     {
@@ -217,7 +225,7 @@ namespace OfficeOpenXml.Utils
         }
 
         private static string GetDateText(DateTime d, string format, ExcelFormatTranslator.FormatPart f, CultureInfo cultureInfo)
-        {           
+        {
             if (f.SpecialDateFormat == ExcelFormatTranslator.eSystemDateFormat.SystemLongDate)
             {
                 return d.ToLongDateString();
@@ -229,6 +237,31 @@ namespace OfficeOpenXml.Utils
             else if (f.SpecialDateFormat == ExcelFormatTranslator.eSystemDateFormat.SystemShortDate)
             {
                 return d.ToShortDateString();
+            }
+            else if(f.SpecialDateFormat != ExcelFormatTranslator.eSystemDateFormat.None)
+            {
+                TimeSpan ts;
+                if (f.NetFormat.IndexOf("y") >= 0 || f.NetFormat.IndexOf("d")>=0)
+                {
+                    ts = new TimeSpan(d.Ticks - d.Date.Ticks);
+                }
+                else
+                {
+                    ts = new TimeSpan(d.Ticks - 599264352000000000);
+                }
+
+                if ((f.SpecialDateFormat & ExcelFormatTranslator.eSystemDateFormat.AllHours)== ExcelFormatTranslator.eSystemDateFormat.AllHours)
+                {
+                    format = format.Replace("[h]", ((int)ts.TotalHours).ToString(CultureInfo.InvariantCulture));
+                }
+                if ((f.SpecialDateFormat & ExcelFormatTranslator.eSystemDateFormat.AllMinutes) == ExcelFormatTranslator.eSystemDateFormat.AllMinutes)
+                {
+                    format = format.Replace("[m]", ((int)ts.TotalMinutes).ToString(CultureInfo.InvariantCulture));
+                }
+                if ((f.SpecialDateFormat & ExcelFormatTranslator.eSystemDateFormat.AllSeconds) == ExcelFormatTranslator.eSystemDateFormat.AllSeconds)
+                {
+                    format = format.Replace("[s]", ((int)ts.TotalSeconds).ToString(CultureInfo.InvariantCulture));
+                }
             }
             if (format == "d" || format == "D")
             {

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/DateTimeFunctionsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/DateTimeFunctionsTests.cs
@@ -423,7 +423,6 @@ namespace EPPlusTest.Excel.Functions
 
             Assert.IsTrue(Math.Abs(0.0861 - roundedResult) < double.Epsilon);
         }
-
         [TestMethod]
         public void YearFracShouldReturnCorrectResultWithEuroBasis()
         {

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -247,5 +247,120 @@ namespace EPPlusTest.Issues
                 SaveAndCleanup(p1);
             }
         }
+        [TestMethod]
+        public void Issue_1497_Dynamic_Array_Formulae()
+        {
+
+            //Issue: If two namedRanges (columns with Names) are calculated like "=range1 + range2" Only the first row of the ranges are calculated and the result is copied to the rest of the rows from the resultcolumn. 
+
+#if Core
+            var dir = AppContext.BaseDirectory;
+            dir = Directory.GetParent(dir).Parent.Parent.Parent.FullName;
+#else
+            var dir = AppDomain.CurrentDomain.BaseDirectory;
+#endif
+            using var p = OpenTemplatePackage("i1497.xlsx");
+
+            var ws = p.Workbook.Worksheets.First();
+            ws.Calculate();
+
+            //range in range in Fomular
+            Assert.AreEqual(311d, ws.Cells["C1"].Value);
+            Assert.AreEqual(306d, ws.Cells["C2"].Value);
+
+            //range1+range2 horizontal
+            Assert.AreEqual(103d, ws.Cells["C3"].Value);
+            Assert.AreEqual(104d, ws.Cells["C4"].Value);
+            Assert.AreEqual(105d, ws.Cells["C5"].Value);
+            Assert.AreEqual(106d, ws.Cells["C6"].Value);
+            Assert.AreEqual(107d, ws.Cells["C7"].Value);
+            Assert.AreEqual(108d, ws.Cells["C8"].Value);
+            Assert.AreEqual(109d, ws.Cells["C9"].Value);
+            Assert.AreEqual(110d, ws.Cells["C10"].Value);
+
+            Assert.AreEqual(112d, ws.Cells["C12"].Value);
+            Assert.AreEqual(113d, ws.Cells["C13"].Value);
+            Assert.AreEqual(114d, ws.Cells["C14"].Value);
+
+            //range3+range4 vertical
+            Assert.AreEqual(101d, ws.Cells["F21"].Value);
+            Assert.AreEqual(102d, ws.Cells["G21"].Value);
+            Assert.AreEqual(103d, ws.Cells["H21"].Value);
+            Assert.AreEqual(104d, ws.Cells["I21"].Value);
+            Assert.AreEqual(105d, ws.Cells["J21"].Value);
+            Assert.AreEqual(106d, ws.Cells["K21"].Value);
+            Assert.AreEqual(107d, ws.Cells["L21"].Value);
+            Assert.AreEqual(108d, ws.Cells["M21"].Value);
+            Assert.AreEqual(109d, ws.Cells["N21"].Value);
+            Assert.AreEqual(110d, ws.Cells["O21"].Value);
+            Assert.AreEqual(111d, ws.Cells["P21"].Value);
+            Assert.AreEqual(112d, ws.Cells["Q21"].Value);
+            Assert.AreEqual(113d, ws.Cells["R21"].Value);
+
+            //When Issue_WithRangeCalculation_IF
+            Assert.AreEqual(306d, ws.Cells["H2"].Value);
+            Assert.AreEqual(103d, ws.Cells["H3"].Value);
+            Assert.AreEqual(104d, ws.Cells["H4"].Value);
+            Assert.AreEqual(105d, ws.Cells["H5"].Value);
+
+            Assert.AreEqual(100d, ws.Cells["I2"].Value);
+            Assert.AreEqual(100d, ws.Cells["I3"].Value);
+            Assert.AreEqual(100d, ws.Cells["I4"].Value);
+            Assert.AreEqual(100d, ws.Cells["I5"].Value);
+
+            Assert.AreEqual(100d, ws.Cells["J2"].Value);
+            Assert.AreEqual(100d, ws.Cells["J3"].Value);
+            Assert.AreEqual(100d, ws.Cells["J4"].Value);
+            Assert.AreEqual(100d, ws.Cells["J5"].Value);
+
+            Assert.AreEqual("Falsche Auswahl", ws.Cells["K2"].Value);
+            Assert.AreEqual("Falsche Auswahl", ws.Cells["K3"].Value);
+            Assert.AreEqual("Falsche Auswahl", ws.Cells["K4"].Value);
+            Assert.AreEqual("Falsche Auswahl", ws.Cells["K5"].Value);
+
+
+            //Normal
+            Assert.AreEqual(198d, ws.Cells["C18"].Value);
+
+            //String
+            Assert.AreEqual("#VALUE!", ws.Cells["C19"].Value.ToString());
+            Assert.AreEqual("#VALUE!", ws.Cells["C15"].Value.ToString());
+
+            //Empty Cell
+            Assert.AreEqual(100d, ws.Cells["C11"].Value);
+            Assert.AreEqual(20d, ws.Cells["C20"].Value);
+
+            //OutOfRange IF
+            Assert.AreEqual("#VALUE!", ws.Cells["H1"].Value.ToString());
+            Assert.AreEqual("#VALUE!", ws.Cells["I1"].Value.ToString());
+            Assert.AreEqual("#VALUE!", ws.Cells["J1"].Value.ToString());
+            Assert.AreEqual("Falsche Auswahl", ws.Cells["K1"].Value);
+            Assert.AreEqual("#VALUE!", ws.Cells["H6"].Value.ToString());
+            Assert.AreEqual("#VALUE!", ws.Cells["I6"].Value.ToString());
+            Assert.AreEqual("#VALUE!", ws.Cells["J6"].Value.ToString());
+            Assert.AreEqual("Falsche Auswahl", ws.Cells["K6"].Value);
+
+            //OutOfRange Normal
+            Assert.AreEqual("#VALUE!", ws.Cells["C16"].Value.ToString());
+            Assert.AreEqual("#VALUE!", ws.Cells["E21"].Value.ToString());
+            Assert.AreEqual("#VALUE!", ws.Cells["S21"].Value.ToString());
+
+            //UseAGAIN
+            Assert.AreEqual(206d, ws.Cells["F2"].Value);
+            Assert.AreEqual(3d, ws.Cells["F3"].Value);
+            Assert.AreEqual(4d, ws.Cells["F4"].Value);
+            Assert.AreEqual(5d, ws.Cells["F5"].Value);
+            //UseIFAGAIN
+            Assert.AreEqual(306d, ws.Cells["M2"].Value);
+            Assert.AreEqual(103d, ws.Cells["M3"].Value);
+            Assert.AreEqual(104d, ws.Cells["M4"].Value);
+            Assert.AreEqual(105d, ws.Cells["M5"].Value);
+            Assert.AreEqual("#VALUE!", ws.Cells["M6"].Value.ToString());
+
+
+            //Check if something in if is fixed wrong
+            Assert.AreEqual(2d, ws.Cells["F11"].Value);
+            Assert.AreEqual(1d, ws.Cells["F12"].Value);
+        }
     }
 }

--- a/src/EPPlusTest/Issues/PivotTableIssues.cs
+++ b/src/EPPlusTest/Issues/PivotTableIssues.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using System.IO;
+using OfficeOpenXml.FormulaParsing;
+
+namespace EPPlusTest.Issues
+{
+    [TestClass]
+    public class PivotTableIssues : TestBase
+    {
+        [TestMethod]
+        public void s688()
+        {
+            using (ExcelPackage package = OpenTemplatePackage("s688.xlsx"))
+            {
+                package.Workbook.Worksheets[0].PivotTables[0].Calculate(true);
+                SaveAndCleanup(package);
+            }
+        }
+        [TestMethod]
+        public void s692()
+        {
+            using (ExcelPackage p = OpenTemplatePackage("s692.xlsx"))
+            {
+                foreach (ExcelWorksheet worksheet in p.Workbook.Worksheets)
+                {
+                    foreach (var table in worksheet.PivotTables)
+                    {
+                        table.Calculate(refreshCache: true);
+                    }
+                }
+                SaveAndCleanup(p);
+            }
+        }
+    }
+}

--- a/src/EPPlusTest/Issues/StylingIssues.cs
+++ b/src/EPPlusTest/Issues/StylingIssues.cs
@@ -72,12 +72,6 @@ namespace EPPlusTest
         public void IssueMissingDecimalsTextFormular()
         {
             //Issue: TEXT-formular deletes decimals in german format
-#if Core
-            var dir = AppContext.BaseDirectory;
-            dir = Directory.GetParent(dir).Parent.Parent.Parent.FullName;
-#else
-            var dir = AppDomain.CurrentDomain.BaseDirectory;
-#endif
             using var p = OpenTemplatePackage("Textformat.xlsx");
 
             SwitchToCulture("de-DE");
@@ -113,6 +107,102 @@ namespace EPPlusTest
 			//Assert.AreEqual("-,--€", p.Workbook.Worksheets[0].Cells["A20"].Value);
 
 			SwitchBackToCurrentCulture();
+        }
+        [TestMethod]
+        public void Issue1493()
+        {
+            ExcelPackageSettings.CultureSpecificBuildInNumberFormats.Add("de-DE",
+                new Dictionary<int, string>()
+                {
+                   {14, "dd.mm.yyyy"}, {15,"dd. mmm yy"}, {16,"dd. mmm"}, {17,"mmm yy"}, {18, "hh:mm AM/PM" }, {22, "dd.mm.yyyy hh:mm"},{39, "#,##0.00;-#,##0.00"}, {47, "mm:ss,f"}
+                });
+
+            using var p = OpenTemplatePackage("i1493.xlsx");
+            
+            SwitchToCulture("de-DE");
+            p.Workbook.NumberFormatToTextHandler = TextHandler;
+            p.Workbook.Calculate();
+            var ws = p.Workbook.Worksheets[0];
+
+            Assert.AreEqual("123456789,1", ws.Cells["A2"].Text); // actual "123456789,123456"
+            Assert.AreEqual("123456789", ws.Cells["A3"].Text);
+            Assert.AreEqual("123456789,12", ws.Cells["A4"].Text);
+            Assert.AreEqual("123.456.789", ws.Cells["A5"].Text);
+            Assert.AreEqual("123.456.789,12", ws.Cells["A6"].Text);
+            Assert.AreEqual("123.456.789,12", ws.Cells["A9"].Text);
+            Assert.AreEqual("123.456.789,12", ws.Cells["A10"].Text);
+            Assert.AreEqual("123.456.789 €", ws.Cells["A11"].Text);
+            Assert.AreEqual("123.456.789 €", ws.Cells["A12"].Text);
+            Assert.AreEqual("123.456.789,12 €", ws.Cells["A13"].Text);
+            Assert.AreEqual("123.456.789,12 €", ws.Cells["A14"].Text);
+            Assert.AreEqual("12345678912%", ws.Cells["A15"].Text);
+            Assert.AreEqual("12345678912,35%", ws.Cells["A16"].Text);
+            Assert.AreEqual("1,23E+08", ws.Cells["A17"].Text);
+            Assert.AreEqual("123,5E+6", ws.Cells["A18"].Text); // actual "123456789,1"
+            Assert.AreEqual("123456789 1/8", ws.Cells["A19"].Text);
+            Assert.AreEqual("123456789 10/81", ws.Cells["A20"].Text);
+            Assert.AreEqual("29.03.2018", ws.Cells["A21"].Text);
+
+#if (NET6_0_OR_GREATER)
+            Assert.AreEqual("29. März 18", ws.Cells["A22"].Text); // actual "29-März-18"
+            Assert.AreEqual("29. März", ws.Cells["A23"].Text); // actual "29-März"
+            Assert.AreEqual("Mär 18", ws.Cells["A24"].Text); // actual "Mär-18"
+
+            Assert.AreEqual("Mär 2019", ws.Cells["A38"].Text); // actual "Mär 2019"
+#else
+            Assert.AreEqual("29. Mrz 18", ws.Cells["A22"].Text); // actual "29-März-18"
+            Assert.AreEqual("29. Mrz", ws.Cells["A23"].Text); // actual "29-März"
+            Assert.AreEqual("Mrz 18", ws.Cells["A24"].Text); // actual "Mär-18"
+
+            Assert.AreEqual("Mrz 2019", ws.Cells["A38"].Text); // actual "Mär 2019"
+            Assert.AreEqual("Samstag, 30. März 2019", ws.Cells["A39"].Text);
+#endif            
+            Assert.AreEqual("10:45 AM", ws.Cells["A25"].Text); // actual "10:45"
+            Assert.AreEqual("10:45:00 AM", ws.Cells["A26"].Text); // actual "10:45:00" 
+            Assert.AreEqual("10:45", ws.Cells["A27"].Text);
+            Assert.AreEqual("10:45:00", ws.Cells["A28"].Text);
+            Assert.AreEqual("29.03.2019 10:45", ws.Cells["A29"].Text); // actual "3.29.19 10:45"
+            Assert.AreEqual("44:59", ws.Cells["A30"].Text); // actual "03:59"
+            Assert.AreEqual("44:59,9", ws.Cells["A31"].Text); // actual "0359.0"
+            Assert.AreEqual("43555,48958", ws.Cells["A32"].Text); // actual "43555,4895832755"
+            Assert.AreEqual("1045332:44:59", ws.Cells["A33"].Text); // actual "12:03:59"
+            Assert.AreEqual("123.456.789 ", ws.Cells["A35"].Text); // actual "123.456.789"
+            Assert.AreEqual("Samstag, 30. März 2019", ws.Cells["A39"].Text);
+
+            Assert.AreEqual("-123.456.789,12", ws.Cells["B9"].Text); // actual "(123.456.789,12)"
+            Assert.AreEqual("-123.456.789 €", ws.Cells["B10"].Text); // actual "-123.456.789 €"
+            Assert.AreEqual("-1,23E+08", ws.Cells["B17"].Text);
+            Assert.AreEqual("-123,5E+6", ws.Cells["B18"].Text); //actual "-123456789,1"
+            Assert.AreEqual("-123456789 1/8", ws.Cells["B19"].Text);   //actual: "--123456789 1/" 
+            Assert.AreEqual("-123456789 10/81", ws.Cells["B20"].Text); //actual: "--123456789  1/"  
+
+            Assert.AreEqual("0", ws.Cells["C2"].Text);
+            Assert.AreEqual("0", ws.Cells["C3"].Text);
+            Assert.AreEqual("0,00", ws.Cells["C4"].Text);
+            Assert.AreEqual("0,00", ws.Cells["C9"].Text);
+            Assert.AreEqual("0,00 €", ws.Cells["C11"].Text);
+            Assert.AreEqual("0,00 €", ws.Cells["C13"].Text);
+            Assert.AreEqual("0,00 €", ws.Cells["C14"].Text);
+            Assert.AreEqual("0%", ws.Cells["C15"].Text);
+            Assert.AreEqual("0,00%", ws.Cells["C16"].Text);
+            Assert.AreEqual("0,00E+00", ws.Cells["C17"].Text);
+            Assert.AreEqual("000,0E+0", ws.Cells["C18"].Text); // actual "0,0"
+
+            Assert.AreEqual("- €", ws.Cells["C34"].Text);
+            Assert.AreEqual("- ", ws.Cells["C35"].Text);
+            Assert.AreEqual("- €", ws.Cells["C36"].Text);
+            Assert.AreEqual("- ", ws.Cells["C37"].Text);
+            
+            SwitchBackToCurrentCulture();
+        }
+        public string TextHandler(NumberFormatToTextNumberFormatToText options)
+        {
+            switch(options.NumberFormat.NumFmtId)
+            {
+                case 15:
+                    break;
+            }
+            return options.Text;
         }
     }
 }

--- a/src/EPPlusTest/Issues/StylingIssues.cs
+++ b/src/EPPlusTest/Issues/StylingIssues.cs
@@ -195,7 +195,7 @@ namespace EPPlusTest
             
             SwitchBackToCurrentCulture();
         }
-        public string TextHandler(NumberFormatToTextNumberFormatToText options)
+        public string TextHandler(NumberFormatToTextArgs options)
         {
             switch(options.NumberFormat.NumFmtId)
             {


### PR DESCRIPTION
Fix for issue #1493 
- Fixed several bugs in the `ExcelRangeBase.Text` property. 
  - The General result did not return the same significant numbers as Excel.
  - Negative numbers with fractions returned an incorrect result.
  - AM/PM was not returned for some cultures.
- Added new static property `ExcelPackageSettings.CultureSpecificBuildInNumberFormats` to specify culture specific number formats for individual cultures.
- Added new call-back function `ExcelWorkbook.NumberFormatToTextHandler` to override the default `Text` value.

Fix for #1504 
-- Pivot tables fields with sorting sometimes failed when calculating a pivot table.
-- Refreshing a pivot table could cause a corrupt workbook or selecting the incorrect value in  page field, if the selected value index of the page field was outside the number of items in the field or changed the index.