### PR TITLE
Added TREND, LINEST and LOGEST

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/BuiltInFunctions.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/BuiltInFunctions.cs
@@ -277,6 +277,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
             Functions["trimmean"] = new Trimmean();
             Functions["ztest"] = new Ztest();
             Functions["z.test"] = new ZDotTest();
+
+            Functions["linest"] = new Linest();
+            Functions["logest"] = new Logest();
+
             // Information
             Functions["isblank"] = new IsBlank();
             Functions["isnumber"] = new IsNumber();

--- a/src/EPPlus/FormulaParsing/Excel/Functions/BuiltInFunctions.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/BuiltInFunctions.cs
@@ -274,12 +274,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
             Functions["weibull.dist"] = new WeibullDotDist();
             Functions["weibull"] = new WeibullDist();
             Functions["t.test"] = new TTest();
+            Functions["ttest"] = new TTest();
             Functions["trimmean"] = new Trimmean();
             Functions["ztest"] = new Ztest();
             Functions["z.test"] = new ZDotTest();
 
             Functions["linest"] = new Linest();
             Functions["logest"] = new Logest();
+            Functions["trend"] = new Trend();
 
             // Information
             Functions["isblank"] = new IsBlank();

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Finance/PriceDisc.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Finance/PriceDisc.cs
@@ -16,8 +16,6 @@ using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Finance
 {

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/LinestHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/LinestHelper.cs
@@ -30,7 +30,7 @@ using System.Text.RegularExpressions;
 using static OfficeOpenXml.FormulaParsing.Excel.Functions.Engineering.Conversions;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 //using System.ComponentModel.DataAnnotations;
-namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
+namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers 
 {
     internal class LinestHelper
     {
@@ -361,7 +361,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
             }
 
             RangeFlattener.GetNumericPairLists(rangeX, rangeY, !multipleXranges, out List<double> knownXsList, out List<double> knownYsList);
-            //y values cant be zero or negative since we have to take the logarithm of the y-values to find a solution.
+            //y values cant be zero or negative since we have to take the logarithm of the y-values to find a solution (LOGEST).
             if (logest)
             {
                 for (var i = 0; i < knownYsList.Count(); i++)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/LinestHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/LinestHelper.cs
@@ -1,12 +1,525 @@
-﻿using System;
+﻿/*************************************************************************************************
+ Required Notice: Copyright (C) EPPlus Software AB. 
+ This software is licensed under PolyForm Noncommercial License 1.0.0 
+ and may only be used for noncommercial purposes 
+ https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+ A commercial license to use this software can be purchased at https://epplussoftware.com
+*************************************************************************************************
+ Date               Author                       Change
+*************************************************************************************************
+ 05/07/2023         EPPlus Software AB         Implemented function
+*************************************************************************************************/
+using OfficeOpenXml.DataValidation.Events;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Database;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Text;
+using OfficeOpenXml.FormulaParsing.ExcelUtilities;
+using OfficeOpenXml.FormulaParsing.FormulaExpressions.FunctionCompilers;
+using OfficeOpenXml.FormulaParsing.Ranges;
+using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Drawing.Text;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+using static OfficeOpenXml.FormulaParsing.Excel.Functions.Engineering.Conversions;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
 {
     internal class LinestHelper
     {
+        public static InMemoryRange CalculateMultipleXRanges(double[] knownYs, double[][] xRangeList, bool constVar, bool stats, bool logest)
+        {
+
+            //Adding a column of ones to account for the intercept.
+            //This column will be the first column in the matrix, so all columns are shifted to the right to make space.
+            if (constVar)
+            {
+                for (var r = 0; r < xRangeList.Count(); r++)
+                {
+                    for (var c = xRangeList[r].Count() - 1; c > 0; c--)
+                    {
+                        xRangeList[r][c] = xRangeList[r][c - 1];
+                    }
+                }
+                for (var r = 0; r < xRangeList.Count(); r++)
+                {
+                    xRangeList[r][0] = 1d;
+                }
+            }
+
+            var width = xRangeList[0].Count();
+            var height = xRangeList.Count();
+
+            //Gaussian elimination to get rank and which columns to be dropped due to collinearity.
+            //Choosing between two collinear columns, the later is chosen.
+            var dropCols = MatrixHelper.GaussRank(xRangeList, constVar);
+            var xRangeListCopy = xRangeList;
+
+            //columns are dropped based of off dropCols. The drop columns are represented as zero in the coefficients and standard error results.
+            if (dropCols.Count() > 0) xRangeList = MatrixHelper.RemoveColumns(xRangeList, dropCols);
+
+            //LOGEST can be expressed as EXP(LINEST(LN(yRange), xRange))
+            //We simply take the natural logarithm of the predictor value and apply the function above to retrieve the coefficients for a non-linear regression
+            if (logest)
+            {
+                for (var i = 0; i < knownYs.Length; i++)
+                {
+                    knownYs[i] = Math.Log(knownYs[i]);
+                }
+            }
+
+            //GetSlope calculates the OLS estimator
+            var multipleRegressionSlopes = GetSlope(xRangeList, knownYs, constVar, stats, out bool matrixIsSingular);
+
+            //If LOGEST, we transform the linear results according to the formula LOGEST = EXP(LINEST(LN(y), x))
+            if (logest)
+            {
+                for (var i = 0; i < multipleRegressionSlopes.Length; i++)
+                {
+                    multipleRegressionSlopes[i][0] = Math.Exp(multipleRegressionSlopes[i][0]);
+                }
+            }
+
+            //betaCoefficients are constructed in the same way as they are presented in Excel, e.g reversed order (x_n, x_(n-1), ..., x_1)
+            //This results in some messy code below
+            double[] betaCoefficients = new double[multipleRegressionSlopes.Count() + dropCols.Count()];
+            betaCoefficients[betaCoefficients.Count() - 1] = multipleRegressionSlopes[0][0];
+
+            if (dropCols.Count() > 0)
+            {
+                if (constVar)
+                {
+                    for (var i = 0; i < dropCols.Count(); i++)
+                    {
+                        //If logest we represent collinear columns with 1 instead of 0
+                        betaCoefficients[betaCoefficients.Count() - 1 - (int)dropCols[i]] = (logest) ? 1d : 0d;
+                    }
+
+                    var count = multipleRegressionSlopes.Count() - 1;
+                    for (var i = 0; i < betaCoefficients.Count() - 1; i++)
+                    {
+                        if (!dropCols.Contains(betaCoefficients.Count() - 1 - i))
+                        {
+                            betaCoefficients[i] = multipleRegressionSlopes[count][0];
+                            count--;
+                        }
+                    }
+                }
+                else
+                {
+                    //Fix here
+                    betaCoefficients[betaCoefficients.Count() - 1] = (logest) ? 1d : 0d;
+
+                    if (logest)
+                    {
+                        for (var i = 0; i < dropCols.Count(); i++)
+                        {
+                            //If logest we represent collinear columns with 1 instead of 0
+                            betaCoefficients[betaCoefficients.Count() - 2 - (int)dropCols[i]] = 1d;
+                        }
+                    }
+
+                    var count = 0;
+                    for (var i = 0; i < betaCoefficients.Count() - 1; i++)
+                    {
+                        if (!dropCols.Contains(betaCoefficients.Count() - 2 - i))
+                        {
+                            betaCoefficients[i] = multipleRegressionSlopes[multipleRegressionSlopes.Count() - 2 - count][0];
+                            count++;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (constVar)
+                {
+                    betaCoefficients[betaCoefficients.Count() - 1] = multipleRegressionSlopes[0][0];
+
+                    var count = 0;
+                    for (var i = multipleRegressionSlopes.Count() - 1; i > 0; i--)
+                    {
+                        betaCoefficients[count] = multipleRegressionSlopes[i][0];
+                        count++;
+                    }
+                }
+                else
+                {
+                    betaCoefficients[betaCoefficients.Count() - 1] = (logest) ? 1d : 0d;
+
+                    var count = 0;
+                    for (var i = 0; i < betaCoefficients.Count() - 1; i++)
+                    {
+                        betaCoefficients[i] = multipleRegressionSlopes[multipleRegressionSlopes.Count() - 2 - count][0];
+                        count++;
+                    }
+                }
+            }
+
+            if (!stats)
+            {
+                var resultRange = new InMemoryRange(1, (short)(betaCoefficients.Count()));
+                if (constVar)
+                {
+                    resultRange.SetValue(0, betaCoefficients.Count() - 1, betaCoefficients[betaCoefficients.Count() - 1]);
+                }
+                else
+                {
+                    var intercept = (logest) ? 1d : 0d;
+                    resultRange.SetValue(0, betaCoefficients.Count() - 1, intercept);
+                }
+
+                //Linest returns the coefficients in reversed order, so we iterate through the list from the end to get the correct order.
+                for (var i = 0; i < betaCoefficients.Count() - 1; i++)
+                {
+                    resultRange.SetValue(0, i, betaCoefficients[i]);
+                }
+                return resultRange;
+            }
+            else
+            {
+                var resultRangeStats = new InMemoryRange(5, (short)betaCoefficients.Count());
+                if (constVar)
+                {
+                    resultRangeStats.SetValue(0, betaCoefficients.Count() - 1, betaCoefficients[betaCoefficients.Count() - 1]);
+                }
+                else
+                {
+                    resultRangeStats.SetValue(0, betaCoefficients.Count() - 1, 0d);
+                    if (logest) resultRangeStats.SetValue(0, betaCoefficients.Count() - 1, 1d);
+                }
+
+                for (var i = 0; i < betaCoefficients.Count() - 1; i++)
+                {
+                    resultRangeStats.SetValue(0, i, betaCoefficients[i]);
+                }
+
+                List<double> standardErrorSlopes = new List<double>();
+                List<double> estimatedYs = new List<double>(); //This is calculated for each row as y = m1 * x1 + m2 * x2 + ... + mn * xn + intercept (m = coefficient).
+                List<double> estimatedErrors = new List<double>(); //This is simply the difference between the observed y-value and the predicted y-value.
+
+                for (var i = 0; i < height; i++)
+                {
+                    var y = 0d;
+                    for (var k = 0; k < width; k++)
+                    {
+                        if (logest)
+                        {
+                            //For LOGEST: Log the coefficients to get rid of EXP
+                            y += (k != betaCoefficients.Count() - 1) ? Math.Log(betaCoefficients[k]) * xRangeListCopy[i][width - 1 - k] : Math.Log(betaCoefficients[k]);
+                        }
+                        else
+                        {
+                            //For LINEST: y = m1 * x1 + m2 * x2 ... mn * xn + b
+                            y += (k != betaCoefficients.Count() - 1) ? betaCoefficients[k] * xRangeListCopy[i][width - 1 - k] : betaCoefficients[k];
+                        }
+                    }
+                    estimatedYs.Add(y);
+                }
+
+                for (var i = 0; i < estimatedYs.Count; i++)
+                {
+                    var error = knownYs[i] - estimatedYs[i];
+                    estimatedErrors.Add(error);
+                }
+
+                //DevSq calculates the sum of squares deviation from the sample mean
+                var ssresid = (constVar) ? MatrixHelper.DevSq(estimatedErrors, false) : MatrixHelper.DevSq(estimatedErrors, true);
+                var ssreg = (constVar) ? MatrixHelper.DevSq(estimatedYs, false) : MatrixHelper.DevSq(estimatedYs, true);
+                var rSquared = ssreg / (ssreg + ssresid);
+                var df = Math.Max(height - width + dropCols.Count(), 0d); //Adjust df when columns are dropped --> For every dropped column, +1 to degrees of freedom
+                var standardErrorEstimate = (df != 0d) ? Math.Sqrt(ssresid / df) : 0d;
+                object fStatistic = 0d;
+                if (df != 0)
+                {
+                    fStatistic = (constVar) ? (ssreg / (width - 1 - dropCols.Count())) / (ssresid / df) : (ssreg / width) / (ssresid / df);
+                }
+                else
+                {
+                    fStatistic = ExcelErrorValue.Create(eErrorType.Num);
+                }
+
+                //Calculating standard errors of all coefficients below
+                var residualMS = (df != 0d) ? ssresid / (height - width + dropCols.Count()) : 0d; //Mean squared of the sum of residual
+                var xT = MatrixHelper.TransposeMatrix(xRangeList, height, width - dropCols.Count());
+                var xTdotX = MatrixHelper.Multiply(xT, xRangeList);
+                var inverseMat = MatrixHelper.Inverse(xTdotX);
+                var mIs = (MatrixHelper.GetDeterminant(xTdotX) < 1E-8) ? true : false;
+
+                //This shouldn't be possible anymore since we have a way of handling singular matrix (GaussianRank)
+                if (mIs)
+                {
+                    for (var i = 0; i < inverseMat.Count(); i++)
+                    {
+                        for (var j = 0; j < inverseMat[0].Count(); j++)
+                        {
+                            inverseMat[i][j] = 0d;
+                        }
+                    }
+                }
+
+                //Standard errors are derived from the inverse matrix of sum of squares and cross product (SSCP matrix) multiplied with residualMS
+                //The standard errors are the squared root of the main diagonal of this matrix.
+
+                var standardErrorMat = MatrixHelper.MatrixMultDouble(inverseMat, residualMS);
+                var diagonal = MatrixHelper.MatrixDiagonal(standardErrorMat);
+                double[] standardErrorList = new double[diagonal.Count()];
+                for (var i = 0; i < standardErrorList.Count(); i++)
+                {
+                    standardErrorList[i] = Math.Sqrt(diagonal[i]);
+                }
+
+                //Adjust the standard errors of collinear columns to zero
+                double[] standardErrorArray = new double[standardErrorList.Count() + dropCols.Count()];
+                var standardIndex = 1;
+                if (dropCols.Count() > 0)
+                {
+                    standardErrorArray[0] = standardErrorList[0];
+                    for (var i = 1; i < standardErrorArray.Count(); i++)
+                    {
+                        if (dropCols.Contains(standardErrorArray.Count() - i - 1))
+                        {
+                            standardErrorArray[i] = 0d;
+                        }
+                        else
+                        {
+                            standardErrorArray[i] = standardErrorList[standardIndex];
+                            standardIndex++;
+                        }
+                    }
+                }
+
+                //Can be improved. Using different arrays depending on if columns have been dropped or not
+                if (dropCols.Count() > 0)
+                {
+                    if (constVar)
+                    {
+                        resultRangeStats.SetValue(1, xRangeList[0].Count() - 1, standardErrorArray[standardErrorArray.Count() - 1]);
+                    }
+                    else
+                    {
+                        resultRangeStats.SetValue(1, xRangeList[0].Count(), ExcelErrorValue.Create(eErrorType.NA));
+                    }
+
+                    int pos3 = 0;
+                    for (var i = (constVar) ? standardErrorArray.Count() - 1 : standardErrorArray.Count() - 1; i >= 0; i--)
+                    {
+                        resultRangeStats.SetValue(1, pos3++, standardErrorArray[i]);
+                    }
+                }
+                else
+                {
+                    if (constVar)
+                    {
+                        resultRangeStats.SetValue(1, xRangeList[0].Count() - 1, standardErrorList[standardErrorList.Count() - 1]);
+                    }
+                    else
+                    {
+                        resultRangeStats.SetValue(1, xRangeList[0].Count(), ExcelErrorValue.Create(eErrorType.NA));
+                    }
+
+                    int pos3 = 0;
+                    for (var i = (constVar) ? standardErrorList.Count() - 1 : standardErrorList.Count() - 1; i >= 0; i--)
+                    {
+                        resultRangeStats.SetValue(1, pos3++, standardErrorList[i]);
+                    }
+                }
+
+                if (constVar)
+                {
+                    for (var col = 2; col < width; col++)
+                    {
+                        for (var row = 2; row < 5; row++)
+                        {
+                            resultRangeStats.SetValue(row, col, ExcelErrorValue.Create(eErrorType.NA));
+                        }
+                    }
+                }
+                else
+                {
+                    for (var col = 2; col < width + 1; col++)
+                    {
+                        for (var row = 2; row < 5; row++)
+                        {
+                            resultRangeStats.SetValue(row, col, ExcelErrorValue.Create(eErrorType.NA));
+                        }
+                    }
+                }
+
+                resultRangeStats.SetValue(2, 0, rSquared);
+                resultRangeStats.SetValue(2, 1, standardErrorEstimate);
+                resultRangeStats.SetValue(3, 0, fStatistic);
+                resultRangeStats.SetValue(3, 1, df);
+                resultRangeStats.SetValue(4, 0, ssreg);
+                resultRangeStats.SetValue(4, 1, ssresid);
+                return resultRangeStats;
+            }
+        }
+
+        private static double[][] GetSlope(double[][] xValues, double[] yValues, bool constVar, bool stats, out bool matrixIsSingular)
+        {
+            var width = xValues[0].Count();
+            var height = xValues.Count();
+            var xT = MatrixHelper.TransposeMatrix(xValues, height, width);
+            var xTdotX = MatrixHelper.Multiply(xT, xValues);
+            var myInverse = MatrixHelper.Inverse(xTdotX);
+            var dotProduct = MatrixHelper.Multiply(myInverse, xT);
+            double[][] yValuesJagged = yValues.Select(yVal => new double[] { yVal }).ToArray();
+
+            //b = (X'X)^-1 * X' * Y
+            var b = MatrixHelper.Multiply(dotProduct, yValuesJagged);
+            matrixIsSingular = (MatrixHelper.GetDeterminant(xTdotX) < 1E-8) ? true : false; //This threshold could be investigated further
+
+            if (!constVar)
+            {
+                double[][] extendedB = new double[b.Count() + 1][];
+                for (var i = 0; i < b.Count(); i++)
+                {
+                    extendedB[i] = new double[1];
+                    extendedB[i][0] = b[i][0];
+                }
+                extendedB[extendedB.Count() - 1] = new double[1];
+                extendedB[extendedB.Count() - 1][0] = 0d;
+                return extendedB;
+            }
+            return b;
+        }
+
+        public static InMemoryRange CalculateResult(double[] knownYs, double[] knownXs, bool constVar, bool stats, bool logest)
+        {
+            var knownYsCopy = knownYs.ToList();
+            if (logest)
+            {
+                for (var i = 0; i < knownYs.Count(); i++)
+                {
+                    knownYs[i] = Math.Log(knownYs[i]);
+                }
+            }
+
+            var averageY = knownYs.Average();
+            var averageX = knownXs.Average();
+
+            double nominator = 0d;
+            double denominator = 0d;
+            double xDiff = 0d;
+            double yDiff = 0d;
+            double estimatedDiff = 0d;
+            double ssr = 0d;
+            double sst = 0d;
+            var df = 0d;
+            var v1 = 0d;
+            var v2 = 0d;
+            var fStatistics = 0d;
+
+            for (var i = 0; i < knownYs.Count(); i++)
+            {
+                var y = knownYs[i];
+                var x = knownXs[i];
+
+                if (constVar)
+                {
+                    nominator += (x - averageX) * (y - averageY);
+                    denominator += (x - averageX) * (x - averageX);
+                }
+                else
+                {
+                    nominator += x * y;
+                    denominator += Math.Pow(x, 2);
+                }
+
+            }
+
+            var m = (denominator != 0) ? nominator / denominator : 0d;
+            var b = (constVar) ? averageY - (m * averageX) : 0d;
+
+            //LOGEST can be expressed as EXP(LINEST(LN(y), x))
+            if (logest) m = Math.Exp(m);
+            if (logest) b = Math.Exp(b);
+
+            if (stats)
+            {
+                for (var i = 0; i < knownXs.Count(); i++)
+                {
+                    var x = knownXs[i];
+                    var y = knownYs[i];
+
+                    //LOGEST uses the same statistics as LINEST, but with logged y-values. We remove the EXP to get correct statistics (correct according to excel)
+                    var estimatedY = (logest) ? Math.Log(m) * x + Math.Log(b) : m * x + b; //LINEST formula
+
+                    if (constVar)
+                    {
+                        estimatedDiff += Math.Pow(y - estimatedY, 2);
+                        xDiff += Math.Pow(x - averageX, 2);
+                        yDiff += Math.Pow(y - estimatedY, 2);
+                        ssr += Math.Pow(estimatedY - averageY, 2);
+                        sst += Math.Pow(y - averageY, 2);
+                    }
+                    else
+                    {
+                        estimatedDiff += Math.Pow(y - estimatedY, 2);
+                        xDiff += Math.Pow(x, 2);
+                        yDiff = Math.Pow(y - estimatedY, 2);
+                        ssr += Math.Pow(estimatedY, 2);
+                        sst += Math.Pow(y, 2);
+                    }
+
+                }
+
+                var errorVariance = yDiff / (knownXs.Count() - 2);
+                if (!constVar) errorVariance = yDiff / (knownXs.Count() - 1);
+
+                var standardErrorM = (constVar) ? Math.Sqrt(1d / (knownXs.Count() - 2d) * estimatedDiff / xDiff) :
+                                                  Math.Sqrt(1d / (knownXs.Count() - 1d) * estimatedDiff / xDiff);
+
+                object standardErrorB = Math.Sqrt(errorVariance) * Math.Sqrt(1d / knownXs.Count() + Math.Pow(averageX, 2) / xDiff);
+                if (!constVar) standardErrorB = ExcelErrorValue.Create(eErrorType.NA);
+
+                var rSquared = ssr / sst;
+                var standardErrorEstimateY = (!constVar) ? SEHelper.GetStandardError(knownXs, knownYs, true) :
+                                                          SEHelper.GetStandardError(knownXs, knownYs, false);
+                var ssreg = ssr;
+                var ssresid = (constVar) ? yDiff : (sst - ssr);
+
+                if (constVar)
+                {
+                    df = knownXs.Count() - 2;
+                    v1 = knownXs.Count() - df - 1;
+                    v2 = df;
+                    fStatistics = (ssr / v1) / (yDiff / v2);
+                }
+                else
+                {
+                    df = knownXs.Count() - 1;
+                    v1 = knownXs.Count() - df;
+                    v2 = df;
+                    fStatistics = ssr / (ssresid / (knownXs.Count() - 1));
+                }
+
+                var resultRangeStats = new InMemoryRange(5, 2);
+                resultRangeStats.SetValue(0, 0, m);
+                resultRangeStats.SetValue(0, 1, b);
+                resultRangeStats.SetValue(1, 0, standardErrorM);
+                resultRangeStats.SetValue(1, 1, standardErrorB);
+                resultRangeStats.SetValue(2, 0, rSquared);
+                resultRangeStats.SetValue(2, 1, standardErrorEstimateY);
+                resultRangeStats.SetValue(3, 0, fStatistics);
+                resultRangeStats.SetValue(3, 1, df);
+                resultRangeStats.SetValue(4, 0, ssreg);
+                resultRangeStats.SetValue(4, 1, ssresid);
+                return resultRangeStats;
+            }
+
+            var resultRangeNormal = new InMemoryRange(1, 2);
+            resultRangeNormal.SetValue(0, 0, m);
+            resultRangeNormal.SetValue(0, 1, b);
+            return resultRangeNormal;
+
+        }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/LinestHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/LinestHelper.cs
@@ -20,7 +20,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
 {
     internal class LinestHelper
     {
-        public static InMemoryRange MultipleRegResult(double[] knownYs, double[][] xRangeList, bool constVar, bool stats, bool logest)
+        internal static InMemoryRange MultipleRegResult(double[] knownYs, double[][] xRangeList, bool constVar, bool stats, bool logest)
         {
 
             //Adding a column of ones to account for the intercept.
@@ -162,7 +162,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
             }
         }
 
-        private static double[] GetSlope(double[][] xValues, double[] yValues, bool constVar, bool stats, bool logest, out bool matrixIsSingular)
+        internal static double[] GetSlope(double[][] xValues, double[] yValues, bool constVar, bool stats, bool logest, out bool matrixIsSingular)
         {
             var width = xValues[0].Count();
             var height = xValues.Count();
@@ -191,7 +191,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
             return bArray;
         }
 
-        public static InMemoryRange LinearRegResult(double[] knownXs, double[] knownYs, bool constVar, bool stats, bool logest)
+        internal static InMemoryRange LinearRegResult(double[] knownXs, double[] knownYs, bool constVar, bool stats, bool logest)
         {
             var knownYsCopy = knownYs.ToList();
             if (logest)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/LinestHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/LinestHelper.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
+{
+    internal class LinestHelper
+    {
+    }
+}

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/MatrixHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/MatrixHelper.cs
@@ -13,29 +13,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
     {
 
         //Contains various functions for matrix operations.
-        internal static List<List<double>> TransposedMult(List<List<double>> matrix, double width, double height)
-        {
-            //This function returns the result of a transposed matrix multiplied by itself.
-
-            List<List<double>> resultMatrix = new List<List<double>>();
-
-            for (int i = 0; i < width; i++)
-            {
-                List<double> matrixRow = new List<double>();
-                for (int j = 0; j < width; j++)
-                {
-                    var dotSum = 0d;
-                    for (int k = 0; k < height; k++)
-                    {
-                        dotSum += matrix[i][k] * matrix[j][k];
-                    }
-                    matrixRow.Add(dotSum);
-                }
-                resultMatrix.Add(matrixRow);
-            }
-
-            return resultMatrix;
-        }
 
         internal static double[][] TransposeMatrix(double[][] matrix, int rows, int cols)
         {
@@ -51,13 +28,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
             }
             return transposedMat;
         }
-        public static double DevSq(List<double> array, bool meanIsZero)
-        {
-            //Returns the sum of squares of deviations from a set of datapoints.
-            var mean = (!meanIsZero) ? array.Select(x => (double)x).Average() : 0d;
-            return array.Aggregate(0d, (val, x) => val += Math.Pow(x - mean, 2));
-        }
-        public static double[][] MatrixMultDouble(double[][] matrix, double multiplier)
+
+        internal static double[][] MatrixMultDouble(double[][] matrix, double multiplier)
         {
             //Multiplies all elements in a matrix with a single number.
             double[][] resultMat = CreateMatrix(matrix.Count(), matrix[0].Count());
@@ -70,7 +42,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
             }
             return resultMat;
         }
-        public static double[] MatrixDiagonal(double[][] matrix)
+        internal static double[] MatrixDiagonal(double[][] matrix)
         {
             //Returns the diagonal of a matrix.
             double[] resultArray = new double[matrix.Count()];
@@ -82,72 +54,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
                 }
             }
             return resultArray;
-        }
-        public static List<List<double>> MatrixMult(List<List<double>> matrix1, List<List<double>> matrix2, bool evenDimensions)
-        {
-            //Calculates the result of multiplying two matrixes
-            if (!evenDimensions)
-            {
-                List<List<double>> resultMatrix = new List<List<double>>();
-                for (int i = 0; i < matrix1.Count; i++)
-                {
-                    List<double> matrixRow = new List<double>();
-                    for (int j = 0; j < matrix2[0].Count; j++)
-                    {
-                        var prodSum = 0d;
-
-                        for (int k = 0; k < matrix1.Count; k++)
-                        {
-                            prodSum += matrix1[i][k] * matrix2[k][j];
-                        }
-                        matrixRow.Add(prodSum);
-                    }
-                    resultMatrix.Add(matrixRow);
-                }
-                return resultMatrix;
-            }
-            else
-            {
-                List<List<double>> resultMatrix = new List<List<double>>();
-                return resultMatrix;
-            }
-
-        }
-        public static List<List<double>> MatrixMultArray(List<List<double>> matrix, List<double> array)
-        {
-            //Returns the result matrix of a matrix multiplied with an array.
-            List<List<double>> resultMatrix = new List<List<double>>();
-            for (int i = 0; i < matrix.Count; i++)
-            {
-                List<double> matrixRow = new List<double>();
-                var prodSum = 0d;
-                for (int j = 0; j < array.Count; j++)
-                {
-                    prodSum += matrix[i][j] * array[j];
-                }
-                matrixRow.Add(prodSum);
-                resultMatrix.Add(matrixRow);
-            }
-            return resultMatrix;
-        }
-        public static List<List<double>> GetMatrixMinor(List<List<double>> matrix, double i, double j)
-        {
-            //Returns the minor for a given matrix and entries i:th row and j:th col
-            List<List<double>> resultMatrix = new List<List<double>>();
-            for (int row = 0; row < matrix.Count; row++)
-            {
-                if (row == i) continue;
-
-                List<double> matrixRow = new List<double>();
-                for (int col = 0; col < matrix[row].Count; col++)
-                {
-                    if (col == j) continue;
-
-                    matrixRow.Add(matrix[row][col]);
-                }
-                resultMatrix.Add(matrixRow);
-            }
-            return resultMatrix;
         }
 
         internal static double[][] CreateMatrix(int rows, int cols)
@@ -375,7 +281,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
             return elements;
         }
 
-        internal static int argMaxAbsolute(double[][] mat)
+        internal static int ArgMaxIndex(double[][] mat)
         {
             //This function finds the index of the largest absolute value in the input matrix
 
@@ -483,7 +389,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
                         }
                         rowCount += 1;
                     }
-                    int dd = argMaxAbsolute(subMatrix);
+                    int dd = ArgMaxIndex(subMatrix);
 
                     ixr = dd / (n - ix0);
                     ixc = dd % (n - ix0);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/MatrixHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/MatrixHelper.cs
@@ -9,11 +9,11 @@ using System.Xml.Xsl;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
 {
-    internal class MatrixHelper
+    internal static class MatrixHelper
     {
 
         //Contains various functions for matrix operations.
-        public static List<List<double>> TransposedMult(List<List<double>> matrix, double width, double height)
+        internal static List<List<double>> TransposedMult(List<List<double>> matrix, double width, double height)
         {
             //This function returns the result of a transposed matrix multiplied by itself.
 

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/MatrixHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/MatrixHelper.cs
@@ -1,25 +1,155 @@
-﻿/*************************************************************************************************
-  Required Notice: Copyright (C) EPPlus Software AB. 
-  This software is licensed under PolyForm Noncommercial License 1.0.0 
-  and may only be used for noncommercial purposes 
-  https://polyformproject.org/licenses/noncommercial/1.0.0/
-
-  A commercial license to use this software can be purchased at https://epplussoftware.com
- *************************************************************************************************
-  Date               Author                       Change
- *************************************************************************************************
-  01/27/2020         EPPlus Software AB       Initial release EPPlus 7.2
- *************************************************************************************************/
+﻿using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Text;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading;
+using System.Xml.Xsl;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
 {
-    internal static class MatrixHelper
+    internal class MatrixHelper
     {
+
+        //Contains various functions for matrix operations.
+        public static List<List<double>> TransposedMult(List<List<double>> matrix, double width, double height)
+        {
+            //This function returns the result of a transposed matrix multiplied by itself.
+
+            List<List<double>> resultMatrix = new List<List<double>>();
+
+            for (int i = 0; i < width; i++)
+            {
+                List<double> matrixRow = new List<double>();
+                for (int j = 0; j < width; j++)
+                {
+                    var dotSum = 0d;
+                    for (int k = 0; k < height; k++)
+                    {
+                        dotSum += matrix[i][k] * matrix[j][k];
+                    }
+                    matrixRow.Add(dotSum);
+                }
+                resultMatrix.Add(matrixRow);
+            }
+
+            return resultMatrix;
+        }
+
+        internal static double[][] TransposeMatrix(double[][] matrix, int rows, int cols)
+        {
+            //This function takes a jagged matrix as input, and returns its transpose.
+            double[][] transposedMat = CreateMatrix(cols, rows);
+
+            for (int r = 0; r < rows; r++)
+            {
+                for (int c = 0; c < cols; c++)
+                {
+                    transposedMat[c][r] = matrix[r][c];
+                }
+            }
+            return transposedMat;
+        }
+        public static double DevSq(List<double> array, bool meanIsZero)
+        {
+            //Returns the sum of squares of deviations from a set of datapoints.
+            var mean = (!meanIsZero) ? array.Select(x => (double)x).Average() : 0d;
+            return array.Aggregate(0d, (val, x) => val += Math.Pow(x - mean, 2));
+        }
+        public static double[][] MatrixMultDouble(double[][] matrix, double multiplier)
+        {
+            //Multiplies all elements in a matrix with a single number.
+            double[][] resultMat = CreateMatrix(matrix.Count(), matrix[0].Count());
+            for (int row = 0; row < matrix.Count(); row++)
+            {
+                for (int col = 0; col < matrix[0].Count(); col++)
+                {
+                    resultMat[row][col] = matrix[row][col] * multiplier;
+                }
+            }
+            return resultMat;
+        }
+        public static double[] MatrixDiagonal(double[][] matrix)
+        {
+            //Returns the diagonal of a matrix.
+            double[] resultArray = new double[matrix.Count()];
+            for (int row = 0; row < matrix[0].Count(); row++)
+            {
+                for (int col = 0; col < matrix.Count(); col++)
+                {
+                    if (row == col) resultArray[row] = matrix[row][col];
+                }
+            }
+            return resultArray;
+        }
+        public static List<List<double>> MatrixMult(List<List<double>> matrix1, List<List<double>> matrix2, bool evenDimensions)
+        {
+            //Calculates the result of multiplying two matrixes
+            if (!evenDimensions)
+            {
+                List<List<double>> resultMatrix = new List<List<double>>();
+                for (int i = 0; i < matrix1.Count; i++)
+                {
+                    List<double> matrixRow = new List<double>();
+                    for (int j = 0; j < matrix2[0].Count; j++)
+                    {
+                        var prodSum = 0d;
+
+                        for (int k = 0; k < matrix1.Count; k++)
+                        {
+                            prodSum += matrix1[i][k] * matrix2[k][j];
+                        }
+                        matrixRow.Add(prodSum);
+                    }
+                    resultMatrix.Add(matrixRow);
+                }
+                return resultMatrix;
+            }
+            else
+            {
+                List<List<double>> resultMatrix = new List<List<double>>();
+                return resultMatrix;
+            }
+
+        }
+        public static List<List<double>> MatrixMultArray(List<List<double>> matrix, List<double> array)
+        {
+            //Returns the result matrix of a matrix multiplied with an array.
+            List<List<double>> resultMatrix = new List<List<double>>();
+            for (int i = 0; i < matrix.Count; i++)
+            {
+                List<double> matrixRow = new List<double>();
+                var prodSum = 0d;
+                for (int j = 0; j < array.Count; j++)
+                {
+                    prodSum += matrix[i][j] * array[j];
+                }
+                matrixRow.Add(prodSum);
+                resultMatrix.Add(matrixRow);
+            }
+            return resultMatrix;
+        }
+        public static List<List<double>> GetMatrixMinor(List<List<double>> matrix, double i, double j)
+        {
+            //Returns the minor for a given matrix and entries i:th row and j:th col
+            List<List<double>> resultMatrix = new List<List<double>>();
+            for (int row = 0; row < matrix.Count; row++)
+            {
+                if (row == i) continue;
+
+                List<double> matrixRow = new List<double>();
+                for (int col = 0; col < matrix[row].Count; col++)
+                {
+                    if (col == j) continue;
+
+                    matrixRow.Add(matrix[row][col]);
+                }
+                resultMatrix.Add(matrixRow);
+            }
+            return resultMatrix;
+        }
+
         internal static double[][] CreateMatrix(int rows, int cols)
         {
             double[][] matrix = new double[rows][];
@@ -243,6 +373,212 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
                 elements[i] = product / luMatrix[i][i];
             }
             return elements;
+        }
+
+        internal static int argMaxAbsolute(double[][] mat)
+        {
+            //This function finds the index of the largest absolute value in the input matrix
+
+            double maxAbsValue = double.MinValue;
+            int maxIndex = -1;
+            int flatIndex = 0;
+
+            for (int i = 0; i < mat.Count(); i++)
+            {
+                for (int j = 0; j < mat[0].Count(); j++)
+                {
+                    double absValue = Math.Abs(mat[i][j]);
+                    if (absValue > maxAbsValue)
+                    {
+                        maxAbsValue = absValue;
+                        maxIndex = flatIndex;
+                    }
+                    flatIndex += 1;
+                }
+            }
+
+            return maxIndex;
+        }
+
+        internal static double GetM2Norm(double[][] rr)
+        {
+
+            //Calculates the 2-norm (euclidean, L2 norm) of the matrix.
+
+            int m = rr.Count();
+            int n = rr[0].Count();
+
+            var m1norm = 0d;
+            for (int i = 0; i < n; i++)
+            {
+                //Sum of the max absolute values of all values in column i
+                var dd = 0d;
+                for (int r = 0; r < rr.Count(); r++)
+                {
+                    dd += Math.Abs(rr[r][i]);
+                    m1norm = Math.Max(m1norm, dd);
+                }
+            }
+
+            var m8norm = 0d;
+            for (int i = 0; i < m; i++)
+            {
+                //Sum of the max absolute values of all values in row i
+                var dd = 0d;
+                for (int c = 0; c < rr[0].Count(); c++)
+                {
+                    dd += Math.Abs(rr[i][c]);
+                    m8norm = Math.Max(m8norm, dd);
+                }
+            }
+
+            return Math.Sqrt(m1norm * m8norm);
+        }
+
+        internal static List<double> GaussRank(double[][] xRange, bool constVal)
+        {
+            //This function takes the input matrix and transforms it to echelon form (every leading coefficient is 1 and is to the right of the leading coefficient on the row above).
+            //This is done with complete pivoting to improve numerical stability and identify linearly dependent columns.
+            // 
+            var xTdotX = MatrixHelper.Multiply(MatrixHelper.TransposeMatrix(xRange, xRange.Count(), xRange[0].Count()), xRange);
+            List<double> drop = new List<double>();
+            int m = xTdotX.Length;
+            int n = xTdotX[0].Length;
+            var m2norm = GetM2Norm(xRange);
+            var eps = 2.220446049250313E-16;
+            var xeps = 1000 * eps;
+            int ixr;
+            int ixc;
+
+            double[] colOrder = new double[n];
+            int count = 0;
+            for (int i = 0; i < n; i++)
+            {
+                colOrder[i] = count;
+                count += 1;
+            }
+
+            for (int ix0 = 0; ix0 < n; ix0++)
+            {
+                if (ix0 == 0 && constVal)
+                {
+                    //If column with 1's has been added, this column is addressed first.
+                    ixr = 0;
+                    ixc = 0;
+                }
+                else
+                {
+                    //Complete pivoting is performed
+                    //Pivote element becomes the index with the largest absolute value in each sub matrix
+                    double[][] subMatrix = new double[m - ix0][];
+                    int rowCount = 0;
+                    for (int i = ix0; i < m; i++)
+                    {
+                        subMatrix[rowCount] = new double[n - ix0];
+                        int colCount = 0;
+                        for (int j = ix0; j < n; j++)
+                        {
+                            subMatrix[rowCount][colCount] = xTdotX[i][j];
+                            colCount += 1;
+                        }
+                        rowCount += 1;
+                    }
+                    int dd = argMaxAbsolute(subMatrix);
+
+                    ixr = dd / (n - ix0);
+                    ixc = dd % (n - ix0);
+                    ixr += ix0;
+                    ixc += ix0;
+
+                    List<double> ddArray = new List<double>();
+                    for (int i = 0; i < xTdotX[ixr].Count(); i++)
+                    {
+                        var tmp = Math.Abs(Math.Abs(xTdotX[ixr][i]) - Math.Abs(xTdotX[ixr][ixc]));
+                        if (tmp < 1000 * xeps) ddArray.Add(i);
+                    }
+                    ixc = (int)ddArray[0];
+                    if (ddArray.Count() > 1)
+                    {
+                        ixc = (int)ddArray[ddArray.Count() - 1];
+                    }
+                }
+
+                if (Math.Abs(xTdotX[ixr][ixc]) > eps)
+                {
+                    //row swap
+                    for (int i = 0; i < xTdotX[ixr].Count(); ++i)
+                    {
+                        var tmp = xTdotX[ix0][i];
+                        xTdotX[ix0][i] = xTdotX[ixr][i];
+                        xTdotX[ixr][i] = tmp;
+                    }
+                    //column swap
+                    for (int i = 0; i < xTdotX.Count(); i++)
+                    {
+                        var tmp = xTdotX[i][ix0];
+                        xTdotX[i][ix0] = xTdotX[i][ixc];
+                        xTdotX[i][ixc] = tmp;
+                    }
+
+                    var tmp1 = colOrder[ix0];
+                    colOrder[ix0] = colOrder[ixc];
+                    colOrder[ixc] = tmp1;
+
+                    //Elimination
+                    for (int ix2 = ix0 + 1; ix2 < m; ix2++)
+                    {
+                        var dd = xTdotX[ix2][ix0] / xTdotX[ix0][ix0];
+
+                        for (int j = 0; j < xTdotX[ix2].Count(); j++)
+                        {
+                            xTdotX[ix2][j] -= xTdotX[ix0][j] * dd;
+                        }
+                    }
+
+                }
+            }
+
+            //Deciding on collinear columns:
+            for (int i = 0; i < n; i++)
+            {
+                var v1 = xTdotX[i][i];
+                var v2 = m2norm;
+                var v3 = xeps;
+                var v4 = Math.Floor(Math.Abs(v1 / v2) / v3); //.Floor should be correct
+                if (v4 == 0)
+                {
+                    drop.Add(colOrder[i]);
+                }
+            }
+
+            //Contains column index on what variables should be dropped due to collinearity
+            return drop;
+        }
+
+        internal static double[][] RemoveColumns(double[][] xRangeList, List<double> dropCols)
+        {
+            //Removes column indexes in dropCols from the matrix xRangeList
+            int height = xRangeList.Length;
+            if (height == 0) return xRangeList;
+
+            int width = xRangeList[0].Length;
+            HashSet<double> dropColsSet = new HashSet<double>(dropCols);
+
+            double[][] newXRangeList = new double[height][];
+            for (int i = 0; i < height; i++)
+            {
+                List<double> newRow = new List<double>();
+                for (int j = 0; j < width; j++)
+                {
+                    if (!dropColsSet.Contains(j))
+                    {
+                        newRow.Add(xRangeList[i][j]);
+                    }
+                }
+                newXRangeList[i] = newRow.ToArray();
+            }
+
+            return newXRangeList;
         }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/MatrixHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/MatrixHelper.cs
@@ -580,5 +580,15 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
 
             return newXRangeList;
         }
+
+        internal static double[] ListToArray(List<double> list)
+        {
+            double[] arr = new double[list.Count];
+            for (var i = 0; i < list.Count; i++)
+            {
+                arr[i] = list[i];
+            }
+            return arr;
+        }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/SEHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/SEHelper.cs
@@ -5,6 +5,7 @@ using System.Text;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
 {
+    //Helper classes are static
     internal class SEHelper
     {
         public static double GetStandardError(double[] xValues, double[] yValues, bool pushToZero)
@@ -42,6 +43,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
             return result;
         }
 
+        //Fill out names, remove from matrixhelper
         public static double DevSq(double[] array, bool meanIsZero)
         {
             //Returns the sum of squares of deviations from a set of datapoints.

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/SEHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/SEHelper.cs
@@ -2,11 +2,51 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
 {
     internal class SEHelper
     {
+        public static double GetStandardError(double[] xValues, double[] yValues, bool pushToZero)
+        {
+
+            double yMean = yValues.Average();
+            double xMean = xValues.Average();
+            int sampleSize = yValues.Count();
+            var p1 = 0d;
+            var numerator = 0d;
+            var denominator = 0d;
+
+            for (var i = 0; i < yValues.Count(); i++)
+            {
+                double y1 = yValues[i];
+                double x1 = xValues[i];
+
+                if (pushToZero)
+                {
+                    p1 += Math.Pow(y1, 2);
+                    numerator += x1 * y1;
+                    denominator += Math.Pow(x1, 2);
+                }
+                else
+                {
+                    p1 += System.Math.Pow(y1 - yMean, 2);
+                    numerator += (x1 - xMean) * (y1 - yMean);
+                    denominator += (System.Math.Pow(x1 - xMean, 2));
+                }
+            }
+
+            double result = (pushToZero) ? Math.Sqrt((p1 - numerator * numerator / denominator) / (sampleSize - 1)) :
+                                           Math.Sqrt((p1 - numerator * numerator / denominator) / (sampleSize - 2));
+
+            return result;
+        }
+
+        public static double DevSq(double[] array, bool meanIsZero)
+        {
+            //Returns the sum of squares of deviations from a set of datapoints.
+            var mean = (!meanIsZero) ? array.Select(x => (double)x).Average() : 0d;
+            return array.Aggregate(0d, (val, x) => val += Math.Pow(x - mean, 2));
+        }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/SEHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/SEHelper.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
+{
+    internal class SEHelper
+    {
+    }
+}

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/TrendHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/TrendHelper.cs
@@ -1,0 +1,53 @@
+﻿using OfficeOpenXml.FormulaParsing.Ranges;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
+{
+    internal class TrendHelper
+    {
+        internal static InMemoryRange GetTrendValuesMultiple(double[][] xRanges, double[] coefficients, bool constVar, bool columnArray)
+        {
+            var resultRange = (constVar) ? new InMemoryRange((short)xRanges.Count(), 1) : new InMemoryRange(1, (short)xRanges.Count());
+            //If const, we remove the column of ones.
+            List<double> removeColumn = [xRanges[0].Count() - 1];
+            if (constVar) xRanges = MatrixHelper.RemoveColumns(xRanges, removeColumn);
+            for (var i = 0; i < xRanges.Length; i++)
+            {
+                var trendVal = 0d;
+                for (var j = 0; j < xRanges[i].Length; j++)
+                {
+                    trendVal += coefficients[j] * xRanges[i][xRanges[i].Count() - 1 - j];
+                }
+                if (columnArray)
+                {
+                    resultRange.SetValue(i, 0, trendVal + coefficients[coefficients.Length - 1]);
+                }
+                else
+                {
+                    resultRange.SetValue(0, i, trendVal + coefficients.Length - 1);
+                }
+            }
+            return resultRange;
+        }
+
+        internal static InMemoryRange GetTrendValuesSingle(double[] xRanges, double[] coefficients, bool columnArray)
+        {
+            var resultRange = (columnArray) ? new InMemoryRange((short)xRanges.Count(), 1) : new InMemoryRange(1, (short)xRanges.Count());
+            for (var i = 0; i < xRanges.Count(); i++)
+            {
+                if (columnArray)
+                {
+                    resultRange.SetValue(i, 0, xRanges[i] * coefficients[0] + coefficients[1]);
+                }
+                else
+                {
+                    resultRange.SetValue(0, i, xRanges[i] * coefficients[0] + coefficients[1]);
+                }
+                
+            }
+            return resultRange;
+        }
+    }
+}

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/TrendHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/TrendHelper.cs
@@ -9,7 +9,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
     {
         internal static InMemoryRange GetTrendValuesMultiple(double[][] xRanges, double[] coefficients, bool constVar, bool columnArray)
         {
-            var resultRange = (constVar) ? new InMemoryRange((short)xRanges.Count(), 1) : new InMemoryRange(1, (short)xRanges.Count());
+            var resultRange = (columnArray) ? new InMemoryRange((short)xRanges.Count(), 1) : new InMemoryRange(1, (short)xRanges.Count());
             //If const, we remove the column of ones.
             List<double> removeColumn = [xRanges[0].Count() - 1];
             if (constVar) xRanges = MatrixHelper.RemoveColumns(xRanges, removeColumn);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/TrendHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/TrendHelper.cs
@@ -26,7 +26,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
                 }
                 else
                 {
-                    resultRange.SetValue(0, i, trendVal + coefficients.Length - 1);
+                    resultRange.SetValue(0, i, trendVal + coefficients[coefficients.Length - 1]);
                 }
             }
             return resultRange;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Linest.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Linest.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
+{
+    internal class Linest
+    {
+    }
+}

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Linest.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Linest.cs
@@ -1,12 +1,194 @@
-﻿using System;
+﻿/*************************************************************************************************
+ Required Notice: Copyright (C) EPPlus Software AB. 
+ This software is licensed under PolyForm Noncommercial License 1.0.0 
+ and may only be used for noncommercial purposes 
+ https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+ A commercial license to use this software can be purchased at https://epplussoftware.com
+*************************************************************************************************
+ Date               Author                       Change
+*************************************************************************************************
+ 19/06/2024         EPPlus Software AB       Initial release EPPlus 7
+*************************************************************************************************/
+using OfficeOpenXml.Drawing.Style.Fill;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
+using OfficeOpenXml.FormulaParsing.ExcelUtilities;
+using OfficeOpenXml.FormulaParsing.FormulaExpressions;
+using OfficeOpenXml.FormulaParsing.Ranges;
+using OfficeOpenXml.Sorting.Internal;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
 {
-    internal class Linest
+    [FunctionMetadata(
+       Category = ExcelFunctionCategory.Statistical,
+       EPPlusVersion = "7.0",
+       Description = "The LINEST function calculates a regressional line that fits your data. It also calculates additional statistics." +
+                     "It can handle several x-variables and perform multiple regression analysis.")]
+    internal class Linest : ExcelFunction
     {
+        public override int ArgumentMinLength => 1;
+
+        public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
+        {
+
+            //X can have more than one vector corresponding to each y-value
+            if (!arguments[0].IsExcelRange) return CompileResult.GetErrorResult(eErrorType.Value);
+            var constVar = true;
+            var stats = false;
+            bool multipleXranges = false;
+            bool columnArray = false;
+            bool rowArray = false;
+            if (arguments.Count() > 1 && arguments[1].IsExcelRange)
+            {
+                var rangeX = arguments[1].ValueAsRangeInfo;
+                var rangeY = arguments[0].ValueAsRangeInfo;
+                var xColumns = rangeX.Size.NumberOfCols;
+                var yColumns = rangeY.Size.NumberOfCols;
+                var xRows = rangeX.Size.NumberOfRows;
+                var yRows = rangeY.Size.NumberOfRows;
+
+                if (arguments.Count() > 2 && arguments[2].DataType != DataType.Empty) constVar = ArgToBool(arguments, 2);
+                if (arguments.Count() > 3) stats = ArgToBool(arguments, 3);
+
+                if ((xRows != yRows && xColumns == yColumns)
+                    || (xColumns != yColumns && xRows == yRows))
+                {
+                    multipleXranges = true;
+                }
+                else
+                {
+                    if (xRows != yRows || xColumns != yColumns) return CreateResult(eErrorType.Ref);
+                }
+
+                //Flat list of all values
+                RangeFlattener.GetNumericPairLists(rangeX, rangeY, !multipleXranges, out List<double> knownXsList, out List<double> knownYsList);
+
+                //Converting the result of rangeflattener to double[]
+                double[] knownXs = new double[knownXsList.Count];
+                double[] knownYs = new double[knownYsList.Count];
+
+                for (var i = 0; i < knownXsList.Count; i++)
+                {
+                    knownXs[i] = knownXsList[i];
+                }
+
+                for (var i = 0; i < knownYsList.Count; i++)
+                {
+                    knownYs[i] = knownYsList[i];
+                }
+                var r = 0;
+                var c = 0;
+                if (multipleXranges)
+                {
+                    if (multipleXranges && xColumns != yColumns)
+                    {
+                        columnArray = true;
+
+                        r = xRows;
+                        c = xColumns;
+                    }
+                    else if (multipleXranges && xRows != yRows)
+                    {
+                        rowArray = true;
+                        r = xColumns;
+                        c = xRows;
+                    }
+                }
+                else
+                {
+                    r = knownXs.Count();
+                    c = 1;
+                }
+                if (multipleXranges && constVar)
+                {
+                    c += 1; //This is because we need to add a vector of ones to the matrix in order to account for the intercept
+                }
+
+                double[][] xRanges = MatrixHelper.CreateMatrix(r, c);
+
+                if (columnArray)
+                {
+                    var counter = 0;
+                    var delimiter = (constVar) ? xRanges[0].Count() - 1 : xRanges[0].Count();
+                    for (var i = 0; i < xRanges.Count(); i++)
+                    {
+                        for (var j = 0; j < delimiter; j++)
+                        {
+                            xRanges[i][j] = knownXs[counter];
+                            counter += 1;
+                        }
+                    }
+                }
+
+                else if (rowArray)
+                {
+                    //This shifts data thats row-based to column-based.
+                    var counter = 0;
+                    var delimiter = (constVar) ? xRanges[0].Count() - 1 : xRanges[0].Count();
+                    for (var i = 0; i < delimiter; i++)
+                    {
+                        for (var j = 0; j < xRanges.Count(); j++)
+                        {
+                            xRanges[j][i] = knownXs[counter];
+                            counter += 1;
+                        }
+                    }
+                }
+
+                if (multipleXranges)
+                {
+                    var resultRangeX = LinestHelper.CalculateMultipleXRanges(knownYs, xRanges, constVar, stats, false);
+                    return CreateDynamicArrayResult(resultRangeX, DataType.ExcelRange);
+                }
+                else
+                {
+                    var resultRange = LinestHelper.CalculateResult(knownYs, knownXs, constVar, stats, false);
+                    return CreateDynamicArrayResult(resultRange, DataType.ExcelRange);
+                }
+            }
+            else
+            {
+                var knownYsList = ArgsToDoubleEnumerable(new List<FunctionArgument> { arguments[0] }, context, out ExcelErrorValue e1).ToList();
+                if (e1 != null) return CreateResult(e1.Type);
+                var knownXsList = GetDefaultKnownXs(knownYsList.Count());
+
+                //Working around jagged array issues
+                double[] knownYs = new double[knownYsList.Count()];
+                double[] knownXs = new double[knownXsList.Count()];
+
+                for (var i = 0; i < knownYsList.Count(); i++)
+                {
+                    knownYs[i] = knownYsList[i];
+                }
+
+                for (var i = 0; i < knownXsList.Count(); i++)
+                {
+                    knownXs[i] = knownXsList[i];
+                }
+
+                if (arguments.Count() > 2) constVar = ArgToBool(arguments, 2);
+                if (arguments.Count() > 3) stats = ArgToBool(arguments, 3);
+
+                var resultRange = LinestHelper.CalculateResult(knownYs, knownXs, constVar, stats, false);
+                return CreateDynamicArrayResult(resultRange, DataType.ExcelRange);
+            }
+
+        }
+        private List<double> GetDefaultKnownXs(int count)
+        {
+            //If no x-values are provided as input, LINEST aranges default values in ascending order
+            List<double> result = new List<double>();
+            for (int i = 1; i <= count; i++)
+            {
+                result.Add(i);
+            }
+            return result;
+        }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Logest.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Logest.cs
@@ -12,6 +12,7 @@
 *************************************************************************************************/
 using OfficeOpenXml.Drawing.Style.Fill;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
 using OfficeOpenXml.FormulaParsing.ExcelUtilities;
@@ -19,6 +20,7 @@ using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using OfficeOpenXml.FormulaParsing.Ranges;
 using OfficeOpenXml.Sorting.Internal;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -39,165 +41,33 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
             if (!arguments[0].IsExcelRange) return CompileResult.GetErrorResult(eErrorType.Value);
             var constVar = true;
             var stats = false;
-            bool multipleXranges = false;
-            bool columnArray = false;
-            bool rowArray = false;
+            if (arguments.Count() > 2 && arguments[2].DataType != DataType.Empty) constVar = ArgToBool(arguments, 2);
+            if (arguments.Count() > 3) stats = ArgToBool(arguments, 3);
+
             if (arguments.Count() > 1 && arguments[1].IsExcelRange)
             {
                 var rangeX = arguments[1].ValueAsRangeInfo;
                 var rangeY = arguments[0].ValueAsRangeInfo;
-                var xColumns = rangeX.Size.NumberOfCols;
-                var yColumns = rangeY.Size.NumberOfCols;
-                var xRows = rangeX.Size.NumberOfRows;
-                var yRows = rangeY.Size.NumberOfRows;
-
-                if (arguments.Count() > 2 && arguments[2].DataType != DataType.Empty) constVar = ArgToBool(arguments, 2); //Need to change this
-                if (arguments.Count() > 3) stats = ArgToBool(arguments, 3);
-
-                double[] knownXs, knownYs;
-                double[][] xRanges;
-                return NewMethod(constVar, ref multipleXranges, ref columnArray, ref rowArray, rangeX, rangeY, xColumns, yColumns, xRows, yRows, out knownXs, out knownYs, out xRanges);
-
-                if (multipleXranges)
+                var linestResult = LinestHelper.ExecuteLinest(rangeX, rangeY, constVar, stats, true, out eErrorType? error);
+                if (error == null)
                 {
-                    var resultRangeX = LinestHelper.CalculateMultipleXRanges(knownYs, xRanges, constVar, stats, true);
-                    return CreateDynamicArrayResult(resultRangeX, DataType.ExcelRange);
+                    return CreateDynamicArrayResult(linestResult, DataType.ExcelRange);
                 }
                 else
                 {
-                    var resultRange = LinestHelper.CalculateResult(knownYs, knownXs, constVar, stats, true);
-                    return CreateDynamicArrayResult(resultRange, DataType.ExcelRange);
+                    return CompileResult.GetErrorResult(error.Value);
                 }
             }
             else
             {
                 var knownYsList = ArgsToDoubleEnumerable(new List<FunctionArgument> { arguments[0] }, context, out ExcelErrorValue e1).ToList();
                 if (e1 != null) return CreateResult(e1.Type);
-                var knownXsList = GetDefaultKnownXs(knownYsList.Count());
+                var knownXs = LinestHelper.GetDefaultKnownXs(knownYsList.Count());
+                var knownYs = MatrixHelper.ListToArray(knownYsList);
+                var resultRange = LinestHelper.LinearRegResult(knownXs, knownYs, constVar, stats, true);
 
-                //Working around jagged array issues
-                double[] knownYs = new double[knownYsList.Count()];
-                double[] knownXs = new double[knownXsList.Count()];
-
-                for (var i = 0; i < knownYsList.Count(); i++)
-                {
-                    knownYs[i] = knownYsList[i];
-                }
-
-                for (var i = 0; i < knownXsList.Count(); i++)
-                {
-                    knownXs[i] = knownXsList[i];
-                }
-
-                if (arguments.Count() > 2) constVar = ArgToBool(arguments, 2);
-                if (arguments.Count() > 3) stats = ArgToBool(arguments, 3);
-
-                var resultRange = LinestHelper.CalculateResult(knownYs, knownXs, constVar, stats, true);
                 return CreateDynamicArrayResult(resultRange, DataType.ExcelRange);
             }
-        }
-
-        private CompileResult NewMethod(bool constVar, ref bool multipleXranges, ref bool columnArray, ref bool rowArray, IRangeInfo rangeX, IRangeInfo rangeY, short xColumns, short yColumns, int xRows, int yRows, out double[] knownXs, out double[] knownYs, out double[][] xRanges)
-        {
-            if ((xRows != yRows && xColumns == yColumns)
-                || (xColumns != yColumns && xRows == yRows))
-            {
-                multipleXranges = true;
-            }
-            else
-            {
-                if (xRows != yRows || xColumns != yColumns) return CreateResult(eErrorType.Ref);
-            }
-
-            RangeFlattener.GetNumericPairLists(rangeX, rangeY, !multipleXranges, out List<double> knownXsList, out List<double> knownYsList);
-
-            //Converting the result of rangeflattener to double[]
-            knownXs = new double[knownXsList.Count];
-            knownYs = new double[knownYsList.Count];
-
-            //y values cant be zero or negative since we have to take the logarithm of the y-values to find a solution.
-            for (var i = 0; i < knownYsList.Count(); i++)
-            {
-                if (knownYsList[i] <= 0) return CreateResult(eErrorType.Num);
-            }
-
-            for (var i = 0; i < knownXsList.Count; i++)
-            {
-                knownXs[i] = knownXsList[i];
-            }
-
-            for (var i = 0; i < knownYsList.Count; i++)
-            {
-                knownYs[i] = knownYsList[i];
-            }
-            var r = 0;
-            var c = 0;
-            if (multipleXranges)
-            {
-                if (multipleXranges && xColumns != yColumns)
-                {
-                    columnArray = true;
-
-                    r = xRows;
-                    c = xColumns;
-                }
-                else if (multipleXranges && xRows != yRows)
-                {
-                    rowArray = true;
-                    r = xColumns;
-                    c = xRows;
-                }
-            }
-            else
-            {
-                r = knownXs.Count();
-                c = 1;
-            }
-            if (multipleXranges && constVar)
-            {
-                c += 1; //This is because we need to add a vector of ones to the matrix in order to account for the intercept
-            }
-
-            xRanges = MatrixHelper.CreateMatrix(r, c);
-            if (columnArray)
-            {
-                var counter = 0;
-                var delimiter = (constVar) ? xRanges[0].Count() - 1 : xRanges[0].Count();
-                for (var i = 0; i < xRanges.Count(); i++)
-                {
-                    for (var j = 0; j < delimiter; j++)
-                    {
-                        xRanges[i][j] = knownXs[counter];
-                        counter += 1;
-                    }
-                }
-            }
-
-            else if (rowArray)
-            {
-                //This shifts data thats row-based to column-based.
-                var counter = 0;
-                var delimiter = (constVar) ? xRanges[0].Count() - 1 : xRanges[0].Count();
-                for (var i = 0; i < delimiter; i++)
-                {
-                    for (var j = 0; j < xRanges.Count(); j++)
-                    {
-                        xRanges[j][i] = knownXs[counter];
-                        counter += 1;
-                    }
-                }
-            }
-        }
-
-        private List<double> GetDefaultKnownXs(int count)
-        {
-            //If no x-values are provided as input, LOGEST aranges default values in ascending order
-            List<double> result = new List<double>();
-            for (int i = 1; i <= count; i++)
-            {
-                result.Add(i);
-            }
-            return result;
         }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Logest.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Logest.cs
@@ -54,95 +54,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
                 if (arguments.Count() > 2 && arguments[2].DataType != DataType.Empty) constVar = ArgToBool(arguments, 2); //Need to change this
                 if (arguments.Count() > 3) stats = ArgToBool(arguments, 3);
 
-                if ((xRows != yRows && xColumns == yColumns)
-                    || (xColumns != yColumns && xRows == yRows))
-                {
-                    multipleXranges = true;
-                }
-                else
-                {
-                    if (xRows != yRows || xColumns != yColumns) return CreateResult(eErrorType.Ref);
-                }
-
-                RangeFlattener.GetNumericPairLists(rangeX, rangeY, !multipleXranges, out List<double> knownXsList, out List<double> knownYsList);
-
-                //Converting the result of rangeflattener to double[]
-                double[] knownXs = new double[knownXsList.Count];
-                double[] knownYs = new double[knownYsList.Count];
-
-                //y values cant be zero or negative since we have to take the logarithm of the y-values to find a solution.
-                for (var i = 0; i < knownYsList.Count(); i++)
-                {
-                    if (knownYsList[i] <= 0) return CreateResult(eErrorType.Num);
-                }
-
-                for (var i = 0; i < knownXsList.Count; i++)
-                {
-                    knownXs[i] = knownXsList[i];
-                }
-
-                for (var i = 0; i < knownYsList.Count; i++)
-                {
-                    knownYs[i] = knownYsList[i];
-                }
-                var r = 0;
-                var c = 0;
-                if (multipleXranges)
-                {
-                    if (multipleXranges && xColumns != yColumns)
-                    {
-                        columnArray = true;
-
-                        r = xRows;
-                        c = xColumns;
-                    }
-                    else if (multipleXranges && xRows != yRows)
-                    {
-                        rowArray = true;
-                        r = xColumns;
-                        c = xRows;
-                    }
-                }
-                else
-                {
-                    r = knownXs.Count();
-                    c = 1;
-                }
-                if (multipleXranges && constVar)
-                {
-                    c += 1; //This is because we need to add a vector of ones to the matrix in order to account for the intercept
-                }
-
-                double[][] xRanges = MatrixHelper.CreateMatrix(r, c);
-
-                if (columnArray)
-                {
-                    var counter = 0;
-                    var delimiter = (constVar) ? xRanges[0].Count() - 1 : xRanges[0].Count();
-                    for (var i = 0; i < xRanges.Count(); i++)
-                    {
-                        for (var j = 0; j < delimiter; j++)
-                        {
-                            xRanges[i][j] = knownXs[counter];
-                            counter += 1;
-                        }
-                    }
-                }
-
-                else if (rowArray)
-                {
-                    //This shifts data thats row-based to column-based.
-                    var counter = 0;
-                    var delimiter = (constVar) ? xRanges[0].Count() - 1 : xRanges[0].Count();
-                    for (var i = 0; i < delimiter; i++)
-                    {
-                        for (var j = 0; j < xRanges.Count(); j++)
-                        {
-                            xRanges[j][i] = knownXs[counter];
-                            counter += 1;
-                        }
-                    }
-                }
+                double[] knownXs, knownYs;
+                double[][] xRanges;
+                return NewMethod(constVar, ref multipleXranges, ref columnArray, ref rowArray, rangeX, rangeY, xColumns, yColumns, xRows, yRows, out knownXs, out knownYs, out xRanges);
 
                 if (multipleXranges)
                 {
@@ -180,6 +94,98 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
 
                 var resultRange = LinestHelper.CalculateResult(knownYs, knownXs, constVar, stats, true);
                 return CreateDynamicArrayResult(resultRange, DataType.ExcelRange);
+            }
+        }
+
+        private CompileResult NewMethod(bool constVar, ref bool multipleXranges, ref bool columnArray, ref bool rowArray, IRangeInfo rangeX, IRangeInfo rangeY, short xColumns, short yColumns, int xRows, int yRows, out double[] knownXs, out double[] knownYs, out double[][] xRanges)
+        {
+            if ((xRows != yRows && xColumns == yColumns)
+                || (xColumns != yColumns && xRows == yRows))
+            {
+                multipleXranges = true;
+            }
+            else
+            {
+                if (xRows != yRows || xColumns != yColumns) return CreateResult(eErrorType.Ref);
+            }
+
+            RangeFlattener.GetNumericPairLists(rangeX, rangeY, !multipleXranges, out List<double> knownXsList, out List<double> knownYsList);
+
+            //Converting the result of rangeflattener to double[]
+            knownXs = new double[knownXsList.Count];
+            knownYs = new double[knownYsList.Count];
+
+            //y values cant be zero or negative since we have to take the logarithm of the y-values to find a solution.
+            for (var i = 0; i < knownYsList.Count(); i++)
+            {
+                if (knownYsList[i] <= 0) return CreateResult(eErrorType.Num);
+            }
+
+            for (var i = 0; i < knownXsList.Count; i++)
+            {
+                knownXs[i] = knownXsList[i];
+            }
+
+            for (var i = 0; i < knownYsList.Count; i++)
+            {
+                knownYs[i] = knownYsList[i];
+            }
+            var r = 0;
+            var c = 0;
+            if (multipleXranges)
+            {
+                if (multipleXranges && xColumns != yColumns)
+                {
+                    columnArray = true;
+
+                    r = xRows;
+                    c = xColumns;
+                }
+                else if (multipleXranges && xRows != yRows)
+                {
+                    rowArray = true;
+                    r = xColumns;
+                    c = xRows;
+                }
+            }
+            else
+            {
+                r = knownXs.Count();
+                c = 1;
+            }
+            if (multipleXranges && constVar)
+            {
+                c += 1; //This is because we need to add a vector of ones to the matrix in order to account for the intercept
+            }
+
+            xRanges = MatrixHelper.CreateMatrix(r, c);
+            if (columnArray)
+            {
+                var counter = 0;
+                var delimiter = (constVar) ? xRanges[0].Count() - 1 : xRanges[0].Count();
+                for (var i = 0; i < xRanges.Count(); i++)
+                {
+                    for (var j = 0; j < delimiter; j++)
+                    {
+                        xRanges[i][j] = knownXs[counter];
+                        counter += 1;
+                    }
+                }
+            }
+
+            else if (rowArray)
+            {
+                //This shifts data thats row-based to column-based.
+                var counter = 0;
+                var delimiter = (constVar) ? xRanges[0].Count() - 1 : xRanges[0].Count();
+                for (var i = 0; i < delimiter; i++)
+                {
+                    for (var j = 0; j < xRanges.Count(); j++)
+                    {
+                        xRanges[j][i] = knownXs[counter];
+                        counter += 1;
+                    }
+                }
             }
         }
 

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Logest.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Logest.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
+{
+    internal class Logest
+    {
+    }
+}

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Logest.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Logest.cs
@@ -1,12 +1,197 @@
-﻿using System;
+﻿/*************************************************************************************************
+ Required Notice: Copyright (C) EPPlus Software AB. 
+ This software is licensed under PolyForm Noncommercial License 1.0.0 
+ and may only be used for noncommercial purposes 
+ https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+ A commercial license to use this software can be purchased at https://epplussoftware.com
+*************************************************************************************************
+ Date               Author                       Change
+*************************************************************************************************
+ 19/06/2024         EPPlus Software AB       Initial release EPPlus 7
+*************************************************************************************************/
+using OfficeOpenXml.Drawing.Style.Fill;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
+using OfficeOpenXml.FormulaParsing.ExcelUtilities;
+using OfficeOpenXml.FormulaParsing.FormulaExpressions;
+using OfficeOpenXml.FormulaParsing.Ranges;
+using OfficeOpenXml.Sorting.Internal;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
 {
-    internal class Logest
+    [FunctionMetadata(
+       Category = ExcelFunctionCategory.Statistical,
+       EPPlusVersion = "7.0",
+       Description = "The LOGEST function calculates an exponential curve that best fits the input data. It can also provide multiple curves if there are multiple " +
+                     "x-variables.")]
+    internal class Logest : ExcelFunction
     {
+        public override int ArgumentMinLength => 1;
+
+        public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
+        {
+            if (!arguments[0].IsExcelRange) return CompileResult.GetErrorResult(eErrorType.Value);
+            var constVar = true;
+            var stats = false;
+            bool multipleXranges = false;
+            bool columnArray = false;
+            bool rowArray = false;
+            if (arguments.Count() > 1 && arguments[1].IsExcelRange)
+            {
+                var rangeX = arguments[1].ValueAsRangeInfo;
+                var rangeY = arguments[0].ValueAsRangeInfo;
+                var xColumns = rangeX.Size.NumberOfCols;
+                var yColumns = rangeY.Size.NumberOfCols;
+                var xRows = rangeX.Size.NumberOfRows;
+                var yRows = rangeY.Size.NumberOfRows;
+
+                if (arguments.Count() > 2 && arguments[2].DataType != DataType.Empty) constVar = ArgToBool(arguments, 2); //Need to change this
+                if (arguments.Count() > 3) stats = ArgToBool(arguments, 3);
+
+                if ((xRows != yRows && xColumns == yColumns)
+                    || (xColumns != yColumns && xRows == yRows))
+                {
+                    multipleXranges = true;
+                }
+                else
+                {
+                    if (xRows != yRows || xColumns != yColumns) return CreateResult(eErrorType.Ref);
+                }
+
+                RangeFlattener.GetNumericPairLists(rangeX, rangeY, !multipleXranges, out List<double> knownXsList, out List<double> knownYsList);
+
+                //Converting the result of rangeflattener to double[]
+                double[] knownXs = new double[knownXsList.Count];
+                double[] knownYs = new double[knownYsList.Count];
+
+                //y values cant be zero or negative since we have to take the logarithm of the y-values to find a solution.
+                for (var i = 0; i < knownYsList.Count(); i++)
+                {
+                    if (knownYsList[i] <= 0) return CreateResult(eErrorType.Num);
+                }
+
+                for (var i = 0; i < knownXsList.Count; i++)
+                {
+                    knownXs[i] = knownXsList[i];
+                }
+
+                for (var i = 0; i < knownYsList.Count; i++)
+                {
+                    knownYs[i] = knownYsList[i];
+                }
+                var r = 0;
+                var c = 0;
+                if (multipleXranges)
+                {
+                    if (multipleXranges && xColumns != yColumns)
+                    {
+                        columnArray = true;
+
+                        r = xRows;
+                        c = xColumns;
+                    }
+                    else if (multipleXranges && xRows != yRows)
+                    {
+                        rowArray = true;
+                        r = xColumns;
+                        c = xRows;
+                    }
+                }
+                else
+                {
+                    r = knownXs.Count();
+                    c = 1;
+                }
+                if (multipleXranges && constVar)
+                {
+                    c += 1; //This is because we need to add a vector of ones to the matrix in order to account for the intercept
+                }
+
+                double[][] xRanges = MatrixHelper.CreateMatrix(r, c);
+
+                if (columnArray)
+                {
+                    var counter = 0;
+                    var delimiter = (constVar) ? xRanges[0].Count() - 1 : xRanges[0].Count();
+                    for (var i = 0; i < xRanges.Count(); i++)
+                    {
+                        for (var j = 0; j < delimiter; j++)
+                        {
+                            xRanges[i][j] = knownXs[counter];
+                            counter += 1;
+                        }
+                    }
+                }
+
+                else if (rowArray)
+                {
+                    //This shifts data thats row-based to column-based.
+                    var counter = 0;
+                    var delimiter = (constVar) ? xRanges[0].Count() - 1 : xRanges[0].Count();
+                    for (var i = 0; i < delimiter; i++)
+                    {
+                        for (var j = 0; j < xRanges.Count(); j++)
+                        {
+                            xRanges[j][i] = knownXs[counter];
+                            counter += 1;
+                        }
+                    }
+                }
+
+                if (multipleXranges)
+                {
+                    var resultRangeX = LinestHelper.CalculateMultipleXRanges(knownYs, xRanges, constVar, stats, true);
+                    return CreateDynamicArrayResult(resultRangeX, DataType.ExcelRange);
+                }
+                else
+                {
+                    var resultRange = LinestHelper.CalculateResult(knownYs, knownXs, constVar, stats, true);
+                    return CreateDynamicArrayResult(resultRange, DataType.ExcelRange);
+                }
+            }
+            else
+            {
+                var knownYsList = ArgsToDoubleEnumerable(new List<FunctionArgument> { arguments[0] }, context, out ExcelErrorValue e1).ToList();
+                if (e1 != null) return CreateResult(e1.Type);
+                var knownXsList = GetDefaultKnownXs(knownYsList.Count());
+
+                //Working around jagged array issues
+                double[] knownYs = new double[knownYsList.Count()];
+                double[] knownXs = new double[knownXsList.Count()];
+
+                for (var i = 0; i < knownYsList.Count(); i++)
+                {
+                    knownYs[i] = knownYsList[i];
+                }
+
+                for (var i = 0; i < knownXsList.Count(); i++)
+                {
+                    knownXs[i] = knownXsList[i];
+                }
+
+                if (arguments.Count() > 2) constVar = ArgToBool(arguments, 2);
+                if (arguments.Count() > 3) stats = ArgToBool(arguments, 3);
+
+                var resultRange = LinestHelper.CalculateResult(knownYs, knownXs, constVar, stats, true);
+                return CreateDynamicArrayResult(resultRange, DataType.ExcelRange);
+            }
+        }
+
+        private List<double> GetDefaultKnownXs(int count)
+        {
+            //If no x-values are provided as input, LOGEST aranges default values in ascending order
+            List<double> result = new List<double>();
+            for (int i = 1; i <= count; i++)
+            {
+                result.Add(i);
+            }
+            return result;
+        }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Trend.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Trend.cs
@@ -1,0 +1,112 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  06/07/2023         EPPlus Software AB         Implemented function
+ *************************************************************************************************/
+
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
+using OfficeOpenXml.FormulaParsing.ExcelUtilities;
+using OfficeOpenXml.FormulaParsing.FormulaExpressions;
+using OfficeOpenXml.FormulaParsing.Ranges;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
+{
+
+    [FunctionMetadata(
+    Category = ExcelFunctionCategory.Statistical,
+    EPPlusVersion = "7.0",
+    Description = "Returns the y-values along a linear trend that fits the inputted data. If new_x's is given, it returns the y-values" +
+                  "along those x-values.")]
+    internal class Trend : ExcelFunction
+    {
+        public override int ArgumentMinLength => 1;
+
+        public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
+        {
+            //Error management
+            var constVar = true;
+            if (!arguments[0].IsExcelRange) return CompileResult.GetErrorResult(eErrorType.Value);
+
+            if (arguments.Count() > 1 && arguments[1].IsExcelRange)
+            {
+                var argY = arguments[0].ValueAsRangeInfo;
+                var argX = arguments[1].ValueAsRangeInfo;
+
+                if (arguments.Count() > 3) constVar = ArgToBool(arguments, 3);
+
+                var linestResult = LinestHelper.ExecuteLinest(argX, argY, constVar, false, false, out eErrorType? error);
+                double[] coefficients = new double[linestResult.Size.NumberOfCols];
+                for (var i = 0; i < coefficients.Length; i++)
+                {
+                    coefficients[i] = (double)linestResult.GetValue(0, i);
+                }
+
+                bool multipleXranges = false;
+                double[][] xRanges;
+                if (arguments[2].IsExcelRange)
+                {
+                    var argNewX = arguments[2].ValueAsRangeInfo;
+                    if ((argNewX.Size.NumberOfRows != argY.Size.NumberOfRows && argNewX.Size.NumberOfCols == argY.Size.NumberOfCols)
+                    || (argNewX.Size.NumberOfCols != argY.Size.NumberOfCols && argNewX.Size.NumberOfRows == argY.Size.NumberOfRows)) multipleXranges = true;
+                    xRanges = LinestHelper.RangeToJaggedDouble(argNewX, argY, constVar, multipleXranges);
+                    if (multipleXranges)
+                    {
+                        return CreateDynamicArrayResult(TrendHelper.GetTrendValuesMultiple(xRanges, coefficients, constVar), DataType.ExcelRange);
+                    }
+                    else
+                    {
+                        RangeFlattener.GetNumericPairLists(argNewX, argY, !multipleXranges, out List<double> knownXsList, out List<double> knownYsList);
+                        var knownXs = MatrixHelper.ListToArray(knownXsList);
+                        return CreateDynamicArrayResult(TrendHelper.GetTrendValuesSingle(knownXs, coefficients), DataType.ExcelRange);
+                    }
+                }
+                else
+                {
+                    if ((argX.Size.NumberOfRows != argY.Size.NumberOfRows && argX.Size.NumberOfCols == argY.Size.NumberOfCols)
+                    || (argX.Size.NumberOfCols != argY.Size.NumberOfCols && argX.Size.NumberOfRows == argY.Size.NumberOfRows)) multipleXranges = true;
+                    if (multipleXranges)
+                    {
+                        xRanges = LinestHelper.RangeToJaggedDouble(argX, argY, constVar, multipleXranges);
+                        return CreateDynamicArrayResult(TrendHelper.GetTrendValuesMultiple(xRanges, coefficients, constVar), DataType.ExcelRange);
+                    }
+                    else
+                    {
+                        RangeFlattener.GetNumericPairLists(argX, argY, !multipleXranges, out List<double> knownXsList, out List<double> knownYsList);
+                        var knownXs = MatrixHelper.ListToArray(knownXsList);
+                        return CreateDynamicArrayResult(TrendHelper.GetTrendValuesSingle(knownXs, coefficients), DataType.ExcelRange);
+                    }
+                }
+            }
+            else
+            {
+                //Code for default values here
+                var knownYsList = ArgsToDoubleEnumerable(new List<FunctionArgument> { arguments[0] }, context, out ExcelErrorValue e1).ToList();
+                var knownYs = MatrixHelper.ListToArray(knownYsList);
+                var knownXs = LinestHelper.GetDefaultKnownXs(knownYs.Count());
+                var linestResult = LinestHelper.LinearRegResult(knownXs, knownYs, constVar, false, false);
+                double[] coefficients3 = new double[linestResult.Size.NumberOfCols];
+                for (var i = 0; i < coefficients3.Length; i++)
+                {
+                    coefficients3[i] = (double)linestResult.GetValue(0, i);
+                }
+
+                return CreateDynamicArrayResult(TrendHelper.GetTrendValuesSingle(knownXs, coefficients3), DataType.ExcelRange);
+            }
+        }
+    }
+}

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Trend.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Trend.cs
@@ -63,7 +63,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
                 return CreateDynamicArrayResult(TrendHelper.GetTrendValuesSingle(xVals, defaultCoefficients, columnArray), DataType.ExcelRange);
             }
 
-            if (arguments.Count > 3) constVar = ArgToBool(arguments, 3);
+            if (arguments.Count() > 3) constVar = ArgToBool(arguments, 3);
 
             //Get the line coefficient(s)
             if ((argX.Size.NumberOfRows != argY.Size.NumberOfRows && argX.Size.NumberOfCols == argY.Size.NumberOfCols)
@@ -78,6 +78,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
                 coefficients[i] = (double)linestResult.GetValue(0, i);
             }
 
+            //If newXs is given:
             if (arguments[2].IsExcelRange)
             {
                 argNewX = arguments[2].ValueAsRangeInfo;
@@ -99,6 +100,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
                 }
             }
             
+            //If newXs is omitted:
             if (multipleXranges)
             {
                 var xRanges = LinestHelper.GetRangeAsJaggedDouble(argX, argY, constVar, multipleXranges);
@@ -108,117 +110,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
             //Return for single variable case
             RangeFlattener.GetNumericPairLists(argX, argY, !multipleXranges, out List<double> knownXsList, out List<double> knownYsList);
             var knownXs = MatrixHelper.ListToArray(knownXsList);
-            if (argX.Size.NumberOfCols == 1) columnArray = true;
             return CreateDynamicArrayResult(TrendHelper.GetTrendValuesSingle(knownXs, coefficients, columnArray), DataType.ExcelRange);
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-            //if (arguments.Count() > 1 && arguments[1].IsExcelRange)
-            //{
-            //    var argY = arguments[0].ValueAsRangeInfo;
-            //    var argX = arguments[1].ValueAsRangeInfo;
-
-            //    if (arguments.Count() > 3) constVar = ArgToBool(arguments, 3);
-
-            //    var linestResult = LinestHelper.ExecuteLinest(argX, argY, constVar, false, false, out eErrorType? error);
-            //    double[] coefficients = new double[linestResult.Size.NumberOfCols];
-            //    for (var i = 0; i < coefficients.Length; i++)
-            //    {
-            //        coefficients[i] = (double)linestResult.GetValue(0, i);
-            //    }
-
-            //    bool multipleXranges = false;
-            //    double[][] xRanges;
-            //    if (arguments[2].IsExcelRange)
-            //    {
-            //        var argNewX = arguments[2].ValueAsRangeInfo;
-            //        if ((argNewX.Size.NumberOfRows != argY.Size.NumberOfRows && argNewX.Size.NumberOfCols == argY.Size.NumberOfCols)
-            //        || (argNewX.Size.NumberOfCols != argY.Size.NumberOfCols && argNewX.Size.NumberOfRows == argY.Size.NumberOfRows)) multipleXranges = true;
-            //        if (multipleXranges)
-            //        {
-            //            if (multipleXranges && argNewX.Size.NumberOfCols != argY.Size.NumberOfCols)
-            //            {
-            //                columnArray = true;
-            //            }
-            //            xRanges = LinestHelper.RangeToJaggedDouble(argNewX, argY, constVar, multipleXranges);
-            //            if (multipleXranges)
-            //            {
-            //                return CreateDynamicArrayResult(TrendHelper.GetTrendValuesMultiple(xRanges, coefficients, constVar, columnArray), DataType.ExcelRange);
-            //            }
-            //            else
-            //            {
-            //                RangeFlattener.GetNumericPairLists(argNewX, argY, !multipleXranges, out List<double> knownXsList, out List<double> knownYsList);
-            //                var knownXs = MatrixHelper.ListToArray(knownXsList);
-            //                if (argNewX.Size.NumberOfCols == 1) columnArray = true;
-            //                return CreateDynamicArrayResult(TrendHelper.GetTrendValuesSingle(knownXs, coefficients, columnArray), DataType.ExcelRange);
-            //            }
-            //        }
-            //        else
-            //        {
-            //            if ((argX.Size.NumberOfRows != argY.Size.NumberOfRows && argX.Size.NumberOfCols == argY.Size.NumberOfCols)
-            //            || (argX.Size.NumberOfCols != argY.Size.NumberOfCols && argX.Size.NumberOfRows == argY.Size.NumberOfRows)) multipleXranges = true;
-            //            if (multipleXranges)
-            //            {
-            //                if (multipleXranges && argNewX.Size.NumberOfCols != argY.Size.NumberOfCols)
-            //                {
-            //                    columnArray = true;
-            //                }
-            //            }
-            //            if (multipleXranges)
-            //            {
-            //                xRanges = LinestHelper.RangeToJaggedDouble(argX, argY, constVar, multipleXranges);
-            //                return CreateDynamicArrayResult(TrendHelper.GetTrendValuesMultiple(xRanges, coefficients, constVar, columnArray), DataType.ExcelRange);
-            //            }
-            //            else
-            //            {
-            //                RangeFlattener.GetNumericPairLists(argX, argY, !multipleXranges, out List<double> knownXsList, out List<double> knownYsList);
-            //                var knownXs = MatrixHelper.ListToArray(knownXsList);
-            //                if (argNewX.Size.NumberOfCols == 1) columnArray = true;
-            //                return CreateDynamicArrayResult(TrendHelper.GetTrendValuesSingle(knownXs, coefficients, columnArray), DataType.ExcelRange);
-            //            }
-            //        }
-            //    }
-            //}
-            //else
-            //{
-            //    //Code for default values here
-            //    var knownYsList = ArgsToDoubleEnumerable(new List<FunctionArgument> { arguments[0] }, context, out ExcelErrorValue e1).ToList();
-            //    var knownYs = MatrixHelper.ListToArray(knownYsList);
-            //    var knownXs = LinestHelper.GetDefaultKnownXs(knownYs.Count());
-            //    var linestDefaultResult = LinestHelper.LinearRegResult(knownXs, knownYs, constVar, false, false);
-            //    double[] coefficients3 = new double[linestDefaultResult.Size.NumberOfCols];
-            //    for (var i = 0; i < coefficients3.Length; i++)
-            //    {
-            //        coefficients3[i] = (double)linestDefaultResult.GetValue(0, i);
-            //    }
-            //    return CreateDynamicArrayResult(TrendHelper.GetTrendValuesSingle(knownXs, coefficients3, columnArray), DataType.ExcelRange);        
-            //}
         }
     }
 }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/LinestTest.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/LinestTest.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EPPlusTest.FormulaParsing.Excel.Functions.Statistical
+{
+    internal class LinestTest
+    {
+    }
+}

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/LinestTest.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/LinestTest.cs
@@ -652,7 +652,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Statistical
         //public void WorkBookTest()
         //{
         //    var wbPath = "C:\\Users\\HannesAlm\\Downloads\\LinestWorkBook2.xlsx";
-        //    using (ExcelPackage package = new ExcelPackage(new FileInfo(wbPath))) 
+        //    using (ExcelPackage package = new ExcelPackage(new FileInfo(wbPath)))
         //    {
         //        ExcelWorksheet worksheet = package.Workbook.Worksheets[0];
 
@@ -779,6 +779,34 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Statistical
                 Assert.AreEqual(0d, result4);
                 Assert.AreEqual(0d, result5);
             }
+        }
+
+        [TestMethod]
+        public void LinestConstCollinearTest()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("Const False and Collinearity test");
+                sheet.Cells["A1"].Value = 1;
+                sheet.Cells["A2"].Value = 2;
+                sheet.Cells["A3"].Value = 3;
+                sheet.Cells["A4"].Value = 4;
+                sheet.Cells["B1"].Value = 5;
+                sheet.Cells["B2"].Value = 6;
+                sheet.Cells["B3"].Value = 7;
+                sheet.Cells["B4"].Value = 8;
+                sheet.Cells["C1"].Value = 9;
+                sheet.Cells["C2"].Value = 10;
+                sheet.Cells["C3"].Value = 11;
+                sheet.Cells["C4"].Value = 12;
+                sheet.Cells["D1"].Value = 13;
+                sheet.Cells["D2"].Value = 14;
+                sheet.Cells["D3"].Value = 15;
+                sheet.Cells["D4"].Value = 16;
+                sheet.Cells["D6"].Formula = "LINEST(A1:A4, B1:D4, FALSE, True)";
+                sheet.Calculate();
+            }
+
         }
     }
 }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/LinestTest.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/LinestTest.cs
@@ -1,12 +1,784 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace EPPlusTest.FormulaParsing.Excel.Functions.Statistical
 {
-    internal class LinestTest
+    [TestClass]
+    public class LinestTest
     {
+        [TestMethod]
+        public void LinestNoConstInput()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = 0;
+                sheet.Cells["B3"].Value = 4;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["A8"].Formula = "LINEST(A2:A5, B2:B5,,FALSE)";
+                sheet.Calculate();
+                Assert.AreEqual(2d, sheet.Cells["A8"].Value);
+                Assert.AreEqual(1d, sheet.Cells["B8"].Value);
+            }
+        }
+
+        [TestMethod]
+        public void LinestNoStatInput()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = 0;
+                sheet.Cells["B3"].Value = 4;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["A8"].Formula = "LINEST(A2:A5,B2:B5,FALSE)";
+                sheet.Calculate();
+                var result = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                Assert.AreEqual(2.310344828d, result);
+                Assert.AreEqual(0d, sheet.Cells["B8"].Value);
+            }
+        }
+
+        [TestMethod]
+        public void LinestTestWithStatsAndConst()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with statistics");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = 0;
+                sheet.Cells["B3"].Value = 1;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["A8"].Formula = "LINEST(A2:A5,B2:B5,TRUE,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 1);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 1);
+                var result3 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result4 = System.Math.Round((double)sheet.Cells["B9"].Value, 9);
+                var result5 = System.Math.Round((double)sheet.Cells["A10"].Value, 2);
+                var result6 = System.Math.Round((double)sheet.Cells["B10"].Value, 9);
+                var result7 = System.Math.Round((double)sheet.Cells["A11"].Value, 9);
+                var result8 = System.Math.Round((double)sheet.Cells["B11"].Value, 0);
+                var result9 = System.Math.Round((double)sheet.Cells["A12"].Value, 1);
+                var result10 = System.Math.Round((double)sheet.Cells["B12"].Value, 1);
+                Assert.AreEqual(1.4d, result1);
+                Assert.AreEqual(3.4d, result2);
+                Assert.AreEqual(1.587450787d, result3);
+                Assert.AreEqual(2.969848481d, result4);
+                Assert.AreEqual(0.28d, result5);
+                Assert.AreEqual(3.54964787d, result6);
+                Assert.AreEqual(0.777777778d, result7);
+                Assert.AreEqual(2d, result8);
+                Assert.AreEqual(9.8d, result9);
+                Assert.AreEqual(25.2, result10);
+            }
+        }
+
+        [TestMethod]
+        public void LinestTestWithStatConstIsFalse()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with statistics and const = false");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = 0;
+                sheet.Cells["B3"].Value = 1;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["A8"].Formula = "LINEST(A2:A5,B2:B5,FALSE,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 0);
+                var result3 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result4 = sheet.Cells["B9"].Value;
+                var result5 = System.Math.Round((double)sheet.Cells["A10"].Value, 9);
+                var result6 = System.Math.Round((double)sheet.Cells["B10"].Value, 9);
+                var result7 = System.Math.Round((double)sheet.Cells["A11"].Value, 9);
+                var result8 = System.Math.Round((double)sheet.Cells["B11"].Value, 0);
+                var result9 = System.Math.Round((double)sheet.Cells["A12"].Value, 7);
+                var result10 = System.Math.Round((double)sheet.Cells["B12"].Value, 8);
+                Assert.AreEqual(2.857142857d, result1);
+                Assert.AreEqual(0d, result2);
+                Assert.AreEqual(0.996592835d, result3);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result4);
+                Assert.AreEqual(0.732600733d, result5);
+                Assert.AreEqual(3.728908943d, result6);
+                Assert.AreEqual(8.219178082d, result7);
+                Assert.AreEqual(3d, result8);
+                Assert.AreEqual(114.2857143d, result9);
+                Assert.AreEqual(41.71428571d, result10);
+            }
+        }
+
+        [TestMethod]
+        public void LinestTestWithNoXs()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with no Xs and only one argument: ");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["A6"].Value = 11;
+                sheet.Cells["A7"].Value = 2;
+                sheet.Cells["A8"].Formula = "LINEST(A2:A7)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                Assert.AreEqual(0.371428571d, result1);
+                Assert.AreEqual(4.533333333d, result2);
+            }
+        }
+
+        [TestMethod]
+        public void LinestTestWithNoXsAndConstIsTrue()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with no Xs and const is true: ");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["A6"].Value = 11;
+                sheet.Cells["A7"].Value = 2;
+                sheet.Cells["A8"].Formula = "LINEST(A2:A7,,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                Assert.AreEqual(0.371428571d, result1);
+                Assert.AreEqual(4.533333333d, result2);
+            }
+        }
+
+        [TestMethod]
+        public void LinestTestWithNoXsAndConstTrueStatTrue()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with no Xs and const is true and stat is true: ");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["A6"].Value = 11;
+                sheet.Cells["A7"].Value = 2;
+                sheet.Cells["A8"].Formula = "LINEST(A2:A7,,TRUE,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result4 = System.Math.Round((double)sheet.Cells["B9"].Value, 9);
+                var result5 = System.Math.Round((double)sheet.Cells["A10"].Value, 9);
+                var result6 = System.Math.Round((double)sheet.Cells["B10"].Value, 9);
+                var result7 = System.Math.Round((double)sheet.Cells["A11"].Value, 9);
+                var result8 = System.Math.Round((double)sheet.Cells["B11"].Value, 0);
+                var result9 = System.Math.Round((double)sheet.Cells["A12"].Value, 9);
+                var result10 = System.Math.Round((double)sheet.Cells["B12"].Value, 8);
+                Assert.AreEqual(0.371428571d, result1);
+                Assert.AreEqual(4.533333333d, result2);
+                Assert.AreEqual(1.031081593d, result3);
+                Assert.AreEqual(4.015485896d, result4);
+                Assert.AreEqual(0.031422374d, result5);
+                Assert.AreEqual(4.313323765d, result6);
+                Assert.AreEqual(0.129767085d, result7);
+                Assert.AreEqual(4d, result8);
+                Assert.AreEqual(2.414285714d, result9);
+                Assert.AreEqual(74.41904762d, result10);
+            }
+        }
+
+        [TestMethod]
+        public void LinestTestWithNoXsAndConstFalseStatTrue()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with no Xs and const is false and stat is true: ");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["A6"].Value = 11;
+                sheet.Cells["A7"].Value = 2;
+                sheet.Cells["A8"].Formula = "LINEST(A2:A7,,FALSE,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 0);
+                var result3 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result4 = sheet.Cells["B9"].Value;
+                var result5 = System.Math.Round((double)sheet.Cells["A10"].Value, 9);
+                var result6 = System.Math.Round((double)sheet.Cells["B10"].Value, 9);
+                var result7 = System.Math.Round((double)sheet.Cells["A11"].Value, 9);
+                var result8 = System.Math.Round((double)sheet.Cells["B11"].Value, 0);
+                var result9 = System.Math.Round((double)sheet.Cells["A12"].Value, 7);
+                var result10 = System.Math.Round((double)sheet.Cells["B12"].Value, 8);
+                Assert.AreEqual(1.417582418d, result1);
+                Assert.AreEqual(0d, result2);
+                Assert.AreEqual(0.464407618d, result3);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result4);
+                Assert.AreEqual(0.65077627d, result5);
+                Assert.AreEqual(4.43016632d, result6);
+                Assert.AreEqual(9.317469205d, result7);
+                Assert.AreEqual(5d, result8);
+                Assert.AreEqual(182.8681319d, result9);
+                Assert.AreEqual(98.13186813d, result10);
+            }
+        }
+
+        [TestMethod]
+        public void LinestTestUnevenSizes()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test where datapoints are equal but size is not");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["B2"].Value = 0;
+                sheet.Cells["B3"].Value = 1;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["C3"].Value = 7;
+                sheet.Cells["C4"].Value = 2;
+                sheet.Cells["C5"].Value = 3;
+                sheet.Cells["A8"].Formula = "LINEST(A2:B3,C2:C5,FALSE,TRUE)";
+                sheet.Calculate();
+                var result1 = sheet.Cells["A8"].Value;
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Ref), result1);
+
+            }
+        }
+
+        [TestMethod]
+        public void LinestMultipleXRangesSeveralColumns()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with multiple x-ranges");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = 0;
+                sheet.Cells["B3"].Value = 4;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["C2"].Value = 6;
+                sheet.Cells["C3"].Value = 5;
+                sheet.Cells["C4"].Value = 2;
+                sheet.Cells["C5"].Value = 0;
+                sheet.Cells["A8"].Formula = "LINEST(A2:A5,B2:C5)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 0);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 0);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 0);
+                Assert.AreEqual(0d, result1);
+                Assert.AreEqual(2d, result2);
+                Assert.AreEqual(1d, result3);
+            }
+        }
+
+        [TestMethod]
+        public void LinestMultipleXRangesSeveralRows()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with multiple x-ranges");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["B2"].Value = 9;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["D2"].Value = 7;
+                sheet.Cells["E2"].Value = 0;
+                sheet.Cells["A3"].Value = 4;
+                sheet.Cells["B3"].Value = 2;
+                sheet.Cells["C3"].Value = 3;
+                sheet.Cells["D3"].Value = 6;
+                sheet.Cells["E3"].Value = 5;
+                sheet.Cells["A4"].Value = 2;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["C4"].Value = 8;
+                sheet.Cells["D4"].Value = 5;
+                sheet.Cells["E4"].Value = 1;
+                sheet.Cells["A8"].Formula = "LINEST(A2:E2,A3:E4)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 9);
+                Assert.AreEqual(0.450151057d, result1);
+                Assert.AreEqual(-0.854984894d, result2);
+                Assert.AreEqual(6.19939577d, result3);
+            }
+        }
+
+        [TestMethod]
+        // Test currently fails because of keeping the floating error, making the code for collinearity detection not work.
+        public void LinestMultipleXRangesTwoByTwo() //This test returns failed because of collinearity
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with multiple x-ranges");
+                sheet.Cells["A2"].Value = 9;
+                sheet.Cells["A3"].Value = 12;
+                sheet.Cells["B2"].Value = 34;
+                sheet.Cells["B3"].Value = 65;
+                sheet.Cells["C2"].Value = 8;
+                sheet.Cells["C3"].Value = 7;
+                sheet.Cells["A8"].Formula = "LINEST(A2:A3,B2:C3)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 0);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 9);
+                Assert.AreEqual(0d, result1);
+                Assert.AreEqual(0.096774194d, result2);
+                Assert.AreEqual(5.709677419d, result3);
+            }
+        }
+
+        [TestMethod]
+        public void LinestMultipleRegressionWithStats()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with multiple x-ranges and stats");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["B2"].Value = 9;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["D2"].Value = 7;
+                sheet.Cells["E2"].Value = 0;
+                sheet.Cells["A3"].Value = 4;
+                sheet.Cells["B3"].Value = 2;
+                sheet.Cells["C3"].Value = 3;
+                sheet.Cells["D3"].Value = 6;
+                sheet.Cells["E3"].Value = 5;
+                sheet.Cells["A4"].Value = 2;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["C4"].Value = 8;
+                sheet.Cells["D4"].Value = 5;
+                sheet.Cells["E4"].Value = 1;
+                sheet.Cells["A8"].Formula = "LINEST(A2:E2,A3:E4,TRUE,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 8);
+                var result4 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result5 = System.Math.Round((double)sheet.Cells["B9"].Value, 9);
+                var result6 = System.Math.Round((double)sheet.Cells["C9"].Value, 9);
+                var result7 = System.Math.Round((double)sheet.Cells["A10"].Value, 9);
+                var result8 = System.Math.Round((double)sheet.Cells["B10"].Value, 9);
+                var result9 = sheet.Cells["C10"].Value;
+                var result10 = System.Math.Round((double)sheet.Cells["A11"].Value, 9);
+                var result11 = (double)sheet.Cells["B11"].Value;
+                var result12 = sheet.Cells["C11"].Value;
+                var result13 = System.Math.Round((double)sheet.Cells["A12"].Value, 8);
+                var result14 = System.Math.Round((double)sheet.Cells["B12"].Value, 8);
+                var result15 = sheet.Cells["C12"].Value;
+                Assert.AreEqual(0.450151057d, result1);
+                Assert.AreEqual(-0.854984894d, result2);
+                Assert.AreEqual(6.19939577d, result3);
+                Assert.AreEqual(0.81889275d, result4);
+                Assert.AreEqual(1.492093601d, result5);
+                Assert.AreEqual(7.119188135d, result6);
+                Assert.AreEqual(0.250122479d, result7);
+                Assert.AreEqual(4.711302858d, result8);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result9);
+                Assert.AreEqual(0.333551109d, result10);
+                Assert.AreEqual(2, result11);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result12);
+                Assert.AreEqual(14.80725076d, result13);
+                Assert.AreEqual(44.39274924d, result14);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result15);
+            }
+        }
+
+        [TestMethod]
+        public void LinestMultipleRegressionWithStatsAndConstIsFalse()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with multiple x-ranges and stats");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["B2"].Value = 9;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["D2"].Value = 7;
+                sheet.Cells["E2"].Value = 0;
+                sheet.Cells["A3"].Value = 4;
+                sheet.Cells["B3"].Value = 2;
+                sheet.Cells["C3"].Value = 3;
+                sheet.Cells["D3"].Value = 6;
+                sheet.Cells["E3"].Value = 5;
+                sheet.Cells["A4"].Value = 2;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["C4"].Value = 8;
+                sheet.Cells["D4"].Value = 5;
+                sheet.Cells["E4"].Value = 1;
+                sheet.Cells["A8"].Formula = "LINEST(A2:E2,A3:E4,FALSE,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 0);
+                var result4 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result5 = System.Math.Round((double)sheet.Cells["B9"].Value, 9);
+                var result6 = sheet.Cells["C9"].Value;
+                var result7 = System.Math.Round((double)sheet.Cells["A10"].Value, 9);
+                var result8 = System.Math.Round((double)sheet.Cells["B10"].Value, 9);
+                var result9 = sheet.Cells["C10"].Value;
+                var result10 = System.Math.Round((double)sheet.Cells["A11"].Value, 9);
+                var result11 = (double)sheet.Cells["B11"].Value;
+                var result12 = sheet.Cells["C11"].Value;
+                var result13 = System.Math.Round((double)sheet.Cells["A12"].Value, 8);
+                var result14 = System.Math.Round((double)sheet.Cells["B12"].Value, 8);
+                var result15 = sheet.Cells["C12"].Value;
+                Assert.AreEqual(0.778248214d, result1);
+                Assert.AreEqual(0.263826409d, result2);
+                Assert.AreEqual(0d, result3);
+                Assert.AreEqual(0.697161675d, result4);
+                Assert.AreEqual(0.727487085d, result5);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result6);
+                Assert.AreEqual(0.607537607d, result7);
+                Assert.AreEqual(4.517526365d, result8);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result9);
+                Assert.AreEqual(2.32202225d, result10);
+                Assert.AreEqual(3, result11);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result12);
+                Assert.AreEqual(94.77586663d, result13);
+                Assert.AreEqual(61.22413337d, result14);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result15);
+            }
+        }
+
+        [TestMethod]
+        public void LinestCollinearityTest() //This test returns failed because of collinearity
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with redundant x-sets");
+                sheet.Cells["A2"].Value = 9;
+                sheet.Cells["A3"].Value = 12;
+                sheet.Cells["B2"].Value = 34;
+                sheet.Cells["B3"].Value = 65;
+                sheet.Cells["C2"].Value = 8;
+                sheet.Cells["C3"].Value = 7;
+                sheet.Cells["D2"].Value = 15;
+                sheet.Cells["D3"].Value = 2431;
+                sheet.Cells["E2"].Value = 2534;
+                sheet.Cells["E3"].Value = 6769;
+                //sheet.Cells["E3"].Value = 5;
+                sheet.Cells["A8"].Formula = "LINEST(A2:A3,B2:E3,TRUE,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 0);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 0);
+                var result4 = System.Math.Round((double)sheet.Cells["D8"].Value, 0);
+                var result5 = System.Math.Round((double)sheet.Cells["E8"].Value, 9);
+                var result6 = System.Math.Round((double)sheet.Cells["A9"].Value, 0);
+                var result7 = System.Math.Round((double)sheet.Cells["B9"].Value, 0);
+                var result8 = System.Math.Round((double)sheet.Cells["C9"].Value, 0);
+                var result9 = System.Math.Round((double)sheet.Cells["D9"].Value, 0);
+                var result10 = System.Math.Round((double)sheet.Cells["E9"].Value, 0);
+                Assert.AreEqual(0.000708383d, result1);
+                Assert.AreEqual(0d, result2);
+                Assert.AreEqual(0d, result3);
+                Assert.AreEqual(0d, result4);
+                Assert.AreEqual(7.204958678d, result5);
+                Assert.AreEqual(0d, result6);
+                Assert.AreEqual(0d, result7);
+                Assert.AreEqual(0d, result8);
+                Assert.AreEqual(0d, result9);
+                Assert.AreEqual(0d, result10);
+            }
+        }
+
+        [TestMethod]
+        public void LinestRemovalOfRedundantVariablesTest() //This test returns failed because of collinearity
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with where independent values are completely dependent of one another");
+                sheet.Cells["A2"].Value = 10;
+                sheet.Cells["A3"].Value = 20;
+                sheet.Cells["A4"].Value = 30;
+                sheet.Cells["A5"].Value = 40;
+                sheet.Cells["A6"].Value = 50;
+                sheet.Cells["B2"].Value = 1;
+                sheet.Cells["B3"].Value = 4;
+                sheet.Cells["B4"].Value = 8;
+                sheet.Cells["B5"].Value = 7;
+                sheet.Cells["B6"].Value = 9;
+                sheet.Cells["C2"].Value = 11;
+                sheet.Cells["C3"].Value = 20;
+                sheet.Cells["C4"].Value = 32;
+                sheet.Cells["C5"].Value = 29;
+                sheet.Cells["C6"].Value = 35;
+                sheet.Cells["A8"].Formula = "LINEST(A2:A6,B2:C6,TRUE,true)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 6);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 0);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 5);
+                var result4 = System.Math.Round((double)sheet.Cells["A9"].Value, 6);
+                var result5 = System.Math.Round((double)sheet.Cells["B9"].Value, 0);
+                var result6 = System.Math.Round((double)sheet.Cells["C9"].Value, 6);
+                var result7 = System.Math.Round((double)sheet.Cells["A10"].Value, 6);
+                var result8 = System.Math.Round((double)sheet.Cells["B10"].Value, 5);
+                var result9 = sheet.Cells["C10"].Value;
+                var result10 = System.Math.Round((double)sheet.Cells["A11"].Value, 5);
+                var result11 = System.Math.Round((double)sheet.Cells["B11"].Value, 0);
+                var result12 = sheet.Cells["C11"].Value;
+                var result13 = System.Math.Round((double)sheet.Cells["A12"].Value, 4);
+                var result14 = System.Math.Round((double)sheet.Cells["B12"].Value, 4);
+                var result15 = sheet.Cells["C12"].Value;
+                Assert.AreEqual(1.479751d, result1);
+                Assert.AreEqual(0d, result2);
+                Assert.AreEqual(-7.58567d, result3);
+                Assert.AreEqual(0.368054d, result4);
+                Assert.AreEqual(0d, result5);
+                Assert.AreEqual(9.891007d, result6);
+                Assert.AreEqual(0.843458, result7);
+                Assert.AreEqual(7.22362, result8);
+                Assert.AreEqual(16.16418d, result10);
+                Assert.AreEqual(3d, result11);
+                Assert.AreEqual(843.4579d, result13);
+                Assert.AreEqual(156.5421, result14);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result9);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result12);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result15);
+            }
+        }
+
+        [TestMethod]
+        public void LinestWithMultipleXNoCollinearity()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("Test with multiple x-variables, but there is no collinearity: ");
+                sheet.Cells["A1"].Value = 1;
+                sheet.Cells["A2"].Value = 9;
+                sheet.Cells["A3"].Value = 18;
+                sheet.Cells["A4"].Value = 0;
+                sheet.Cells["A5"].Value = 4;
+                sheet.Cells["A6"].Value = 45;
+                sheet.Cells["B1"].Value = 50;
+                sheet.Cells["B2"].Value = 345;
+                sheet.Cells["B3"].Value = 3.4983;
+                sheet.Cells["B4"].Value = 234;
+                sheet.Cells["B5"].Value = 876;
+                sheet.Cells["B6"].Value = 876;
+                sheet.Cells["C1"].Value = 2738;
+                sheet.Cells["C2"].Value = 29810;
+                sheet.Cells["C3"].Value = 4309;
+                sheet.Cells["C4"].Value = 95;
+                sheet.Cells["C5"].Value = 34.0678;
+                sheet.Cells["C6"].Value = 561.4823;
+                sheet.Cells["D1"].Value = 2;
+                sheet.Cells["D2"].Value = 8;
+                sheet.Cells["D3"].Value = 6666;
+                sheet.Cells["D4"].Value = 5;
+                sheet.Cells["D5"].Value = 544.45;
+                sheet.Cells["D6"].Value = 7654;
+                sheet.Cells["E1"].Value = 543;
+                sheet.Cells["E2"].Value = 890;
+                sheet.Cells["E3"].Value = 876;
+                sheet.Cells["E4"].Value = 8765;
+                sheet.Cells["E5"].Value = 3487.298;
+                sheet.Cells["E6"].Value = 32.1;
+                sheet.Cells["F1"].Value = 50;
+                sheet.Cells["F2"].Value = 30;
+                sheet.Cells["F3"].Value = 2397.346;
+                sheet.Cells["F4"].Value = 423.789;
+                sheet.Cells["F5"].Value = 432.4;
+                sheet.Cells["F6"].Value = 746;
+                sheet.Cells["F10"].Formula = "LINEST(A1:A6, B1:F6, false, TRUE)";
+                sheet.Calculate();
+
+                //When debugging, this test returns the same as excel.
+
+            }
+        }
+
+        [TestMethod]
+        public void LinestOnesTest()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("Test where one column is just ones: ");
+                sheet.Cells["A1"].Value = 432;
+                sheet.Cells["A2"].Value = 47;
+                sheet.Cells["A3"].Value = 3287389;
+                sheet.Cells["A4"].Value = 23.6789;
+                sheet.Cells["A5"].Value = 246.3673;
+                sheet.Cells["B1"].Value = 1;
+                sheet.Cells["B2"].Value = 1;
+                sheet.Cells["B3"].Value = 1;
+                sheet.Cells["B4"].Value = 1;
+                sheet.Cells["B5"].Value = 1;
+                sheet.Cells["C1"].Value = 46;
+                sheet.Cells["C2"].Value = 23;
+                sheet.Cells["C3"].Value = 69;
+                sheet.Cells["C4"].Value = 12;
+                sheet.Cells["C5"].Value = 8;
+                sheet.Cells["D1"].Value = 92;
+                sheet.Cells["D2"].Value = 46;
+                sheet.Cells["D3"].Value = 132.2;
+                sheet.Cells["D4"].Value = 42;
+                sheet.Cells["D5"].Value = 16.1;
+                sheet.Cells["E7"].Formula = "Linest(A1:A5,B1:D5,FALSE,TRUE)";
+                sheet.Calculate();
+            }
+        }
+
+        //[TestMethod]
+
+        //public void WorkBookTest()
+        //{
+        //    var wbPath = "C:\\Users\\HannesAlm\\Downloads\\LinestWorkBook2.xlsx";
+        //    using (ExcelPackage package = new ExcelPackage(new FileInfo(wbPath))) 
+        //    {
+        //        ExcelWorksheet worksheet = package.Workbook.Worksheets[0];
+
+        //        var set_2_y = worksheet.Cells["I4:I7"].Address;
+        //        var set_2_x = worksheet.Cells["J4:L7"].Address;
+
+        //        var set_3_y = worksheet.Cells["O4:O8"].Address;
+        //        var set_3_x = worksheet.Cells["P4:R8"].Address;
+
+        //        var set_5_y = worksheet.Cells["I24:I33"].Address;
+        //        var set_5_x = worksheet.Cells["J24:M33"].Address;
+
+        //        var set_6_y = worksheet.Cells["P24:P33"].Address;
+        //        var set_6_x = worksheet.Cells["Q24:T33"].Address;
+
+        //        var set_7_y = worksheet.Cells["B50:B54"].Address;
+        //        var set_7_x = worksheet.Cells["C50:D54"].Address;
+
+        //        //And set 9
+
+        //        worksheet.Cells["I15"].Formula = "LINEST(I4:I7, J4:L7, TRUE, TRUE)";
+        //        worksheet.Cells["O16"].Formula = "LINEST(O4:O8, P4:R8, TRUE, TRUE)";
+        //        worksheet.Cells["I41"].Formula = "LINEST(I24:I33, J24:M33, TRUE, TRUE)";
+        //        worksheet.Cells["P41"].Formula = "LINEST(P24:P33, Q24:T33, TRUE, TRUE)";
+        //        worksheet.Cells["B62"].Formula = "LINEST(B50:B54, C50:D54, TRUE, TRUE)";
+        //        worksheet.Cells["K62"].Formula = "LINEST(K50:K54, L50:N54, FALSE, TRUE)";
+        //        worksheet.Calculate();
+
+        //        package.Save();
+        //    }
+        //}
+
+        [TestMethod]
+
+        public void StatTest9()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("stat test");
+                sheet.Cells["A1"].Value = 10;
+                sheet.Cells["A2"].Value = 20;
+                sheet.Cells["A3"].Value = 30;
+                sheet.Cells["A4"].Value = 40;
+                sheet.Cells["A5"].Value = 50;
+                sheet.Cells["B1"].Value = 1;
+                sheet.Cells["B2"].Value = 4;
+                sheet.Cells["B3"].Value = 8;
+                sheet.Cells["B4"].Value = 7;
+                sheet.Cells["B5"].Value = 9;
+                sheet.Cells["C1"].Value = 6;
+                sheet.Cells["C2"].Value = 48;
+                sheet.Cells["C3"].Value = 13;
+                sheet.Cells["C4"].Value = 27;
+                sheet.Cells["C5"].Value = 14;
+                sheet.Cells["D1"].Value = 7;
+                sheet.Cells["D2"].Value = 52;
+                sheet.Cells["D3"].Value = 21;
+                sheet.Cells["D4"].Value = 34;
+                sheet.Cells["D5"].Value = 23;
+                sheet.Cells["D6"].Formula = "LINEST(A1:A5, B1:D5, FALSE, TRUE)";
+                sheet.Calculate();
+            }
+        }
+
+        [TestMethod]
+
+        public void StatTest3()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("stat test");
+                sheet.Cells["A1"].Value = 432;
+                sheet.Cells["A2"].Value = 47;
+                sheet.Cells["A3"].Value = 3287389;
+                sheet.Cells["A4"].Value = 23.6789;
+                sheet.Cells["A5"].Value = 246.3673287;
+                sheet.Cells["B1"].Value = 1;
+                sheet.Cells["B2"].Value = 1;
+                sheet.Cells["B3"].Value = 1;
+                sheet.Cells["B4"].Value = 1;
+                sheet.Cells["B5"].Value = 1;
+                sheet.Cells["C1"].Value = 46;
+                sheet.Cells["C2"].Value = 23;
+                sheet.Cells["C3"].Value = 69;
+                sheet.Cells["C4"].Value = 12;
+                sheet.Cells["C5"].Value = 8;
+                sheet.Cells["D1"].Value = 92;
+                sheet.Cells["D2"].Value = 46;
+                sheet.Cells["D3"].Value = 132.2;
+                sheet.Cells["D4"].Value = 42;
+                sheet.Cells["D5"].Value = 16.1;
+                sheet.Cells["D6"].Formula = "LINEST(A1:A5, B1:D5, TRUE, TRUE)";
+                sheet.Calculate();
+            }
+        }
+
+        [TestMethod]
+        public void LinearConstFalseZerosTest()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("Const False and Collinearity test");
+                sheet.Cells["A1"].Value = 1;
+                sheet.Cells["A2"].Value = 2;
+                sheet.Cells["B1"].Value = 3;
+                sheet.Cells["B2"].Value = 4;
+                sheet.Cells["C1"].Value = 5;
+                sheet.Cells["C2"].Value = 6;
+                sheet.Cells["D1"].Value = 7;
+                sheet.Cells["D2"].Value = 8;
+                sheet.Cells["E1"].Value = 534;
+                sheet.Cells["E2"].Value = 25464;
+                sheet.Cells["D6"].Formula = "LINEST(A1:A2, B1:E2, FALSE, FALSE)";
+                sheet.Calculate();
+
+                var result1 = System.Math.Round((double)sheet.Cells["D6"].Value, 10);
+                var result2 = System.Math.Round((double)sheet.Cells["E6"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["F6"].Value, 0);
+                var result4 = System.Math.Round((double)sheet.Cells["G6"].Value, 0);
+                var result5 = System.Math.Round((double)sheet.Cells["H6"].Value, 0);
+                Assert.AreEqual(3.44875E-05d, result1);
+                Assert.AreEqual(0.140226238d, result2);
+                Assert.AreEqual(-0d, result3);
+                Assert.AreEqual(0d, result4);
+                Assert.AreEqual(0d, result5);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/LogestTest.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/LogestTest.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EPPlusTest.FormulaParsing.Excel.Functions.Statistical
+{
+    internal class LogestTest
+    {
+    }
+}

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/LogestTest.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/LogestTest.cs
@@ -1,12 +1,541 @@
 ﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace EPPlusTest.FormulaParsing.Excel.Functions.Statistical
 {
-    internal class LogestTest
+    [TestClass]
+    public class LogestTest
     {
+        [TestMethod]
+        public void LogestNoConstInput()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = 0;
+                sheet.Cells["B3"].Value = 4;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:A5, B2:B5,,FALSE)";
+                sheet.Calculate();
+                Assert.AreEqual(1.751115956d, System.Math.Round((double)sheet.Cells["A8"].Value, 9));
+                Assert.AreEqual(1.194315591d, System.Math.Round((double)sheet.Cells["B8"].Value, 9));
+            }
+        }
+
+        [TestMethod]
+        public void LogestNoStatInput()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = 0;
+                sheet.Cells["B3"].Value = 4;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:A5,B2:B5,FALSE)";
+                sheet.Calculate();
+                var result = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                Assert.AreEqual(1.850326716d, result);
+                Assert.AreEqual(1d, sheet.Cells["B8"].Value);
+            }
+        }
+
+        [TestMethod]
+        public void LogestTestWithStatsAndConst()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with statistics");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = 0;
+                sheet.Cells["B3"].Value = 1;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:A5,B2:B5,TRUE,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result4 = System.Math.Round((double)sheet.Cells["B9"].Value, 9);
+                var result5 = System.Math.Round((double)sheet.Cells["A10"].Value, 9);
+                var result6 = System.Math.Round((double)sheet.Cells["B10"].Value, 9);
+                var result7 = System.Math.Round((double)sheet.Cells["A11"].Value, 9);
+                var result8 = System.Math.Round((double)sheet.Cells["B11"].Value, 0);
+                var result9 = System.Math.Round((double)sheet.Cells["A12"].Value, 9);
+                var result10 = System.Math.Round((double)sheet.Cells["B12"].Value, 9);
+                Assert.AreEqual(1.690449345d, result1);
+                Assert.AreEqual(1.916789388d, result2);
+                Assert.AreEqual(0.394148965d, result3);
+                Assert.AreEqual(0.737385194d, result4);
+                Assert.AreEqual(0.470078317d, result5);
+                Assert.AreEqual(0.88134388d, result6);
+                Assert.AreEqual(1.7741426d, result7);
+                Assert.AreEqual(2d, result8);
+                Assert.AreEqual(1.378095486d, result9);
+                Assert.AreEqual(1.553534068d, result10);
+            }
+        }
+
+        [TestMethod]
+        public void LogestTestWithStatConstIsFalse()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with statistics and const = false");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = 0;
+                sheet.Cells["B3"].Value = 1;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:A5,B2:B5,FALSE,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 0);
+                var result3 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result4 = sheet.Cells["B9"].Value;
+                var result5 = System.Math.Round((double)sheet.Cells["A10"].Value, 9);
+                var result6 = System.Math.Round((double)sheet.Cells["B10"].Value, 9);
+                var result7 = System.Math.Round((double)sheet.Cells["A11"].Value, 9);
+                var result8 = System.Math.Round((double)sheet.Cells["B11"].Value, 0);
+                var result9 = System.Math.Round((double)sheet.Cells["A12"].Value, 9);
+                var result10 = System.Math.Round((double)sheet.Cells["B12"].Value, 9);
+                Assert.AreEqual(2.234114741d, result1);
+                Assert.AreEqual(1d, result2);
+                Assert.AreEqual(0.226690276d, result3);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result4);
+                Assert.AreEqual(0.807373214d, result5);
+                Assert.AreEqual(0.848197344d, result6);
+                Assert.AreEqual(12.574158032d, result7);
+                Assert.AreEqual(3d, result8);
+                Assert.AreEqual(9.046336342d, result9);
+                Assert.AreEqual(2.158316204d, result10);
+            }
+        }
+
+        [TestMethod]
+        public void LogestTestWithNoXs()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with no Xs and only one argument: ");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["A6"].Value = 11;
+                sheet.Cells["A7"].Value = 2;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:A7)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                Assert.AreEqual(1.134094872d, result1);
+                Assert.AreEqual(2.810925606d, result2);
+            }
+        }
+
+        [TestMethod]
+        public void LogestTestWithNoXsAndConstIsTrue()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with no Xs and const is true: ");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["A6"].Value = 11;
+                sheet.Cells["A7"].Value = 2;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:A7,,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                Assert.AreEqual(1.134094872d, result1);
+                Assert.AreEqual(2.810925606d, result2);
+            }
+        }
+
+        [TestMethod]
+        public void LogestTestWithNoXsAndConstTrueStatTrue()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with no Xs and const is true and stat is true: ");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["A6"].Value = 11;
+                sheet.Cells["A7"].Value = 2;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:A7,,TRUE,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result4 = System.Math.Round((double)sheet.Cells["B9"].Value, 9);
+                var result5 = System.Math.Round((double)sheet.Cells["A10"].Value, 9);
+                var result6 = System.Math.Round((double)sheet.Cells["B10"].Value, 9);
+                var result7 = System.Math.Round((double)sheet.Cells["A11"].Value, 9);
+                var result8 = System.Math.Round((double)sheet.Cells["B11"].Value, 0);
+                var result9 = System.Math.Round((double)sheet.Cells["A12"].Value, 9);
+                var result10 = System.Math.Round((double)sheet.Cells["B12"].Value, 9);
+                Assert.AreEqual(1.134094872d, result1);
+                Assert.AreEqual(2.810925606d, result2);
+                Assert.AreEqual(0.242692744d, result3);
+                Assert.AreEqual(0.945152447d, result4);
+                Assert.AreEqual(0.062976548d, result5);
+                Assert.AreEqual(1.015256588d, result6);
+                Assert.AreEqual(0.268836592d, result7);
+                Assert.AreEqual(4d, result8);
+                Assert.AreEqual(0.277102226d, result9);
+                Assert.AreEqual(4.122983757d, result10);
+            }
+        }
+
+        [TestMethod]
+        public void LogestTestWithNoXsAndConstFalseStatTrue()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with no Xs and const is false and stat is true: ");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["A6"].Value = 11;
+                sheet.Cells["A7"].Value = 2;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:A7,,FALSE,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 0);
+                var result3 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result4 = sheet.Cells["B9"].Value;
+                var result5 = System.Math.Round((double)sheet.Cells["A10"].Value, 9);
+                var result6 = System.Math.Round((double)sheet.Cells["B10"].Value, 9);
+                var result7 = System.Math.Round((double)sheet.Cells["A11"].Value, 8);
+                var result8 = System.Math.Round((double)sheet.Cells["B11"].Value, 0);
+                var result9 = System.Math.Round((double)sheet.Cells["A12"].Value, 8);
+                var result10 = System.Math.Round((double)sheet.Cells["B12"].Value, 9);
+                Assert.AreEqual(1.439560782d, result1);
+                Assert.AreEqual(1d, result2);
+                Assert.AreEqual(0.108490801d, result3);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result4);
+                Assert.AreEqual(0.692832622d, result5);
+                Assert.AreEqual(1.034936276d, result6);
+                Assert.AreEqual(11.27777021d, result7);
+                Assert.AreEqual(5d, result8);
+                Assert.AreEqual(12.07954182d, result9);
+                Assert.AreEqual(5.355465482d, result10);
+            }
+        }
+
+        [TestMethod]
+        public void LogestTestUnevenSizes()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test where datapoints are equal but size is not");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["B2"].Value = 0;
+                sheet.Cells["B3"].Value = 1;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["C3"].Value = 7;
+                sheet.Cells["C4"].Value = 2;
+                sheet.Cells["C5"].Value = 3;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:B3,C2:C5,FALSE,TRUE)";
+                sheet.Calculate();
+                var result1 = sheet.Cells["A8"].Value;
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Ref), result1);
+
+            }
+        }
+
+        [TestMethod]
+        public void LogestMultipleXRangesSeveralColumns()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with multiple x-ranges");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 5;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = 0;
+                sheet.Cells["B3"].Value = 4;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["C2"].Value = 6;
+                sheet.Cells["C3"].Value = 5;
+                sheet.Cells["C4"].Value = 2;
+                sheet.Cells["C5"].Value = 0;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:A5,B2:C5)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 9);
+                Assert.AreEqual(0.923986526d, result1);
+                Assert.AreEqual(1.669991606d, result2);
+                Assert.AreEqual(1.71813453d, result3);
+            }
+        }
+
+        [TestMethod]
+        public void LogestMultipleXRangesSeveralRows()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with multiple x-ranges");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["B2"].Value = 9;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["D2"].Value = 7;
+                sheet.Cells["E2"].Value = 1;
+                sheet.Cells["A3"].Value = 4;
+                sheet.Cells["B3"].Value = 2;
+                sheet.Cells["C3"].Value = 3;
+                sheet.Cells["D3"].Value = 6;
+                sheet.Cells["E3"].Value = 5;
+                sheet.Cells["A4"].Value = 2;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["C4"].Value = 8;
+                sheet.Cells["D4"].Value = 5;
+                sheet.Cells["E4"].Value = 1;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:E2,A3:E4, FALSE, TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 0);
+                var result4 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result5 = System.Math.Round((double)sheet.Cells["B9"].Value, 9);
+                var result6 = sheet.Cells["C9"].Value;
+                var result7 = System.Math.Round((double)sheet.Cells["A10"].Value, 9);
+                var result8 = System.Math.Round((double)sheet.Cells["B10"].Value, 9);
+                var result9 = sheet.Cells["C10"].Value;
+                var result10 = System.Math.Round((double)sheet.Cells["A11"].Value, 9);
+                var result11 = System.Math.Round((double)sheet.Cells["B11"].Value, 0);
+                var result12 = sheet.Cells["C11"].Value;
+                var result13 = System.Math.Round((double)sheet.Cells["A12"].Value, 9);
+                var result14 = System.Math.Round((double)sheet.Cells["B12"].Value, 9);
+                var result15 = sheet.Cells["C12"].Value;
+                Assert.AreEqual(1.284511868d, result1);
+                Assert.AreEqual(1.035289866d, result2);
+                Assert.AreEqual(1d, result3);
+                Assert.AreEqual(0.171842341d, result4);
+                Assert.AreEqual(0.179317206d, result5);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result6);
+                Assert.AreEqual(0.668015656d, result7);
+                Assert.AreEqual(1.113518331d, result8);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result9);
+                Assert.AreEqual(3.018285361d, result10);
+                Assert.AreEqual(3d, result11);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result12);
+                Assert.AreEqual(7.484883324d, result13);
+                Assert.AreEqual(3.719769221d, result14);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result15);
+            }
+        }
+
+        [TestMethod]
+        public void LogestMultipleXRangesTwoByTwo()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with multiple x-ranges");
+                sheet.Cells["A2"].Value = 9;
+                sheet.Cells["A3"].Value = 12;
+                sheet.Cells["B2"].Value = 34;
+                sheet.Cells["B3"].Value = 65;
+                sheet.Cells["C2"].Value = 8;
+                sheet.Cells["C3"].Value = 7;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:A3,B2:C3)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 0);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 9);
+                Assert.AreEqual(1d, result1);
+                Assert.AreEqual(1.00932326d, result2);
+                Assert.AreEqual(6.564670423d, result3);
+            }
+        }
+
+        [TestMethod]
+        public void LogestMultipleRegressionWithStats()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with multiple x-ranges and stats");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["B2"].Value = 9;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["D2"].Value = 7;
+                sheet.Cells["E2"].Value = 0;
+                sheet.Cells["A3"].Value = 4;
+                sheet.Cells["B3"].Value = 2;
+                sheet.Cells["C3"].Value = 3;
+                sheet.Cells["D3"].Value = 6;
+                sheet.Cells["E3"].Value = 5;
+                sheet.Cells["A4"].Value = 2;
+                sheet.Cells["B4"].Value = 2;
+                sheet.Cells["C4"].Value = 8;
+                sheet.Cells["D4"].Value = 5;
+                sheet.Cells["E4"].Value = 1;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:E2,A3:E4,TRUE,TRUE)";
+                sheet.Calculate();
+                var result1 = sheet.Cells["A8"].Value;
+                var result15 = sheet.Cells["C12"].Value;
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Num), result1);
+            }
+        }
+
+        [TestMethod]
+        public void LogestCollinearityTest()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with redundant x-sets");
+                sheet.Cells["A2"].Value = 9;
+                sheet.Cells["A3"].Value = 12;
+                sheet.Cells["B2"].Value = 34;
+                sheet.Cells["B3"].Value = 65;
+                sheet.Cells["C2"].Value = 8;
+                sheet.Cells["C3"].Value = 7;
+                sheet.Cells["D2"].Value = 15;
+                sheet.Cells["D3"].Value = 2431;
+                sheet.Cells["E2"].Value = 2534;
+                sheet.Cells["E3"].Value = 6769;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:A3,B2:E3,TRUE,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 0);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 0);
+                var result4 = System.Math.Round((double)sheet.Cells["D8"].Value, 0);
+                var result5 = System.Math.Round((double)sheet.Cells["E8"].Value, 9);
+                var result6 = System.Math.Round((double)sheet.Cells["A9"].Value, 0);
+                var result7 = System.Math.Round((double)sheet.Cells["B9"].Value, 0);
+                var result8 = System.Math.Round((double)sheet.Cells["C9"].Value, 0);
+                var result9 = System.Math.Round((double)sheet.Cells["D9"].Value, 0);
+                var result10 = System.Math.Round((double)sheet.Cells["E9"].Value, 0);
+                Assert.AreEqual(1.000067932d, result1);
+                Assert.AreEqual(1d, result2);
+                Assert.AreEqual(1d, result3);
+                Assert.AreEqual(1d, result4);
+                Assert.AreEqual(7.576799201d, result5);
+                Assert.AreEqual(0d, result6);
+                Assert.AreEqual(0d, result7);
+                Assert.AreEqual(0d, result8);
+                Assert.AreEqual(0d, result9);
+                Assert.AreEqual(0d, result10);
+            }
+        }
+
+        [TestMethod]
+        public void LinestRemovalOfRedundantVariablesTest()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with where independent values are completely dependent of one another");
+                sheet.Cells["A2"].Value = 10;
+                sheet.Cells["A3"].Value = 20;
+                sheet.Cells["A4"].Value = 30;
+                sheet.Cells["A5"].Value = 40;
+                sheet.Cells["A6"].Value = 50;
+                sheet.Cells["B2"].Value = 1;
+                sheet.Cells["B3"].Value = 4;
+                sheet.Cells["B4"].Value = 8;
+                sheet.Cells["B5"].Value = 7;
+                sheet.Cells["B6"].Value = 9;
+                sheet.Cells["C2"].Value = 11;
+                sheet.Cells["C3"].Value = 20;
+                sheet.Cells["C4"].Value = 32;
+                sheet.Cells["C5"].Value = 29;
+                sheet.Cells["C6"].Value = 35;
+                sheet.Cells["A8"].Formula = "LOGEST(A2:A6,B2:C6,TRUE,true)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 0);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 9);
+                var result4 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result5 = System.Math.Round((double)sheet.Cells["B9"].Value, 0);
+                var result6 = System.Math.Round((double)sheet.Cells["C9"].Value, 9);
+                var result7 = System.Math.Round((double)sheet.Cells["A10"].Value, 9);
+                var result8 = System.Math.Round((double)sheet.Cells["B10"].Value, 9);
+                var result9 = sheet.Cells["C10"].Value;
+                var result10 = System.Math.Round((double)sheet.Cells["A11"].Value, 8);
+                var result11 = System.Math.Round((double)sheet.Cells["B11"].Value, 0);
+                var result12 = sheet.Cells["C11"].Value;
+                var result13 = System.Math.Round((double)sheet.Cells["A12"].Value, 9);
+                var result14 = System.Math.Round((double)sheet.Cells["B12"].Value, 9);
+                var result15 = sheet.Cells["C12"].Value;
+                Assert.AreEqual(1.064146621d, result1);
+                Assert.AreEqual(1d, result2);
+                Assert.AreEqual(5.370304442d, result3);
+                Assert.AreEqual(0.010462504d, result4);
+                Assert.AreEqual(0d, result5);
+                Assert.AreEqual(0.28116703d, result6);
+                Assert.AreEqual(0.921697643d, result7);
+                Assert.AreEqual(0.205342474d, result8);
+                Assert.AreEqual(35.31302299d, result10);
+                Assert.AreEqual(3d, result11);
+                Assert.AreEqual(1.488992392d, result13);
+                Assert.AreEqual(0.126496595d, result14);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result9);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result12);
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), result15);
+            }
+        }
+
+        [TestMethod]
+        public void LogestConstFalseZerosTest()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("Const False and Collinearity test");
+                sheet.Cells["A1"].Value = 1;
+                sheet.Cells["A2"].Value = 2;
+                sheet.Cells["B1"].Value = 3;
+                sheet.Cells["B2"].Value = 4;
+                sheet.Cells["C1"].Value = 5;
+                sheet.Cells["C2"].Value = 6;
+                sheet.Cells["D1"].Value = 7;
+                sheet.Cells["D2"].Value = 8;
+                sheet.Cells["E1"].Value = 534;
+                sheet.Cells["E2"].Value = 25464;
+                sheet.Cells["D6"].Formula = "LOGEST(A1:A2, B1:E2, FALSE, FALSE)";
+                sheet.Calculate();
+
+                var result1 = System.Math.Round((double)sheet.Cells["D6"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["E6"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["F6"].Value, 0);
+                var result4 = System.Math.Round((double)sheet.Cells["G6"].Value, 0);
+                var result5 = System.Math.Round((double)sheet.Cells["H6"].Value, 0);
+                Assert.AreEqual(1.000027889d, result1);
+                Assert.AreEqual(0.997874723d, result2);
+                Assert.AreEqual(1d, result3);
+                Assert.AreEqual(1d, result4);
+                Assert.AreEqual(1d, result5);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/TrendTest.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/TrendTest.cs
@@ -365,34 +365,34 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Statistical
             }
         }
 
