### PR TITLE
LoadFromCollections headers space-separate CamelCase

### DIFF
--- a/src/EPPlus/LoadFunctions/LoadFromCollection.cs
+++ b/src/EPPlus/LoadFunctions/LoadFromCollection.cs
@@ -329,7 +329,11 @@ namespace OfficeOpenXml.LoadFunctions
                             {
                                 header = epplusColumnAttribute.Header;
                             }
-                            else if(string.IsNullOrEmpty(colInfo.Header))
+                            else if(!string.IsNullOrEmpty(colInfo.Header))
+                            {
+                                header = ParseHeader(colInfo.Header);
+                            }
+                            else
                             {
                                 header = ParseHeader(member.Name);
                             }

--- a/src/EPPlus/LoadFunctions/ReflectionHelpers/MemberPath.cs
+++ b/src/EPPlus/LoadFunctions/ReflectionHelpers/MemberPath.cs
@@ -23,6 +23,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using OfficeOpenXml.LoadFunctions.Params;
+using System.Text.RegularExpressions;
 
 namespace OfficeOpenXml.LoadFunctions.ReflectionHelpers
 {

--- a/src/EPPlusTest/LoadFunctions/LoadFromCollectionTests.cs
+++ b/src/EPPlusTest/LoadFunctions/LoadFromCollectionTests.cs
@@ -126,6 +126,15 @@ namespace EPPlusTest.LoadFunctions
             public string CamelCased_And_Underscored { get; set; }
         }
 
+        [EpplusTable(ShowTotal = true)]
+        public class BaseBillingReportExportModel
+        {
+            [EpplusTableColumn(Order = 0, TotalsRowLabel = "Totals", NumberFormat = "m/d/yyyy")]
+            public DateTime RegistrationDate { get; set; }
+            [EpplusTableColumn(Order = 1)]
+            public string RegistrantName { get; set; }
+        }
+
         internal class UrlClass : BClass
         {
             [EpplusIgnore]
@@ -488,6 +497,26 @@ namespace EPPlusTest.LoadFunctions
                     c.HeaderParsingType = HeaderParsingTypes.CamelCaseToSpace;
                 });
                 Assert.AreEqual("Id Of This Instance", sheet.Cells["C1"].Value);
+            }
+        }
+
+        [TestMethod]
+        public void ShouldParseCamelCasedHeadersWhenColumned()
+        {
+            var items = new List<BaseBillingReportExportModel>()
+            {
+                new BaseBillingReportExportModel(){ RegistrantName = "someName" }
+            };
+            using (var pck = new ExcelPackage(new MemoryStream()))
+            {
+                var sheet = pck.Workbook.Worksheets.Add("sheet");
+                sheet.Cells["C1"].LoadFromCollection(items, c =>
+                {
+                    c.PrintHeaders = true;
+                    c.HeaderParsingType = HeaderParsingTypes.CamelCaseToSpace;
+                });
+                Assert.AreEqual("Registration Date", sheet.Cells["C1"].Value);
+                Assert.AreEqual("Registrant Name", sheet.Cells["D1"].Value);
             }
         }
 

--- a/src/EPPlusTest/LoadFunctions/LoadFromCollectionTests.cs
+++ b/src/EPPlusTest/LoadFunctions/LoadFromCollectionTests.cs
@@ -127,12 +127,12 @@ namespace EPPlusTest.LoadFunctions
         }
 
         [EpplusTable(ShowTotal = true)]
-        public class BaseBillingReportExportModel
+        public class CamelCasedAttributesClass
         {
-            [EpplusTableColumn(Order = 0, TotalsRowLabel = "Totals", NumberFormat = "m/d/yyyy")]
-            public DateTime RegistrationDate { get; set; }
+            [EpplusTableColumn(Order = 0, TotalsRowLabel = "DateTotal", NumberFormat = "m/d/yyyy")]
+            public DateTime DateOfPurchase { get; set; }
             [EpplusTableColumn(Order = 1)]
-            public string RegistrantName { get; set; }
+            public string BuyerName { get; set; }
         }
 
         internal class UrlClass : BClass
@@ -503,9 +503,9 @@ namespace EPPlusTest.LoadFunctions
         [TestMethod]
         public void ShouldParseCamelCasedHeadersWhenColumned()
         {
-            var items = new List<BaseBillingReportExportModel>()
+            var items = new List<CamelCasedAttributesClass>()
             {
-                new BaseBillingReportExportModel(){ RegistrantName = "someName" }
+                new CamelCasedAttributesClass(){ BuyerName = "someName" }
             };
             using (var pck = new ExcelPackage(new MemoryStream()))
             {
@@ -515,8 +515,8 @@ namespace EPPlusTest.LoadFunctions
                     c.PrintHeaders = true;
                     c.HeaderParsingType = HeaderParsingTypes.CamelCaseToSpace;
                 });
-                Assert.AreEqual("Registration Date", sheet.Cells["C1"].Value);
-                Assert.AreEqual("Registrant Name", sheet.Cells["D1"].Value);
+                Assert.AreEqual("Date Of Purchase", sheet.Cells["C1"].Value);
+                Assert.AreEqual("Buyer Name", sheet.Cells["D1"].Value);
             }
         }
 


### PR DESCRIPTION
Minor bug in LoadFromCollections caused CamelCased names with attributes not to apply proper parsing when applying HeaderParsingTypes.CamelCaseToSpace