### PR TITLE
Fixes issue 1655

### DIFF
--- a/src/EPPlus/Utils/ConvertUtil.cs
+++ b/src/EPPlus/Utils/ConvertUtil.cs
@@ -428,7 +428,9 @@ namespace OfficeOpenXml.Utils
             }
             for (int i = 0; i < t.Length; i++)
             {
-                if (t[i] <= 0x1f && ((t[i] != '\n' && encodeTabLF == false) || encodeTabLF)) //Not Tab, CR or LF
+                if (t[i] <= 0x1f && 
+                    ((t[i] != '\n' && t[i] != '\r' && t[i] != '\t' && encodeTabLF == false) ||  //Not Tab, CR or LF
+                    encodeTabLF)) 
                 {
                     sb.AppendFormat("_x00{0}_", (t[i] <= 0xf ? "0" : "") + ((int)t[i]).ToString("X"));
                 }

--- a/src/EPPlusTest/Issues/WorksheetIssues.cs
+++ b/src/EPPlusTest/Issues/WorksheetIssues.cs
@@ -489,5 +489,16 @@ namespace EPPlusTest.Issues
 
             }
         }
+        [TestMethod]
+        public void I1628()
+        {
+            using (var p = OpenPackage("i1628.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("Sheet1");
+                ws.Cells["A1"].Value = "A\r\n\tB";
+                SaveAndCleanup(p);
+
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix for issue #1655.
\r\n\t was converted to it's hex representation, i.e. _x000D_. Even though this works, it is not necessary.