### PR TITLE
Added fix for faulty read of conditionalformattings and dataValidations

### DIFF
--- a/docs/articles/fixedissues.md
+++ b/docs/articles/fixedissues.md
@@ -1,4 +1,9 @@
 # Features / Fixed issues - EPPlus 7
+## Version 7.3.1
+### Fixed issues
+* Fixed duplication of conditionalformattings which could occur on repeated saves in some cases.
+* Some ConditionalFormattings would in some cases read or write `{``}` wrong around ids/Uid. Uid property are now always held without `{``}` internally.
+
 ## Version 7.3.0
 ### Features
 * Add support for Precision As Displayed when calculating formulas, via the 'ExcelWorkbook.FullPrecision' property.

--- a/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
+++ b/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
@@ -12,7 +12,6 @@
   07/07/2023         EPPlus Software AB       Epplus 7
  *************************************************************************************************/
 using OfficeOpenXml.ConditionalFormatting.Contracts;
-using OfficeOpenXml.Drawing.Style.Fill;
 using OfficeOpenXml.Utils;
 using OfficeOpenXml.Utils.Extensions;
 using System;
@@ -21,7 +20,6 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
-using System.Net.NetworkInformation;
 using System.Xml;
 
 namespace OfficeOpenXml.ConditionalFormatting
@@ -86,7 +84,7 @@ namespace OfficeOpenXml.ConditionalFormatting
 						//If cf exists in both local and ExtLst spaces
 						if (cf.IsExtLst && cf._uid != null)
 						{
-							localAndExtDict.Add(cf._uid, cf);
+							localAndExtDict.Add(cf._uid.Trim('{','}'), cf);
 						}
 						else
 						{
@@ -121,7 +119,7 @@ namespace OfficeOpenXml.ConditionalFormatting
                     var addresslessCFs = new List<ExcelConditionalFormattingRule>();  
                     do
                     {
-                        string id = xr.GetAttribute("id");
+                        string id = xr.GetAttribute("id").Trim('{','}');
 
                         if (string.IsNullOrEmpty(id))
                         {
@@ -239,6 +237,7 @@ namespace OfficeOpenXml.ConditionalFormatting
                             }
 
                             _rules.Add(dataBar);
+                            dataBar.Uid = id;
                         }
                         else if (xr.GetAttribute("type") == "iconSet")
                         {
@@ -385,6 +384,7 @@ namespace OfficeOpenXml.ConditionalFormatting
                             }
 
                             rule.Priority = priority;
+                            rule.Uid = id;
 
                             if (iconAddress == null && rule != null)
                             {
@@ -394,6 +394,7 @@ namespace OfficeOpenXml.ConditionalFormatting
                         else
                         {
                             var cf = ExcelConditionalFormattingRuleFactory.Create(null, _ws, xr);
+                            cf.Uid = id;
                             _rules.Add(cf);
 
                             if (cf.Address == null)

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingDataBar.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingDataBar.cs
@@ -258,7 +258,7 @@ namespace OfficeOpenXml.ConditionalFormatting
 
         internal static string NewId()
         {
-            return "{" + Guid.NewGuid().ToString().ToUpperInvariant() + "}";
+            return Guid.NewGuid().ToString().ToUpperInvariant();
         }
 
         internal override ExcelConditionalFormattingRule Clone(ExcelWorksheet newWs = null)

--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingRule.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingRule.cs
@@ -197,8 +197,6 @@ namespace OfficeOpenXml.ConditionalFormatting
             {
                 _uid = value;
             }
-
-
         }
 
         bool _isExtLst = false;
@@ -254,10 +252,9 @@ namespace OfficeOpenXml.ConditionalFormatting
                 StopIfTrue = int.Parse(xr.GetAttribute("stopIfTrue")) == 1;
             }
 
-
             if (!string.IsNullOrEmpty(xr.GetAttribute("id")))
             {
-                Uid = xr.GetAttribute("id");
+                Uid = xr.GetAttribute("id").Trim('{','}');
             }
 
             if (!string.IsNullOrEmpty(xr.GetAttribute("dxfId")))

--- a/src/EPPlus/Core/Worksheet/XmlWriter/WorksheetXmlWriter.cs
+++ b/src/EPPlus/Core/Worksheet/XmlWriter/WorksheetXmlWriter.cs
@@ -10,7 +10,6 @@
  *************************************************************************************************
   02/10/2023       EPPlus Software AB       Initial release EPPlus 6.2
  *************************************************************************************************/
-using OfficeOpenXml.Compatibility;
 using OfficeOpenXml.ConditionalFormatting;
 using OfficeOpenXml.ConditionalFormatting.Rules;
 using OfficeOpenXml.Constants;
@@ -1159,7 +1158,7 @@ namespace OfficeOpenXml.Core.Worksheet.XmlWriter
                 var dataBar = (ExcelConditionalFormattingDataBar)format;
                 uid = dataBar.Uid.ToString();
 
-                cache.Append($"<{prefix}cfRule type=\"{format.Type.ToString().UnCapitalizeFirstLetter()}\" id=\"{uid}\">");
+                cache.Append($"<{prefix}cfRule type=\"{format.Type.ToString().UnCapitalizeFirstLetter()}\" id=\"{{{uid}}}\">");
 
                 cache.Append($"<{prefix}dataBar minLength=\"{dataBar.LowValue.minLength}\" ");
                 cache.Append($"maxLength=\"{dataBar.HighValue.maxLength}\"");
@@ -1330,7 +1329,7 @@ namespace OfficeOpenXml.Core.Worksheet.XmlWriter
                         throw new InvalidOperationException($"Impossible case found {format.Type} is not an iconSet");
                 }
 
