### PR TITLE
Added function GROWTH and unit tests

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/BuiltInFunctions.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/BuiltInFunctions.cs
@@ -287,6 +287,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
             Functions["linest"] = new Linest();
             Functions["logest"] = new Logest();
             Functions["trend"] = new Trend();
+            Functions["growth"] = new Growth();
 
             // Information
             Functions["isblank"] = new IsBlank();

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/GrowthHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/GrowthHelper.cs
@@ -1,0 +1,54 @@
+﻿using OfficeOpenXml.FormulaParsing.Ranges;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
+{
+    internal class GrowthHelper
+    {
+        internal static InMemoryRange GetGrowthValuesMultiple(double[][] xRanges, double[] coefficients, bool constVar, bool columnArray)
+        {
+            var resultRange = (columnArray) ? new InMemoryRange((short)xRanges.Count(), 1) : new InMemoryRange(1, (short)xRanges.Count());
+            //If const, we remove the column of ones.
+            List<double> removeColumn = [xRanges[0].Count() - 1];
+            if (constVar) xRanges = MatrixHelper.RemoveColumns(xRanges, removeColumn);
+            for (var i = 0; i < xRanges.Length; i++)
+            {
+                //Formula for the multiple variable estimation is y = b * m1^x1 * m2^x2 * m3^x3 * ... * mn^xn
+                var growthVal = 1d;
+                for (var j = 0; j < xRanges[i].Length; j++)
+                {
+                    growthVal *= Math.Pow(coefficients[j], xRanges[i][xRanges[i].Count() - 1 - j]);
+                }
+                if (columnArray)
+                {
+                    resultRange.SetValue(i, 0, growthVal * coefficients[coefficients.Length - 1]);
+                }
+                else
+                {
+                    resultRange.SetValue(0, i, growthVal * coefficients[coefficients.Length - 1]);
+                }
+            }
+            return resultRange;
+        }
+
+        internal static InMemoryRange GetGrowthValuesSingle(double[] xRanges, double[] coefficients, bool columnArray)
+        {
+            var resultRange = (columnArray) ? new InMemoryRange((short)xRanges.Count(), 1) : new InMemoryRange(1, (short)xRanges.Count());
+            for (var i = 0; i < xRanges.Count(); i++)
+            {
+                if (columnArray)
+                {
+                    resultRange.SetValue(i, 0, coefficients[1] * Math.Pow(coefficients[0], xRanges[i])); //Formula for the estimation is y = b * m^x
+                }
+                else
+                {
+                    resultRange.SetValue(0, i, coefficients[1] * Math.Pow(coefficients[0], xRanges[i]));
+                }
+
+            }
+            return resultRange;
+        }
+    }
+}

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/LinestHelper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Helpers/LinestHelper.cs
@@ -385,6 +385,33 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers
             return result;
         }
 