-        [TestMethod]
+        //[TestMethod]
 
-        public void WorkBookTest()
-        {
-            var wbPath = "C:\\Users\\HannesAlm\\Downloads\\TrendTest.xlsx";
-            using (ExcelPackage package = new ExcelPackage(new FileInfo(wbPath)))
-            {
-                ExcelWorksheet worksheet = package.Workbook.Worksheets[0];
+        //public void WorkBookTest()
+        //{
+        //    var wbPath = "C:\\Users\\HannesAlm\\Downloads\\TrendTest.xlsx";
+        //    using (ExcelPackage package = new ExcelPackage(new FileInfo(wbPath)))
+        //    {
+        //        ExcelWorksheet worksheet = package.Workbook.Worksheets[0];
 
-                worksheet.Cells["O1"].Value = "EPPLUS RESULT";
-                worksheet.Cells["O1"].Style.Font.Bold = true;
-                worksheet.Cells["O2"].Formula = "TREND(A2:A1001, B2:F1001, G2:K1001, FALSE)";
-                worksheet.Calculate();
-                for (int i = 2; i < 1002; i++ )
-                {
-                    var trendVal = (double)System.Math.Round((double)worksheet.Cells["N" + i].Value, 6);
-                    var epplusVal = (double)System.Math.Round((double)worksheet.Cells["O" + i].Value, 6);
-                    if (trendVal == epplusVal)
-                    {
-                        worksheet.Cells["P" + i].Value = "CORRECT";
-                    }
-                    else
-                    {
-                        worksheet.Cells["P" + i].Value = "INCORRECT";
-                    }
-                }
-                package.Save();
-            }
-        }
+        //        worksheet.Cells["O1"].Value = "EPPLUS RESULT";
+        //        worksheet.Cells["O1"].Style.Font.Bold = true;
+        //        worksheet.Cells["O2"].Formula = "TREND(A2:A1001, B2:F1001, G2:K1001, FALSE)";
+        //        worksheet.Calculate();
+        //        for (int i = 2; i < 1002; i++ )
+        //        {
+        //            var trendVal = (double)System.Math.Round((double)worksheet.Cells["N" + i].Value, 6);
+        //            var epplusVal = (double)System.Math.Round((double)worksheet.Cells["O" + i].Value, 6);
+        //            if (trendVal == epplusVal)
+        //            {
+        //                worksheet.Cells["P" + i].Value = "CORRECT";
+        //            }
+        //            else
+        //            {
+        //                worksheet.Cells["P" + i].Value = "INCORRECT";
+        //            }
+        //        }
+        //        package.Save();
+        //    }
+        //}
     }
 }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/TrendTest.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/TrendTest.cs