-                cache.Append($"<{prefix}cfRule type=\"iconSet\" priority=\"{format.Priority}\" id=\"{uid}\">");
+                cache.Append($"<{prefix}cfRule type=\"iconSet\" priority=\"{format.Priority}\" id=\"{{{uid}}}\">");
                 cache.Append($"<{prefix}iconSet ");
 
                 if (isCustom == false)
@@ -1403,7 +1402,7 @@ namespace OfficeOpenXml.Core.Worksheet.XmlWriter
                     cache.Append($"operator=\"{format.Operator.ToEnumString()}\" ");
                 }
 
-                cache.Append($"id=\"{format.Uid}\">");
+                cache.Append($"id=\"{{{format.Uid}}}\">");
 
                 if (format.Type == eExcelConditionalFormattingRuleType.TwoColorScale ||
                     format.Type == eExcelConditionalFormattingRuleType.ThreeColorScale)
@@ -1814,7 +1813,7 @@ namespace OfficeOpenXml.Core.Worksheet.XmlWriter
 
                     string AltPrefix = "x14";
                     cache.Append($"<{prefix}ext xmlns:{AltPrefix}=\"{ExcelPackage.schemaMainX14}\" uri=\"{ExtLstUris.ExtChildUri}\">");
-                    cache.Append($"<{AltPrefix}:id>{dataBar.Uid}</{AltPrefix}:id>");
+                    cache.Append($"<{AltPrefix}:id>{{{dataBar.Uid}}}</{AltPrefix}:id>");
                     cache.Append($"</{prefix}ext>");
 
                     cache.Append($"</{prefix}extLst>");

--- a/src/EPPlus/WorksheetZipStream.cs
+++ b/src/EPPlus/WorksheetZipStream.cs
@@ -228,7 +228,7 @@ namespace OfficeOpenXml
 
             Buffer.Flush();
             var xml = _encoding.GetString(((MemoryStream)Buffer.BaseStream).ToArray());
-            int endElementIx = FindElementPos(xml, endElement, false);
+            int endElementIx = FindLastElementPos(xml, endElement, xmlPrefix, false);
 
             if (endElementIx < 0) return startXml;
             if (string.IsNullOrEmpty(readToElement))
@@ -413,6 +413,7 @@ namespace OfficeOpenXml
             }
 
             ix = xml.LastIndexOf(element, xml.Length - 1);
+            if (ix < 0) return -1;
 
             while (xml[ix - 1] == ':')
             {

--- a/src/EPPlusTest/ConditionalFormatting/CF_ColorScaleTests.cs
+++ b/src/EPPlusTest/ConditionalFormatting/CF_ColorScaleTests.cs
@@ -400,5 +400,65 @@ namespace EPPlusTest.ConditionalFormatting
                 SaveAndCleanup(p);
             }
         }