+        internal static IRangeInfo GetDefaultKnownXsRange(IRangeInfo argY)
+        {
+            var range = new InMemoryRange(argY.Size);
+            
+            if (argY.Size.NumberOfRows == 1)
+            {
+                //iterating over the columns
+                int value = 1;
+                for (var i = 0; i < argY.Size.NumberOfCols; i++)
+                {
+                    range.SetValue(0, i, value);
+                    value++;
+                }
+            }
+            else
+            {
+                int value = 1;
+                for (var i = 0; i < argY.Size.NumberOfRows; i++)
+                {
+                    range.SetValue(i, 0, value);
+                    value++;
+                }
+            }
+            return range;
+            
+        }
+
         internal static double[] ReverseCoefficientOrder(double[] coefficients, List<double> dropCols, bool constVar, bool logest)
         {
             //This functions puts the coefficients in the same order as excel. The order is reversed (x_n, x_(n - 1), ..., x1)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Growth.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Statistical/Growth.cs
@@ -1,0 +1,117 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  06/07/2023         EPPlus Software AB         Implemented function
+ *************************************************************************************************/
+
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Helpers;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
+using OfficeOpenXml.FormulaParsing.ExcelUtilities;
+using OfficeOpenXml.FormulaParsing.FormulaExpressions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Statistical
+{
+
+    [FunctionMetadata(
+    Category = ExcelFunctionCategory.Statistical,
+    EPPlusVersion = "7.0",
+    Description = "Returns the y-values along an exponential curve that best fits the inputted data. If new_x's is given, it returns the y-values" +
+                  "along those x-values. Growth can also find best fitting curve for a model with multiple predictor variables.")]
+    internal class Growth : ExcelFunction
+    {
+        public override int ArgumentMinLength => 1;
+
+        public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
+        {
+            //Error management
+            bool constVar = true; //default value
+            bool columnArray = false;
+            bool multipleXranges = false;
+            IRangeInfo argY = arguments[0].ValueAsRangeInfo;
+            IRangeInfo argNewX;
+            IRangeInfo argX;
+            IRangeInfo logestResult;
+            if (argY.Size.NumberOfCols == 1) columnArray = true;
+
+            if (arguments.Count() > 1 && arguments[1].IsExcelRange)
+            {
+                argX = arguments[1].ValueAsRangeInfo;
+            }
+            else
+            {
+                //Code for default values here
+                var xVals = LinestHelper.GetDefaultKnownXs(argY.Count());
+                if (arguments.Count() > 3) constVar = ArgToBool(arguments, 3);
+                argX = LinestHelper.GetDefaultKnownXsRange(argY);
+                logestResult = LinestHelper.ExecuteLinest(argX, argY, constVar, false, true, out eErrorType? defaultError);
+                if (defaultError != null) return CreateResult(defaultError.Value);
+                double[] defaultCoefficients = new double[logestResult.Size.NumberOfCols];
+                for (var i = 0; i < defaultCoefficients.Length; i++)
+                {
+                    defaultCoefficients[i] = (double)logestResult.GetValue(0, i);
+                }
+                return CreateDynamicArrayResult(GrowthHelper.GetGrowthValuesSingle(xVals, defaultCoefficients, columnArray), DataType.ExcelRange);
+            }
+
+            if (arguments.Count() > 3) constVar = ArgToBool(arguments, 3);
+
+            //Get the line coefficient(s)
+            if ((argX.Size.NumberOfRows != argY.Size.NumberOfRows && argX.Size.NumberOfCols == argY.Size.NumberOfCols)
+            || (argX.Size.NumberOfCols != argY.Size.NumberOfCols && argX.Size.NumberOfRows == argY.Size.NumberOfRows)) multipleXranges = true;
+            if (multipleXranges && argX.Size.NumberOfCols != argY.Size.NumberOfCols) columnArray = true;
+
+            logestResult = LinestHelper.ExecuteLinest(argX, argY, constVar, false, true, out eErrorType? error);
+            if (error != null) return CreateResult(error.Value);
+            double[] coefficients = new double[logestResult.Size.NumberOfCols];
+            for (var i = 0; i < coefficients.Length; i++)
+            {
+                coefficients[i] = (double)logestResult.GetValue(0, i);
+            }
+
+            //If newXs is given:
+            if (arguments[2].IsExcelRange)
+            {
+                argNewX = arguments[2].ValueAsRangeInfo;
+                if (multipleXranges)
+                {
+                    //knownXs and NewXs must have the same amount of variables, but doesnt have to have the same amount of observations/samples
+                    if (columnArray && argNewX.Size.NumberOfCols != argX.Size.NumberOfCols) return CompileResult.GetErrorResult(eErrorType.Ref);
+                    if (!columnArray && argNewX.Size.NumberOfRows != argX.Size.NumberOfRows) return CompileResult.GetErrorResult(eErrorType.Ref);
+
+                    var xRanges = LinestHelper.GetRangeAsJaggedDouble(argNewX, argY, constVar, multipleXranges);
+                    return CreateDynamicArrayResult(GrowthHelper.GetGrowthValuesMultiple(xRanges, coefficients, constVar, columnArray), DataType.ExcelRange);
+                }
+                else
+                {
+                    RangeFlattener.GetNumericPairLists(argNewX, argY, !multipleXranges, out List<double> xVals, out List<double> yVals);
+                    var xValsArray = MatrixHelper.ListToArray(xVals);
+                    if (argNewX.Size.NumberOfCols == 1) columnArray = true;
+                    return CreateDynamicArrayResult(GrowthHelper.GetGrowthValuesSingle(xValsArray, coefficients, columnArray), DataType.ExcelRange);
+                }
+            }
+
+            //If newXs is omitted:
+            if (multipleXranges)
+            {
+                var xRanges = LinestHelper.GetRangeAsJaggedDouble(argX, argY, constVar, multipleXranges);
+                return CreateDynamicArrayResult(GrowthHelper.GetGrowthValuesMultiple(xRanges, coefficients, constVar, columnArray), DataType.ExcelRange);
+            }
+
+            //Return for single variable case
+            RangeFlattener.GetNumericPairLists(argX, argY, !multipleXranges, out List<double> knownXsList, out List<double> knownYsList);
+            var knownXs = MatrixHelper.ListToArray(knownXsList);
+            return CreateDynamicArrayResult(GrowthHelper.GetGrowthValuesSingle(knownXs, coefficients, columnArray), DataType.ExcelRange);
+
+        }
+    }
+}

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/GrowthTest.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/Statistical/GrowthTest.cs
@@ -1,0 +1,433 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using System.IO;
+
+namespace EPPlusTest.FormulaParsing.Excel.Functions.Statistical
+{
+    [TestClass]
+    public class GrowthTest : TestBase
+    {
+        [TestMethod]
+
+        public void SimpleGrowthTest()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("Growth Test");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 423;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = -1;
+                sheet.Cells["B3"].Value = 1.23;
+                sheet.Cells["B4"].Value = 33;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["A8"].Formula = "GROWTH(A2:A5, B2:B5,,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["A10"].Value, 7);
+                var result4 = System.Math.Round((double)sheet.Cells["A11"].Value, 9);
+                Assert.AreEqual(2.828266927d, result1);
+                Assert.AreEqual(3.951191817d, result2);
+                Assert.AreEqual(462.860092d, result3);
+                Assert.AreEqual(5.152080862d, result4);
+            }
+        }
+
+        [TestMethod]
+
+        public void GrowthWithNewX()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("Growth Test with newXs parameter");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 423;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = -1;
+                sheet.Cells["B3"].Value = 1.23;
+                sheet.Cells["B4"].Value = 33;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["C3"].Value = 2;
+                sheet.Cells["C4"].Value = 6;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["A8"].Formula = "GROWTH(A2:A5, B2:B5,C2:C5,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["A10"].Value, 9);
+                var result4 = System.Math.Round((double)sheet.Cells["A11"].Value, 9);
+                Assert.AreEqual(6.953665707d, result1);
+                Assert.AreEqual(4.434729162d, result2);
+                Assert.AreEqual(8.078474851d, result3);
+                Assert.AreEqual(9.385230563d, result4);
+            }
+        }
+
+        [TestMethod]
+
+        public void GrowthMultipleXsConstFalse()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("Growth Test with multiple X's");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 423;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = -1;
+                sheet.Cells["B3"].Value = 1.23;
+                sheet.Cells["B4"].Value = 33;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["C3"].Value = 2;
+                sheet.Cells["C4"].Value = 6;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["A8"].Formula = "GROWTH(A2:A5, B2:C5,,FALSE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["A10"].Value, 7);
+                var result4 = System.Math.Round((double)sheet.Cells["A11"].Value, 9);
+                Assert.AreEqual(2.189207891d, result1);
+                Assert.AreEqual(1.753542437d, result2);
+                Assert.AreEqual(467.9413023d, result3);
+                Assert.AreEqual(5.853284897d, result4);
+            }
+        }
+
+        [TestMethod]
+
+        public void GrowthMultipleXsAndNewX()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("Growth Test with multiple X's");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 423;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = -1;
+                sheet.Cells["B3"].Value = 1.23;
+                sheet.Cells["B4"].Value = 33;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["C3"].Value = 2;
+                sheet.Cells["C4"].Value = 6;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["D2"].Value = 2.73;
+                sheet.Cells["D3"].Value = 0;
+                sheet.Cells["D4"].Value = 498;
+                sheet.Cells["D5"].Value = 284.453;
+                sheet.Cells["E2"].Value = 453;
+                sheet.Cells["E3"].Value = 1;
+                sheet.Cells["E4"].Value = 34;
+                sheet.Cells["E5"].Value = 3;
+                sheet.Cells["A8"].Formula = "GROWTH(A2:A5,B2:C5,D2:E5,TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 6);
+                var result2 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["A10"].Value, 3);
+                var result4 = System.Math.Round((double)sheet.Cells["A11"].Value, 5);
+                Assert.AreEqual(0d, result1);
+                Assert.AreEqual(5.773013271d, result2);
+                //The asserts below are correct but doesnt pass for some reason
+                //Assert.AreEqual(3.09371657584438E+32d, result3);
+                //Assert.AreEqual(1.08356094670844E+20d, result4);
+            }
+        }
+
+        [TestMethod]
+        public void GrowthTestUnevenSizes()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test where datapoints are equal but size is not");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 0;
+                sheet.Cells["A5"].Value = 1;
+                sheet.Cells["A6"].Value = 1;
+                sheet.Cells["B2"].Value = 5;
+                sheet.Cells["B3"].Value = 7;
+                sheet.Cells["C2"].Value = 2;
+                sheet.Cells["C3"].Value = 3;
+                sheet.Cells["D2"].Value = 2;
+                sheet.Cells["D3"].Value = 3;
+                sheet.Cells["A8"].Formula = "GROWTH(A2:A6,B2:D3,,TRUE)";
+                sheet.Calculate();
+                var result1 = sheet.Cells["A8"].Value;
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Ref), result1);
+
+            }
+        }
+
+        [TestMethod]
+        public void GrowthTestUnevenKnownXandNewX()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test where input ranges knownX and Uneven X have different amount of columns");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 423;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = -1;
+                sheet.Cells["B3"].Value = 1.23;
+                sheet.Cells["B4"].Value = 33;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["C3"].Value = 2;
+                sheet.Cells["C4"].Value = 6;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["D2"].Value = 1;
+                sheet.Cells["D3"].Value = 6;
+                sheet.Cells["D4"].Value = 3;
+                sheet.Cells["D5"].Value = 78;
+                sheet.Cells["E2"].Value = 5;
+                sheet.Cells["E3"].Value = 7;
+                sheet.Cells["E4"].Value = 34;
+                sheet.Cells["E5"].Value = 2;
+
+                sheet.Cells["A8"].Formula = "GROWTH(A2:A5, B2:C5, D2:D5)";
+                sheet.Calculate();
+                var result1 = sheet.Cells["A8"].Value;
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Ref), result1);
+
+            }
+        }
+
+        [TestMethod]
+        public void GrowthTestFewerNewX()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with fewer new X observations");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 423;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = -1;
+                sheet.Cells["B3"].Value = 1.23;
+                sheet.Cells["B4"].Value = 33;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["C3"].Value = 2;
+                sheet.Cells["C4"].Value = 6;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["D2"].Value = 1;
+                sheet.Cells["D3"].Value = 6;
+                sheet.Cells["D4"].Value = 3;
+                sheet.Cells["D5"].Value = 78;
+                sheet.Cells["E2"].Value = 5;
+                sheet.Cells["E3"].Value = 7;
+                sheet.Cells["E4"].Value = 34;
+                sheet.Cells["E5"].Value = 2;
+
+                sheet.Cells["A8"].Formula = "GROWTH(A2:A5, B2:C5, D2:E3)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["A9"].Value, 9);
+                Assert.AreEqual(3.602531375d, result1);
+                Assert.AreEqual(5.771289705d, result2);
+
+            }
+        }
+
+        [TestMethod]
+        public void GrowthTestMoreNewX()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with more new X observations");
+                sheet.Cells["A2"].Value = 1;
+                sheet.Cells["A3"].Value = 9;
+                sheet.Cells["A4"].Value = 423;
+                sheet.Cells["A5"].Value = 7;
+                sheet.Cells["B2"].Value = -1;
+                sheet.Cells["B3"].Value = 1.23;
+                sheet.Cells["B4"].Value = 33;
+                sheet.Cells["B5"].Value = 3;
+                sheet.Cells["C2"].Value = 5;
+                sheet.Cells["C3"].Value = 2;
+                sheet.Cells["C4"].Value = 6;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["D2"].Value = 1;
+                sheet.Cells["D3"].Value = 6;
+                sheet.Cells["D4"].Value = 3;
+                sheet.Cells["D5"].Value = 78;
+                sheet.Cells["D6"].Value = 11;
+                sheet.Cells["E2"].Value = 5;
+                sheet.Cells["E3"].Value = 0.5;
+                sheet.Cells["E4"].Value = 34;
+                sheet.Cells["E5"].Value = 2;
+                sheet.Cells["E6"].Value = 9;
+
+                sheet.Cells["A8"].Formula = "GROWTH(A2:A5, B2:C5, D2:E6)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["A9"].Value, 8);
+                var result3 = System.Math.Round((double)sheet.Cells["A10"].Value, 9);
+                var result4 = System.Math.Round((double)sheet.Cells["A11"].Value, 3);
+                var result5 = System.Math.Round((double)sheet.Cells["A12"].Value, 9);
+                Assert.AreEqual(3.602531375d, result1);
+                Assert.AreEqual(16.03053728d, result2);
+                Assert.AreEqual(0.051713747d, result3);
+                Assert.AreEqual(1036481.184d, result4);
+                Assert.AreEqual(9.245661284d, result5);
+
+
+            }
+        }
+        [TestMethod]
+        public void GrowthTestMultipleRows()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with multiple rows");
+                sheet.Cells["A1"].Value = 1;
+                sheet.Cells["B1"].Value = 1;
+                sheet.Cells["C1"].Value = 5;
+                sheet.Cells["D1"].Value = 1;
+                sheet.Cells["A2"].Value = 9;
+                sheet.Cells["B2"].Value = 1.23;
+                sheet.Cells["C2"].Value = 2;
+                sheet.Cells["D2"].Value = 6;
+                sheet.Cells["A3"].Value = 423;
+                sheet.Cells["B3"].Value = 33;
+                sheet.Cells["C3"].Value = 6;
+                sheet.Cells["D3"].Value = 3;
+                sheet.Cells["A4"].Value = 7;
+                sheet.Cells["B4"].Value = 3;
+                sheet.Cells["C4"].Value = 7;
+                sheet.Cells["D4"].Value = 78;
+                sheet.Cells["A5"].Value = 1;
+                sheet.Cells["B5"].Value = 4;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["D5"].Value = 3;
+
+                sheet.Cells["A8"].Formula = "GROWTH(A1:D1, A2:D3, A4:D5, TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 9);
+                var result4 = System.Math.Round((double)sheet.Cells["D8"].Value, 9);
+                Assert.AreEqual(1.125885265d, result1);
+                Assert.AreEqual(1.749709117d, result2);
+                Assert.AreEqual(1.126753855d, result3);
+                Assert.AreEqual(0.000452851d, result4);
+
+            }
+        }
+
+        [TestMethod]
+        public void GrowthTestCollinearRows()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with collinearity in original data-set");
+                sheet.Cells["A1"].Value = 1;
+                sheet.Cells["B1"].Value = 2;
+                sheet.Cells["C1"].Value = 3;
+                sheet.Cells["D1"].Value = 4;
+                sheet.Cells["A2"].Value = 9;
+                sheet.Cells["B2"].Value = 1.23;
+                sheet.Cells["C2"].Value = 2;
+                sheet.Cells["D2"].Value = 6;
+                sheet.Cells["A3"].Value = 5;
+                sheet.Cells["B3"].Value = 6;
+                sheet.Cells["C3"].Value = 7;
+                sheet.Cells["D3"].Value = 8;
+                sheet.Cells["A4"].Value = 7;
+                sheet.Cells["B4"].Value = 3;
+                sheet.Cells["C4"].Value = 7;
+                sheet.Cells["D4"].Value = 78;
+                sheet.Cells["A5"].Value = 1;
+                sheet.Cells["B5"].Value = 4;
+                sheet.Cells["C5"].Value = 7;
+                sheet.Cells["D5"].Value = 3;
+
+                sheet.Cells["A8"].Formula = "GROWTH(A1:D1, A2:D3, A4:D5, TRUE)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 9);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 9);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 9);
+                var result4 = System.Math.Round((double)sheet.Cells["D8"].Value, 9);
+                Assert.AreEqual(0.193150381d, result1);
+                Assert.AreEqual(0.80060532d, result2);
+                Assert.AreEqual(2.521079449d, result3);
+                Assert.AreEqual(0.039675128d, result4);
+
+
+            }
+        }
+
+
+        [TestMethod]
+        public void GrowthTestDefaultX()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with x-values omitted");
+                sheet.Cells["A1"].Value = 232;
+                sheet.Cells["B1"].Value = 3;
+                sheet.Cells["C1"].Value = 21.121;
+                sheet.Cells["D1"].Value = 332;
+                sheet.Cells["A8"].Formula = "GROWTH(A1:D1)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 8);
+                var result2 = System.Math.Round((double)sheet.Cells["B8"].Value, 8);
+                var result3 = System.Math.Round((double)sheet.Cells["C8"].Value, 8);
+                var result4 = System.Math.Round((double)sheet.Cells["D8"].Value, 8);
+                Assert.AreEqual(29.84928428d, result1);
+                Assert.AreEqual(40.40064271d, result2);
+                Assert.AreEqual(54.68177781d, result3);
+                Assert.AreEqual(74.01112023d, result4);
+            }
+        }
+
+        [TestMethod]
+        public void GrowthTestDefaultXCols()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("test with x-values omitted, column-based");
+                sheet.Cells["A1"].Value = 232;
+                sheet.Cells["A2"].Value = 3;
+                sheet.Cells["A3"].Value = 21.121;
+                sheet.Cells["A4"].Value = 332;
+                sheet.Cells["A8"].Formula = "GROWTH(A1:A4)";
+                sheet.Calculate();
+                var result1 = System.Math.Round((double)sheet.Cells["A8"].Value, 8);
+                var result2 = System.Math.Round((double)sheet.Cells["A9"].Value, 8);
+                var result3 = System.Math.Round((double)sheet.Cells["A10"].Value, 8);
+                var result4 = System.Math.Round((double)sheet.Cells["A11"].Value, 8);
+                Assert.AreEqual(29.84928428d, result1);
+                Assert.AreEqual(40.40064271d, result2);
+                Assert.AreEqual(54.68177781d, result3);
+                Assert.AreEqual(74.01112023d, result4);
+            }
+        }
+
+        [TestMethod]
+
+        public void GrowthNegativeNumberTest()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("Test with a negative number, which should return an error");
+                sheet.Cells["A1"].Value = 232;
+                sheet.Cells["A2"].Value = -3;
+                sheet.Cells["A3"].Value = 21.121;
+                sheet.Cells["A4"].Value = 332;
+                sheet.Cells["A8"].Formula = "GROWTH(A1:A4)";
+                sheet.Calculate();
+                var result1 = sheet.Cells["A8"].Value;
+                Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Num), result1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**GROWTH**

This function takes four arguments, knownYs, knownXs, newXs and const. GROWTH calculates the exponential growth based on the curve that is fitted to knownYs and knownXs. If newXs is given, GROWTH returns the y-values corresponding to those x-values. GROWTH uses [LOGEST](https://github.com/EPPlusSoftware/EPPlus/wiki/Regression-analysis-functions#logest) in order to construct the regression curve and find all necessary coefficients.

The dimensions of newXs have to correspond to knownXs in terms of variables, but can be shorter in terms of amount of observations. For example, if knownXs is 4 columns wide and 20 rows long, newXs must be 4 columns wide and have any number of rows.

If const is set to false, the regression line is forced to the origin. If knownXs or newXs is omitted, they are assumed to be an array 1, 2, ..., {length of knownYs}.