@@ -137,5 +137,30 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Statistical
                 Assert.AreEqual(3733.161974d, result4);
             }
         }
+
+        [TestMethod]
+        public void TrendTestUnevenSizes()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test where datapoints are equal but size is not");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 0;
+                sheet.Cells["A5"].Value = 1;
+                sheet.Cells["A6"].Value = 1;
+                sheet.Cells["B2"].Value = 5;
+                sheet.Cells["B3"].Value = 7;
+                sheet.Cells["C2"].Value = 2;
+                sheet.Cells["C3"].Value = 3;
+                sheet.Cells["D2"].Value = 2;
+                sheet.Cells["D3"].Value = 3;
+                sheet.Cells["A8"].Formula = "TREND(A2:A6,B2:D3,,TRUE)";
+                sheet.Calculate();
+                var result1 = sheet.Cells["A8"].Value;
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Ref), result1);
+
+            }
+        }
     }
 }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/TrendTest.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/TrendTest.cs
@@ -162,5 +162,206 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Statistical
 
             }
         }
+
+        [TestMethod]
+        public void TrendTestUnevenKnownXandNewX()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test where input ranges knownX and Uneven X have different amount of columns");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 423;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = -1;
+                sheet.Cells["B3"].Value = 1.23;
+                sheet.Cells["B4"].Value = 33;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["C3"].Value = 2;
+                sheet.Cells["C4"].Value = 6;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["D2"].Value = 1;
+                sheet.Cells["D3"].Value = 6;
+                sheet.Cells["D4"].Value = 3;
+                sheet.Cells["D5"].Value = 78;
+                sheet.Cells["E2"].Value = 5;
+                sheet.Cells["E3"].Value = 7;
+                sheet.Cells["E4"].Value = 34;
+                sheet.Cells["E5"].Value = 2;
+
+                sheet.Cells["A8"].Formula = "TREND(A2:A5, B2:C5, D2:D5)";
+                sheet.Calculate();
+                var result1 = sheet.Cells["A8"].Value;
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Ref), result1);
+
+            }
+        }
+
+        [TestMethod]
+        public void TrendTestFewerNewX()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with fewer new X observations");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 423;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = -1;
+                sheet.Cells["B3"].Value = 1.23;
+                sheet.Cells["B4"].Value = 33;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["C3"].Value = 2;
+                sheet.Cells["C4"].Value = 6;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["D2"].Value = 1;
+                sheet.Cells["D3"].Value = 6;
+                sheet.Cells["D4"].Value = 3;
+                sheet.Cells["D5"].Value = 78;
+                sheet.Cells["E2"].Value = 5;
+                sheet.Cells["E3"].Value = 7;
+                sheet.Cells["E4"].Value = 34;
+                sheet.Cells["E5"].Value = 2;
+
+                sheet.Cells["A8"].Formula = "TREND(A2:A5, B2:C5, D2:E3)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["A9"].Value, 8);
+                Assert.AreEqual(4.217695212d, result1);
+                Assert.AreEqual(62.20772199d, result2);
+
+            }
+        }
+        [TestMethod]
+        public void TrendTestMultipleRows()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with multiple rows");
+                sheet.Cells["A1"].Value = 1;
+                sheet.Cells["B1"].Value = -1;
+                sheet.Cells["C1"].Value = 5;
+                sheet.Cells["D1"].Value = 1;
+                sheet.Cells["A2"].Value = 9;
+                sheet.Cells["B2"].Value = 1.23;
+                sheet.Cells["C2"].Value = 2;
+                sheet.Cells["D2"].Value = 6;
+                sheet.Cells["A3"].Value = 423;
+                sheet.Cells["B3"].Value = 33;
+                sheet.Cells["C3"].Value = 6;
+                sheet.Cells["D3"].Value = 3;
+                sheet.Cells["A4"].Value = 7;
+                sheet.Cells["B4"].Value = 3;
+                sheet.Cells["C4"].Value = 7;
+                sheet.Cells["D4"].Value = 78;
+                sheet.Cells["A5"].Value = 1;
+                sheet.Cells["B5"].Value = 4;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["D5"].Value = 3;
+
+                sheet.Cells["A8"].Formula = "TREND(A1:D1, A2:D3, A4:D5, TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 9);
+                var result4 = System.Math.Round((double)sheet.Cells["D8"].Value, 9);
+                Assert.AreEqual(1.820558632d, result1);
+                Assert.AreEqual(1.744683966d, result2);
+                Assert.AreEqual(1.80605155d, result3);
+                Assert.AreEqual(3.033747918d, result4);
+
+            }
+        }
+
+        [TestMethod]
+        public void TrendTestCollinearRows()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with collinearity in original data-set");
+                sheet.Cells["A1"].Value = 1;
+                sheet.Cells["B1"].Value = 2;
+                sheet.Cells["C1"].Value = 3;
+                sheet.Cells["D1"].Value = 4;
+                sheet.Cells["A2"].Value = 9;
+                sheet.Cells["B2"].Value = 1.23;
+                sheet.Cells["C2"].Value = 2;
+                sheet.Cells["D2"].Value = 6;
+                sheet.Cells["A3"].Value = 5;
+                sheet.Cells["B3"].Value = 6;
+                sheet.Cells["C3"].Value = 7;
+                sheet.Cells["D3"].Value = 8;
+                sheet.Cells["A4"].Value = 7;
+                sheet.Cells["B4"].Value = 3;
+                sheet.Cells["C4"].Value = 7;
+                sheet.Cells["D4"].Value = 78;
+                sheet.Cells["A5"].Value = 1;
+                sheet.Cells["B5"].Value = 4;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["D5"].Value = 3;
+
+                sheet.Cells["A8"].Formula = "TREND(A1:D1, A2:D3, A4:D5, TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 9);
+                var result4 = System.Math.Round((double)sheet.Cells["D8"].Value, 9);
+                Assert.AreEqual(-3d, result1);
+                Assert.AreEqual(0d, result2);
+                Assert.AreEqual(3d, result3);
+                Assert.AreEqual(-1d, result4);
+
+
+            }
+        }
+
+
+        [TestMethod]
+        public void TrendTestDefaultX()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with x-values omitted");
+                sheet.Cells["A1"].Value = 232;
+                sheet.Cells["B1"].Value = 3;
+                sheet.Cells["C1"].Value = 21.121;
+                sheet.Cells["D1"].Value = 332;
+                sheet.Cells["A8"].Formula = "TREND(A1:D1)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 8);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 7);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 7);
+                var result4 = System.Math.Round((double)sheet.Cells["D8"].Value, 7);
+                Assert.AreEqual(99.3121d, result1);
+                Assert.AreEqual(131.1242d, result2);
+                Assert.AreEqual(162.9363d, result3);
+                Assert.AreEqual(194.7484d, result4);
+            }
+        }
+
+        [TestMethod]
+        public void TrendTestDefaultXCols()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with x-values omitted, column-based");
+                sheet.Cells["A1"].Value = 232;
+                sheet.Cells["A2"].Value = 3;
+                sheet.Cells["A3"].Value = 21.121;
+                sheet.Cells["A4"].Value = 332;
+                sheet.Cells["A8"].Formula = "TREND(A1:A4)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 8);
+                var result2 = System.Math.Round((double)sheet.Cells["A9"].Value, 7);
+                var result3 = System.Math.Round((double)sheet.Cells["A10"].Value, 7);
+                var result4 = System.Math.Round((double)sheet.Cells["A11"].Value, 7);
+                Assert.AreEqual(99.3121d, result1);
+                Assert.AreEqual(131.1242d, result2);
+                Assert.AreEqual(162.9363d, result3);
+                Assert.AreEqual(194.7484d, result4);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/TrendTest.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/TrendTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
+using System.IO;
 
 namespace EPPlusTest.FormulaParsing.Excel.Functions.Statistical
 {
@@ -361,6 +362,36 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.Statistical
                 Assert.AreEqual(131.1242d, result2);
                 Assert.AreEqual(162.9363d, result3);
                 Assert.AreEqual(194.7484d, result4);
+            }
+        }
+
+        [TestMethod]
+
+        public void WorkBookTest()
+        {
+            var wbPath = "C:\\Users\\HannesAlm\\Downloads\\TrendTest.xlsx";
+            using (ExcelPackage package = new ExcelPackage(new FileInfo(wbPath)))
+            {
+                ExcelWorksheet worksheet = package.Workbook.Worksheets[0];
+
+                worksheet.Cells["O1"].Value = "EPPLUS RESULT";
+                worksheet.Cells["O1"].Style.Font.Bold = true;
+                worksheet.Cells["O2"].Formula = "TREND(A2:A1001, B2:F1001, G2:K1001, FALSE)";
+                worksheet.Calculate();
+                for (int i = 2; i < 1002; i++ )
+                {
+                    var trendVal = (double)System.Math.Round((double)worksheet.Cells["N" + i].Value, 6);
+                    var epplusVal = (double)System.Math.Round((double)worksheet.Cells["O" + i].Value, 6);
+                    if (trendVal == epplusVal)
+                    {
+                        worksheet.Cells["P" + i].Value = "CORRECT";
+                    }
+                    else
+                    {
+                        worksheet.Cells["P" + i].Value = "INCORRECT";
+                    }
+                }
+                package.Save();
             }
         }
     }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/TrendTest.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/TrendTest.cs