+
+        [TestMethod]
+        public void ColourScaleIdRead()
+        {
+            string id = "";
+            using (var p = OpenTemplatePackage("colourscaleIdTest.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                var format = ws.ConditionalFormatting;
+                id = format[0].Uid;
+                SaveAndCleanup(p);
+            }
+
+            using (var p = new ExcelPackage("C:\\epplusTest\\Testoutput\\colourscaleIdTest.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                var format = ws.ConditionalFormatting;
+
+                var id2 = format[0].Uid;
+                Assert.AreEqual(id, id2);
+                Assert.AreNotEqual(id2[0], '{');
+                Assert.AreNotEqual(id2[id2.Length - 1], '}');
+
+                SaveAndCleanup(p);
+            }
+        }
+
+        [TestMethod]
+        public void CF_ColourScaleIdGenerated()
+        {
+            string id = "";
+            using (var p = OpenPackage("colorScaleGenerated.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("TestIdSheet");
+                var ws2 = p.Workbook.Worksheets.Add("TestIdSheetFormulaTarget");
+
+                ws.Cells["A1:C5"].Formula = "ROW() + COLUMN()";
+                var colorScale = ws.ConditionalFormatting.AddThreeColorScale(ws.Cells["A1:C5"]);
+                colorScale.LowValue.Formula = "sheet2!A1";
+                var format = ws.ConditionalFormatting;
+
+                id = format[0].Uid;
+                Assert.AreNotEqual(id[0], '{');
+                Assert.AreNotEqual(id[id.Length - 1], '}');
+                SaveAndCleanup(p);
+            }
+
+            using (var p = new ExcelPackage("C:\\epplusTest\\Testoutput\\colorScaleGenerated.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                var format = ws.ConditionalFormatting;
+
+                var id2 = format[0].Uid;
+                Assert.AreEqual(id, id2);
+                Assert.AreNotEqual(id2[0], '{');
+                Assert.AreNotEqual(id2[id2.Length - 1], '}');
+
+                SaveAndCleanup(p);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/ConditionalFormatting/CF_DatabarTests.cs
+++ b/src/EPPlusTest/ConditionalFormatting/CF_DatabarTests.cs
@@ -454,5 +454,62 @@ namespace EPPlusTest.ConditionalFormatting
                 SaveAndCleanup(pck);
             }
         }
+        [TestMethod]
+        public void CF_DBIdTest()
+        {
+            string id = "";
+            using (var p = OpenTemplatePackage("databarIdTest.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                var format = ws.ConditionalFormatting;
+                id = format[0].Uid;
+                Assert.AreNotEqual(id[0], '{');
+                Assert.AreNotEqual(id[id.Length - 1], '}');
+                SaveAndCleanup(p);
+            }
+
+            using (var p = new ExcelPackage("C:\\epplusTest\\Testoutput\\databarIdTest.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                var format = ws.ConditionalFormatting;
+
+                var id2 = format[0].Uid;
+                Assert.AreEqual(id, id2);
+                Assert.AreNotEqual(id2[0], '{');
+                Assert.AreNotEqual(id2[id2.Length - 1], '}');
+
+                SaveAndCleanup(p);
+            }
+        }
+        [TestMethod]
+        public void CF_DBIdTestGenerated()
+        {
+            string id = "";
+            using (var p = OpenPackage("databarIdTestGenerated.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("TestIdSheet");
+                ws.Cells["A1:C5"].Formula = "ROW() + COLUMN()";
+                var dataBar = ws.ConditionalFormatting.AddDatabar(ws.Cells["A1:C5"], Color.Red);
+                var format = ws.ConditionalFormatting;
+
+                id = format[0].Uid;
+                Assert.AreNotEqual(id[0], '{');
+                Assert.AreNotEqual(id[id.Length - 1], '}');
+                SaveAndCleanup(p);
+            }
+
+            using (var p = new ExcelPackage("C:\\epplusTest\\Testoutput\\databarIdTestGenerated.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                var format = ws.ConditionalFormatting;
+
+                var id2 = format[0].Uid;
+                Assert.AreEqual(id, id2);
+                Assert.AreNotEqual(id2[0] , '{');
+                Assert.AreNotEqual(id2[id2.Length - 1], '}');
+
+                SaveAndCleanup(p);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/ConditionalFormatting/CF_ExtLstTests.cs
+++ b/src/EPPlusTest/ConditionalFormatting/CF_ExtLstTests.cs
@@ -636,5 +636,65 @@ namespace EPPlusTest.ConditionalFormatting
                 SaveAndCleanup(p);
             }
         }
+
+        [TestMethod]
+        public void CF_ExtStandardID()
+        {
+            string id = "";
+            using (var p = OpenTemplatePackage("ExtStandardIdTest.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                var format = ws.ConditionalFormatting;
+                id = format[0].Uid;
+                SaveAndCleanup(p);
+            }
+
+            using (var p = new ExcelPackage("C:\\epplusTest\\Testoutput\\ExtStandardIdTest.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                var format = ws.ConditionalFormatting;
+
+                var id2 = format[0].Uid;
+                Assert.AreEqual(id, id2);
+                Assert.AreNotEqual(id2[0], '{');
+                Assert.AreNotEqual(id2[id2.Length - 1], '}');
+
+                SaveAndCleanup(p);
+            }
+        }
+
+        [TestMethod]
+        public void CF_IconSetReadIDGenerated()
+        {
+            string id = "";
+            using (var p = OpenPackage("ExtStandardIdTestGenerated.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("TestIdSheet");
+                var ws2 = p.Workbook.Worksheets.Add("TestIdSheetFormulaTarget");
+
+                ws.Cells["A1:C5"].Formula = "ROW() + COLUMN()";
+                var greaterThan = ws.ConditionalFormatting.AddGreaterThan(ws.Cells["A1:C5"]);
+                greaterThan.Formula = "sheet2!A1";
+                var format = ws.ConditionalFormatting;
+
+                id = format[0].Uid;
+                Assert.AreNotEqual(id[0], '{');
+                Assert.AreNotEqual(id[id.Length - 1], '}');
+                SaveAndCleanup(p);
+            }
+
+            using (var p = new ExcelPackage("C:\\epplusTest\\Testoutput\\ExtStandardIdTestGenerated.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                var format = ws.ConditionalFormatting;
+
+                var id2 = format[0].Uid;
+                Assert.AreEqual(id, id2);
+                Assert.AreNotEqual(id2[0], '{');
+                Assert.AreNotEqual(id2[id2.Length - 1], '}');
+
+                SaveAndCleanup(p);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/ConditionalFormatting/CF_IconSetTests.cs
+++ b/src/EPPlusTest/ConditionalFormatting/CF_IconSetTests.cs
@@ -552,5 +552,64 @@ namespace EPPlusTest.ConditionalFormatting
                 SaveAndCleanup(package);
             }
         }
+
+        [TestMethod]
+        public void CF_IconSetReadID()
+        {
+            string id = "";
+            using (var p = OpenTemplatePackage("ExtIconsetIdTest.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                var format = ws.ConditionalFormatting;
+                id = format[0].Uid;
+                SaveAndCleanup(p);
+            }
+
+            using (var p = new ExcelPackage("C:\\epplusTest\\Testoutput\\ExtIconsetIdTest.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                var format = ws.ConditionalFormatting;
+
+                var id2 = format[0].Uid;
+                Assert.AreEqual(id, id2);
+                Assert.AreNotEqual(id2[0], '{');
+                Assert.AreNotEqual(id2[id2.Length - 1], '}');
+
+                SaveAndCleanup(p);
+            }
+        }
+
+        [TestMethod]
+        public void CF_IconSetReadIDGenerated()
+        {
+            string id = "";
+            using (var p = OpenPackage("ExtIconsetIdGenerated.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("TestIdSheet");
+                var ws2 = p.Workbook.Worksheets.Add("TestIdSheetFormulaTarget");
+
+                ws.Cells["A1:C5"].Formula = "ROW() + COLUMN()";
+                var iconSet = ws.ConditionalFormatting.AddThreeIconSet(ws.Cells["A1:C5"], eExcelconditionalFormatting3IconsSetType.Stars);
+                var format = ws.ConditionalFormatting;
+
+                id = format[0].Uid;
+                Assert.AreNotEqual(id[0], '{');
+                Assert.AreNotEqual(id[id.Length - 1], '}');
+                SaveAndCleanup(p);
+            }
+
+            using (var p = new ExcelPackage("C:\\epplusTest\\Testoutput\\ExtIconsetIdGenerated.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+                var format = ws.ConditionalFormatting;
+
+                var id2 = format[0].Uid;
+                Assert.AreEqual(id, id2);
+                Assert.AreNotEqual(id2[0], '{');
+                Assert.AreNotEqual(id2[id2.Length - 1], '}');
+
+                SaveAndCleanup(p);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/ConditionalFormatting/ConditionalFormattingTests.cs
+++ b/src/EPPlusTest/ConditionalFormatting/ConditionalFormattingTests.cs
@@ -1647,7 +1647,6 @@ namespace EPPlusTest.ConditionalFormatting
                 var sheet = pck.Workbook.Worksheets.Add("formulas");
                 var sheet2 = pck.Workbook.Worksheets.Add("formulasRef");
 
-
                 var range = new ExcelAddress("B1:B5");
 
                 var cf = sheet.ConditionalFormatting.AddBeginsWith(range);
@@ -2252,25 +2251,16 @@ namespace EPPlusTest.ConditionalFormatting
         }
 
         protected static void SaveAndCleanup(ExcelPackage pck, bool disposePackage = true)
-
         {
-
             if (pck.Workbook.Worksheets.Count > 0)
-
             {
-
                 pck.Save();
-
             }
 
             if (disposePackage)
-
             {
-
                 pck.Dispose();
-
             }
-
         }
     }
 }

--- a/src/EPPlusTest/ConditionalFormatting/ConditionalFormattingTests.cs
+++ b/src/EPPlusTest/ConditionalFormatting/ConditionalFormattingTests.cs
@@ -2210,5 +2210,67 @@ namespace EPPlusTest.ConditionalFormatting
                 SaveAndCleanup(p);
             }
         }
+
+        [TestMethod]
+        public void MultipleConditionalFormattingRangesShouldBeReadCorrectlyAfterSave()
+        {
+            using (var p1 = OpenPackage("cf_severalCFRead.xlsx", true))
+            {
+                var targetSheet = p1.Workbook.Worksheets.Add("Data Sheet");
+
+                var blanks = targetSheet.Cells["A2:A5"].ConditionalFormatting.AddContainsBlanks();
+
+                blanks.Style.Fill.PatternType = ExcelFillStyle.Solid;
+                blanks.Style.Fill.BackgroundColor.SetColor(Color.BlueViolet);
+                var aboveAverage = targetSheet.Cells["B2:B5"].ConditionalFormatting.AddAboveAverage();
+
+                aboveAverage.Style.Fill.PatternType = ExcelFillStyle.Solid;
+                aboveAverage.Style.Fill.BackgroundColor.SetColor(Color.BlueViolet);
+
+                targetSheet.InsertRow(6, 5);
+
+                Assert.AreEqual("A2:A10", targetSheet.ConditionalFormatting[0].Address.Address);
+
+                targetSheet.Cells["B2:B5"].DataValidation.AddListDataValidation();
+                targetSheet.Cells["A2:A5"].DataValidation.AddListDataValidation();
+
+                SaveAndCleanup(p1, false);
+
+                using (var p2 = new ExcelPackage(p1.Stream))
+                {
+                    var sheet = p2.Workbook.Worksheets[0];
+                    SaveWorkbook("cf_severalCFReadSave2.xlsx", p2);
+
+                    using(var p3 = new ExcelPackage(p2.Stream))
+                    {
+                        var sheet2 = p3.Workbook.Worksheets[0];
+                        Assert.AreEqual(2, sheet2.ConditionalFormatting.Count);
+                        SaveWorkbook("cf_severalCFReadSave3.xlsx", p3);
+                    }
+                }
+            }
+        }
+
+        protected static void SaveAndCleanup(ExcelPackage pck, bool disposePackage = true)
+
+        {
+
+            if (pck.Workbook.Worksheets.Count > 0)
+
+            {
+
+                pck.Save();
+
+            }
+
+            if (disposePackage)
+
+            {
+
+                pck.Dispose();
+
+            }
+
+        }
     }
 }

--- a/src/EPPlusTest/Issues/ConditionalFormattingIssues.cs
+++ b/src/EPPlusTest/Issues/ConditionalFormattingIssues.cs
@@ -32,5 +32,38 @@ namespace EPPlusTest.Issues
                 SaveAndCleanup(p);
             }
         }
+
+        /// <summary>
+        /// Saves and disposes a package
+        /// </summary>
+        /// <param name="pck"></param>
+
+        protected static void SaveAndCleanup(ExcelPackage pck, bool disposePackage = true)
+        {
+            if (pck.Workbook.Worksheets.Count > 0)
+            {
+                pck.Save();
+            }
+
+            if (disposePackage)
+            {
+                pck.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public void s725()
+        {
+            using (var p1 = OpenTemplatePackage("s725.xlsx"))
+            {
+                var sheet = p1.Workbook.Worksheets[6];
+                SaveAndCleanup(p1, false);
+                using (var p2 = new ExcelPackage(p1.Stream))
+                {
+                    var sheet2 = p2.Workbook.Worksheets[6];
+                    SaveWorkbook("s725-secondsaveorig.xlsx", p2);
+                }
+            }
+        }
     }
 }

--- a/src/EPPlusTest/Issues/LegacyTests/Issues.cs
+++ b/src/EPPlusTest/Issues/LegacyTests/Issues.cs
@@ -6226,5 +6226,30 @@ namespace EPPlusTest
                 SaveAndCleanup(package);
             }
         }
+        //[TestMethod]
+        //public void s725()
+        //{
+        //    using (var package = OpenTemplatePackage("SavedWithExcel725.xlsx"))
+        //    {
+        //        var sheet = package.Workbook.Worksheets[0];
+        //        //var cellValue = sheet.Cells["J15"];
+
+        //        //Assert.AreEqual("    10.01", cellValue.Value);
+
+        //        SaveAndCleanup(package);
+        //    }
+
+        //    using (var package2 = OpenPackage("C:\\epplusTest\\Testoutput\\SavedWithExcel725.xlsx"))
+        //    {
+        //        var wb = package2.Workbook;
+        //        var sheet = wb.Worksheets[0];
+        //        //var cellValue = sheet.Cells["J15"];
+
+        //        //Assert.AreEqual("    10.01", cellValue.Value);
+
+        //        package2.SaveAs("DoubleSave.xlsx");
+        //    }
+        //}
+
     }
 }

--- a/src/EPPlusTest/Issues/LegacyTests/Issues.cs
+++ b/src/EPPlusTest/Issues/LegacyTests/Issues.cs
@@ -6226,30 +6226,5 @@ namespace EPPlusTest
                 SaveAndCleanup(package);
             }
         }
-        //[TestMethod]
-        //public void s725()
-        //{
-        //    using (var package = OpenTemplatePackage("SavedWithExcel725.xlsx"))
-        //    {
-        //        var sheet = package.Workbook.Worksheets[0];
-        //        //var cellValue = sheet.Cells["J15"];
-
-        //        //Assert.AreEqual("    10.01", cellValue.Value);
-
-        //        SaveAndCleanup(package);
-        //    }
-
-        //    using (var package2 = OpenPackage("C:\\epplusTest\\Testoutput\\SavedWithExcel725.xlsx"))
-        //    {
-        //        var wb = package2.Workbook;
-        //        var sheet = wb.Worksheets[0];
-        //        //var cellValue = sheet.Cells["J15"];
-
-        //        //Assert.AreEqual("    10.01", cellValue.Value);
-
-        //        package2.SaveAs("DoubleSave.xlsx");
-        //    }
-        //}
-
     }
 }


### PR DESCRIPTION
Reading and writing conditionalformattings with dataValidations following them would cause repeated saving to duplicate the conditionalformattings.

Bug was created by commit 7442b72c