### PR TITLE
Fix doc typo in NumFmtID in ExcelNumberFormat

### DIFF
--- a/docs/api/OfficeOpenXml.Style.ExcelNumberFormat.yml
+++ b/docs/api/OfficeOpenXml.Style.ExcelNumberFormat.yml
@@ -74,7 +74,7 @@ items:
   assemblies:
   - EPPlus
   namespace: OfficeOpenXml.Style
-  summary: "\nThe numeric index fror the format\n"
+  summary: "\nThe numeric index for the format\n"
   example: []
   syntax:
     content: public int NumFmtID { get; }

--- a/src/EPPlus/Style/ExcelNumberFormat.cs
+++ b/src/EPPlus/Style/ExcelNumberFormat.cs
@@ -33,7 +33,7 @@ namespace OfficeOpenXml.Style
             Index = index;
         }
         /// <summary>
-        /// The numeric index fror the format
+        /// The numeric index for the format
         /// </summary>
         public int NumFmtID 
         {


### PR DESCRIPTION
Before submitting this pull request I have...
- [x] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [x] ensured that the functionality I have added/changed is covered by new unit tests.
- [x] merged the target branch into the PR branch and resolved any merge conflicts
- [x] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).