@@ -1,0 +1,141 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+
+namespace EPPlusTest.FormulaParsing.Excel.Functions.Statistical
+{
+    [TestClass]
+    public class TrendTest : TestBase
+    {
+        [TestMethod]
+
+        public void SimpleTrendTest()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("Trend Test");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 423;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = -1;
+                sheet.Cells["B3"].Value = 1.23;
+                sheet.Cells["B4"].Value = 33;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["A8"].Formula = "TREND(A2:A5, B2:B5,,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 8);
+                var result2 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["A10"].Value, 7);
+                var result4 = System.Math.Round((double)sheet.Cells["A11"].Value, 8);
+                Assert.AreEqual(-20.27994279d, result1);
+                Assert.AreEqual(8.606388047d, result2);
+                Assert.AreEqual(420.1394512d, result3);
+                Assert.AreEqual(31.53410356d, result4);
+            }
+        }
+    
+        [TestMethod]
+
+        public void TrendWithNewX()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("Trend Test with newXs parameter");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 423;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = -1;
+                sheet.Cells["B3"].Value = 1.23;
+                sheet.Cells["B4"].Value = 33;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["C3"].Value = 2;
+                sheet.Cells["C4"].Value = 6;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["A8"].Formula = "TREND(A2:A5, B2:B5,C2:C5,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 8);
+                var result2 = System.Math.Round((double)sheet.Cells["A9"].Value, 8);
+                var result3 = System.Math.Round((double)sheet.Cells["A10"].Value, 8);
+                var result4 = System.Math.Round((double)sheet.Cells["A11"].Value, 8);
+                Assert.AreEqual(57.44112673d, result1);
+                Assert.AreEqual(18.58059197d, result2);
+                Assert.AreEqual(70.39463832d, result3);
+                Assert.AreEqual(83.34814991d, result4);
+            }
+        }
+
+        [TestMethod]
+
+        public void TrendMultipleXsConstFalse()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("Trend Test with multiple X's");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 423;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = -1;
+                sheet.Cells["B3"].Value = 1.23;
+                sheet.Cells["B4"].Value = 33;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["C3"].Value = 2;
+                sheet.Cells["C4"].Value = 6;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["A8"].Formula = "TREND(A2:A5, B2:C5,,FALSE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 8);
+                var result2 = System.Math.Round((double)sheet.Cells["A9"].Value, 8);
+                var result3 = System.Math.Round((double)sheet.Cells["A10"].Value, 7);
+                var result4 = System.Math.Round((double)sheet.Cells["A11"].Value, 8);
+                Assert.AreEqual(-23.02271398d, result1);
+                Assert.AreEqual(12.14808294d, result2);
+                Assert.AreEqual(420.4802056d, result3);
+                Assert.AreEqual(25.4194529d, result4);
+            }
+        }
+
+        [TestMethod]
+
+        public void TrendMultipleXsAndNewX()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("Trend Test with multiple X's");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 423;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = -1;
+                sheet.Cells["B3"].Value = 1.23;
+                sheet.Cells["B4"].Value = 33;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["C3"].Value = 2;
+                sheet.Cells["C4"].Value = 6;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["D2"].Value = 2.73;
+                sheet.Cells["D3"].Value = 0;
+                sheet.Cells["D4"].Value = 498;
+                sheet.Cells["D5"].Value = 284.453;
+                sheet.Cells["E2"].Value = 453;
+                sheet.Cells["E3"].Value = 1;
+                sheet.Cells["E4"].Value = 34;
+                sheet.Cells["E5"].Value = 3;
+                sheet.Cells["A8"].Formula = "TREND(A2:A5,B2:C5,D2:E5,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 6);
+                var result2 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["A10"].Value, 6);
+                var result4 = System.Math.Round((double)sheet.Cells["A11"].Value, 6);
+                Assert.AreEqual(-1687.142955d, result1);
+                Assert.AreEqual(6.393489381d, result2);
+                Assert.AreEqual(6418.090568d, result3);
+                Assert.AreEqual(3733.161974d, result4);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**TREND:**

