### PR TITLE
Fix for issue #1596

### DIFF
--- a/src/EPPlus/Drawing/Vml/ExcelVmlDrawingPosition.cs
+++ b/src/EPPlus/Drawing/Vml/ExcelVmlDrawingPosition.cs
@@ -111,7 +111,8 @@ namespace OfficeOpenXml.Drawing.Vml
                     return ret;
                 }
             }
-            throw(new Exception("Anchor element is invalid in vmlDrawing"));
+            return -1;
+            //throw(new Exception("Anchor element is invalid in vmlDrawing"));
         }
     }
 }

--- a/src/EPPlus/Drawing/Vml/ExcelVmlDrawingPosition.cs
+++ b/src/EPPlus/Drawing/Vml/ExcelVmlDrawingPosition.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   01/27/2020         EPPlus Software AB       Initial release EPPlus 5
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -94,7 +95,15 @@ namespace OfficeOpenXml.Drawing.Vml
             }
             else
             {
-                throw (new Exception("Anchor element is invalid in vmlDrawing"));
+                var size = numbers.Length;
+                Array.Resize<string>(ref numbers, 8);
+                for (int i = 0; i < 8; i++)
+                {
+                    if(string.IsNullOrEmpty(numbers[i]))
+                    {
+                        numbers[i] = "0";
+                    }
+                }
             }
             SetXmlNodeString("x:Anchor", string.Join(",",numbers));
         }
@@ -111,8 +120,7 @@ namespace OfficeOpenXml.Drawing.Vml
                     return ret;
                 }
             }
-            return -1;
-            //throw(new Exception("Anchor element is invalid in vmlDrawing"));
+            return 0;
         }
     }
 }

--- a/src/EPPlus/ExcelComment.cs
+++ b/src/EPPlus/ExcelComment.cs
@@ -142,7 +142,10 @@ namespace OfficeOpenXml
                 var cols= a._fromCol - Range._fromCol;
                 Range.Address = value;
                 _commentHelper.SetXmlNodeString("@ref", value);
-
+                
+                //The Anchor element is not mandantory, so exit if it does not exist.
+                if(GetXmlNodeString("x:ClientData/x:Anchor") == "") return;
+                
                 From.Row += rows;
                 To.Row += rows;
 

--- a/src/EPPlusTest/Issues/WorksheetIssues.cs
+++ b/src/EPPlusTest/Issues/WorksheetIssues.cs
@@ -466,6 +466,16 @@ namespace EPPlusTest.Issues
                 SaveAndCleanup(p);
             }
         }
+        [TestMethod]
+        public void I1596()
+        {
+            using (var p = OpenTemplatePackage("i1596.xlsx"))
+            {
+                ExcelWorkbook workbook = p.Workbook;
+                ExcelWorksheet worksheet = workbook.Worksheets[1];
 
+                worksheet.DeleteRow(256);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/WorkSheetTests.cs
+++ b/src/EPPlusTest/WorkSheetTests.cs
@@ -2207,5 +2207,16 @@ namespace EPPlusTest
                 SaveAndCleanup(p);
             }
         }
+        [TestMethod]
+        public void RemoveWorksheet()
+        {
+            using (var p = OpenTemplatePackage("i1596.xlsx"))
+            {
+                ExcelWorkbook workbook = p.Workbook;
+                ExcelWorksheet worksheet = workbook.Worksheets[1];
+
+                worksheet.DeleteRow(256);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/WorkSheetTests.cs
+++ b/src/EPPlusTest/WorkSheetTests.cs
@@ -1122,7 +1122,7 @@ namespace EPPlusTest
             ws.Cells["G53"].Value = new DateTime(1899, 12, 30, 3, 4, 10);
             ws.Cells["G54"].Value = new DateTime(1899, 12, 30, 4, 5, 10);
 
-            ws.Cells["G51:G55"].Style.Numberformat.Format = "HH:MM:SS";
+            ws.Cells["G51:G55"].Style.Numberformat.Format = "hh:mm:ss";
             tbl = ws.Tables.Add(ws.Cells["G50:G54"], "");
             tbl.ShowTotal = true;
             tbl.ShowFilter = false;
@@ -2205,17 +2205,6 @@ namespace EPPlusTest
                 var ws = p.Workbook.Worksheets.Add(spaceName);
                 Assert.AreEqual(" ", ws.Name);
                 SaveAndCleanup(p);
-            }
-        }
-        [TestMethod]
-        public void RemoveWorksheet()
-        {
-            using (var p = OpenTemplatePackage("i1596.xlsx"))
-            {
-                ExcelWorkbook workbook = p.Workbook;
-                ExcelWorksheet worksheet = workbook.Worksheets[1];
-
-                worksheet.DeleteRow(256);
             }
         }
     }


### PR DESCRIPTION
If a vml drawing did not have an anchor element, EPPlus throw an Exception on inserting and deleting rows / columns