### PR TITLE
Fix for 1556 when loading the document from a memory stream.

### DIFF
--- a/src/EPPlus/ExcelPackage.cs
+++ b/src/EPPlus/ExcelPackage.cs
@@ -1314,7 +1314,6 @@ namespace OfficeOpenXml
                 }
                 finally
                 {
-                    ms.Dispose();
 				}
             }            
             //Clear the workbook so that it gets reinitialized next time


### PR DESCRIPTION
The zip stream was disposed before reading the document that exceeded 2GB.