This function takes four arguments, **knownYs**, **knownXs**, **newXs** and **const**. TREND calculates the y-values on the regression line that is fitted to **knownYs** and **knownXs**. If **newXs** is given, TREND returns the y-values corresponding to those x-values. TREND uses LINEST in order to construct the regression line and find all necessary coefficients. 

The dimensions of **newXs** have to correspond to **knownXs** in terms of variables, but can be shorter in terms of amount of observations. For example, if **knownXs** is 4 columns wide and 20 rows long, **newXs** must be 4 columns wide and between 1 - 20 rows long.

If **const** is set to _FALSE_, the regression line is forced to origo. If **knownXs** or **newXs** is omitted, they are assumed to be an array 1, 2, ..., {length of **knownYs**}. For more information on how the regression model works, see below.

**LINEST:**

Returns statistics for a straight line that best fits the inputted data. The function can also calculate the statistics for multiple linear regression when there are several independent variables in the input data (more than one column/row in **knownXs**). The inputs for LINEST are **knownYs** (required), **knownXs** (optional), **const** (optional) and **stats** (optional). **knownYs** is the y-coordinates and **knownXs** is the x-coordinates. If **knownXs** is omitted it is assumed to be 1, 2, ..., {length of **knownYs**}. **Const** is a boolean flag, and if false forces the intercept to go through origo. **Stats** determines if descriptive statistics is included (if stats = true).

