### PR TITLE
Added AllowDuplicateColumnNames to ToDataTableOptions

### DIFF
--- a/src/EPPlus/Export/ToDataTable/DataColumnMappingCollection.cs
+++ b/src/EPPlus/Export/ToDataTable/DataColumnMappingCollection.cs
@@ -151,5 +151,19 @@ namespace OfficeOpenXml.Export.ToDataTable
         {
             return _mappingIndexes.ContainsKey(index);
         }
+
+        internal bool SetNewName(string existingName, string newName)
+        {
+            for(var i = 0; i < Count; i++)
+            {
+                var mapping = this[i];
+                if(mapping.DataColumnName == existingName)
+                {
+                    mapping.DataColumnName = newName;
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 }

--- a/src/EPPlus/Export/ToDataTable/DataTableBuilder.cs
+++ b/src/EPPlus/Export/ToDataTable/DataTableBuilder.cs
@@ -52,7 +52,8 @@ namespace OfficeOpenXml.Export.ToDataTable
                 fromCol = _range.Start.Row;
                 toCol = _range.End.Row;
             }
-            var columnNames = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+            //var columnNames = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+            var columnNames = new Dictionary<string, int>(StringComparer.InvariantCultureIgnoreCase);
             if(_dataTable == null)
             {
                 _dataTable = string.IsNullOrEmpty(_options.DataTableName) ? new DataTable() : new DataTable(_options.DataTableName);
@@ -83,11 +84,27 @@ namespace OfficeOpenXml.Export.ToDataTable
                 {
                     row--;
                 }
-                if(columnNames.Contains(name))
+                if(columnNames.ContainsKey(name) == false)
+                {
+                    columnNames[name] = 1;
+                }
+                else if(_options.AllowDuplicateColumnNames)
+                {
+                    if (columnNames[name] == 1)
+                    {
+                        var newName = $"{name}1";
+                        var prevCol = _dataTable.Columns[name];
+                        prevCol.ColumnName = newName;
+                        _options.Mappings.SetNewName(name, newName);
+                    }
+                    var colNameSuffix = columnNames[name] + 1;
+                    name = $"{name}{colNameSuffix}";
+                    columnNames[name] = colNameSuffix;
+                }
+                else
                 {
                     throw new InvalidOperationException($"Duplicate column name : {name}");
                 }
-                columnNames.Add(name);
                 // find type
                 if (_options.DataIsTransposed)
                 {

--- a/src/EPPlus/Export/ToDataTable/ToDataTableOptions.cs
+++ b/src/EPPlus/Export/ToDataTable/ToDataTableOptions.cs
@@ -145,6 +145,12 @@ namespace OfficeOpenXml.Export.ToDataTable
         public bool DataIsTransposed { get; set; }
 
         /// <summary>
+        /// If true, EPPlus will prepend duplicate column names from the exported worksheet with a number (2,3,4,..n).
+        /// If false, EPPlus will throw an <see cref="InvalidOperationException"> when processing a duplicate column name. Default value is false.
+        /// </summary>
+        public bool AllowDuplicateColumnNames { get; set; }
+
+        /// <summary>
         /// Sets the primary key of the data table. 
         /// </summary>
         /// <param name="columnNames">The name or names of one or more column in the <see cref="System.Data.DataTable"/> that constitutes the primary key</param>

--- a/src/EPPlusTest/Issues/ExportIssues.cs
+++ b/src/EPPlusTest/Issues/ExportIssues.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace EPPlusTest.Issues
+{
+    [TestClass]
+    public class ExportIssues : TestBase
+    {
+        [TestMethod, ExpectedException(typeof(InvalidOperationException))]
+        public void ToDataTableDuplicateColumnNames()
+        {
+            var package = OpenTemplatePackage("ToDataTableDuplicateColumnNames.xlsx");
+            var sheet = package.Workbook.Worksheets[0];
+            var dt = sheet.Cells["A1:C3"].ToDataTable(x =>
+            {
+                x.FirstRowIsColumnNames = true;
+            });
+        }
+
+        [TestMethod]
+        public void ToDataTableDuplicateColumnNames2()
+        {
+            var package = OpenTemplatePackage("ToDataTableDuplicateColumnNames.xlsx");
+            var sheet = package.Workbook.Worksheets[0];
+            var dt = sheet.Cells["A1:C3"].ToDataTable(x =>
+            {
+                x.AllowDuplicateColumnNames = true;
+            });
+            // rows and column count
+            Assert.AreEqual(2, dt.Rows.Count);
+            Assert.AreEqual(3, dt.Columns.Count);
+            // column names
+            Assert.AreEqual("Id", dt.Columns[0].ColumnName);
+            Assert.AreEqual("Name1", dt.Columns[1].ColumnName);
+            Assert.AreEqual("Name2", dt.Columns[2].ColumnName);
+            // row values
+            Assert.AreEqual(1d, dt.Rows[0][0]);
+            Assert.AreEqual("Name 1", dt.Rows[0][1]);
+            Assert.AreEqual("Name 2", dt.Rows[0][2]);
+        }
+    }
+}


### PR DESCRIPTION
See #1677. Added a new parameter `AllowDuplicateColumnNames` parameter to `ToDataTableOptions`.