The statistics calculated with LINEST are the following:

- Coefficient(s) for all independent variables. Variables deemed collinear are represented by a zero.
- Standard error for all coefficients, including the intercept. The standard error for the intercept is set to zero if const = _False_.
- R-squared (coefficient of determination). This value tells us how well the independent variables explain the dependent variable. This is calculated as the sum of squares regression divided by the sum of squares total.
- Standard error for the y-estimate.
- F-statistic. Do keep in mind that LINEST calculates the observed F-value and not an F-test.
- Degrees of Freedom.
- The sum of squares regression (ssreg).
- The residual sum of squares (ssresid).

In some cases, an independent variable can be fully explained by another independent variable. This is called collinearity and poses an issue since the parameter estimation can have infinitely many solutions and the moment matrix X'X can not be inverted due to it being singular. In this situation, LINEST removes collinear columns by transforming the moment matrix to echelon format with complete pivoting. The process of removing collinear columns affects the degrees of freedom of the regression model and some of the statistics.

**LOGEST:**

LOGEST is based on the same calculations as LINEST, including how it handles collinearity for multiple regression analysis. However, the function returns statistics to a curve that best fits the data, rather than a line. The calculations for the LOGEST coefficients are calculated as EXP(LINEST(LN(knownYs), knownXs)). It contains the same argument and outputs as LINEST.
