### PR TITLE
Bug/i1688

### DIFF
--- a/src/EPPlus/Drawing/ExcelDrawingSphereCoordinate.cs
+++ b/src/EPPlus/Drawing/ExcelDrawingSphereCoordinate.cs
@@ -43,7 +43,7 @@ namespace OfficeOpenXml.Drawing
         {
             get
             {
-                return GetXmlNodeAngel(_latPath);
+                return GetXmlNodeAngle(_latPath);
             }
             set
             {
@@ -58,7 +58,7 @@ namespace OfficeOpenXml.Drawing
         {
             get
             {
-                return GetXmlNodeAngel(_lonPath);
+                return GetXmlNodeAngle(_lonPath);
             }
             set
             {
@@ -73,7 +73,7 @@ namespace OfficeOpenXml.Drawing
         {
             get
             {
-                return GetXmlNodeAngel(_revPath);
+                return GetXmlNodeAngle(_revPath);
             }
             set
             {

--- a/src/EPPlus/Drawing/ExcelImage.cs
+++ b/src/EPPlus/Drawing/ExcelImage.cs
@@ -338,7 +338,9 @@ namespace OfficeOpenXml.Drawing
                 }
                 ImageBytes = image;
             }
-            PictureStore.SavePicture(image, _container, pictureType);
+            var picStore = _container.RelationDocument.Package.PictureStore;
+            picStore.SavePicture(image, _container, pictureType);
+            //PictureStore.SavePicture(image, _container, pictureType);
             using (var ms = RecyclableMemory.GetStream(image))
             {
                 if (_container.RelationDocument.Package.Settings.ImageSettings.GetImageBounds(ms, pictureType, out double height, out double width, out double horizontalResolution, out double verticalResolution))

--- a/src/EPPlus/Drawing/ExcelImage.cs
+++ b/src/EPPlus/Drawing/ExcelImage.cs
@@ -338,9 +338,9 @@ namespace OfficeOpenXml.Drawing
                 }
                 ImageBytes = image;
             }
-            var picStore = _container.RelationDocument.Package.PictureStore;
-            picStore.SavePicture(image, _container, pictureType);
-            //PictureStore.SavePicture(image, _container, pictureType);
+
+            PictureStore.SavePicture(image, _container, pictureType);
+
             using (var ms = RecyclableMemory.GetStream(image))
             {
                 if (_container.RelationDocument.Package.Settings.ImageSettings.GetImageBounds(ms, pictureType, out double height, out double width, out double horizontalResolution, out double verticalResolution))

--- a/src/EPPlus/Drawing/ExcelPicture.cs
+++ b/src/EPPlus/Drawing/ExcelPicture.cs
@@ -21,6 +21,8 @@ using OfficeOpenXml.Packaging;
 using System.Linq;
 using System.Globalization;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
+using System.ComponentModel;
+
 
 
 #if NETFULL
@@ -251,7 +253,11 @@ namespace OfficeOpenXml.Drawing
                 var rel = _drawings.Part.GetRelationship(relId);
                 container.UriPic = UriHelper.ResolvePartUri(rel.SourceUri, rel.TargetUri);
             }
+
+            pc.Hashes[ii.Hash].RefCount++;
+
             container.ImageHash = ii.Hash;
+
             using (var ms = RecyclableMemory.GetStream(img))
             {
                 Image.ImageBytes = img;
@@ -492,7 +498,10 @@ namespace OfficeOpenXml.Drawing
                 if (hi.RefCount <= 1)
                 {
                     relDoc.Package.PictureStore.RemoveImage(container.ImageHash, this);
-                    relDoc.RelatedPart.DeleteRelationship(container.RelPic.Id);
+                    if(container.RelPic != null)
+                    {
+                        relDoc.RelatedPart.DeleteRelationship(container.RelPic.Id);
+                    }
                     relDoc.Hashes.Remove(container.ImageHash);
                 }
                 else
@@ -519,6 +528,16 @@ namespace OfficeOpenXml.Drawing
                 else
                 {
                     node.Value = relId;
+                }
+            }
+
+            if (_drawings.Part.RelationshipExists(relId))
+            {
+                IPictureContainer container = this;
+                var thePart = _drawings.Part.Package.GetPart(container.UriPic);
+                if (Part != thePart)
+                {
+                    Part = thePart;
                 }
             }
         }

--- a/src/EPPlus/Drawing/ExcelPicture.cs
+++ b/src/EPPlus/Drawing/ExcelPicture.cs
@@ -20,6 +20,8 @@ using OfficeOpenXml.Drawing.Style.Effect;
 using OfficeOpenXml.Packaging;
 using System.Linq;
 using System.Globalization;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
+
 
 #if NETFULL
 using System.Drawing.Imaging;
@@ -339,6 +341,11 @@ namespace OfficeOpenXml.Drawing
             return xml.ToString();
         }
 
+        //private void AddSvgXml(string attribute)
+        //{
+        //    xml.Append($"<a:blip xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" r:{attribute}=\"\" cstate=\"print\"><a:extLst><a:ext uri=\"{{28A0092B-C50C-407E-A947-70E740481C1C}}\"><a14:useLocalDpi xmlns:a14=\"http://schemas.microsoft.com/office/drawing/2010/main\" val=\"0\"/></a:ext><a:ext uri=\"{{96DAC541-7B7A-43D3-8B79-37D633B846F1}}\"><asvg:svgBlip xmlns:asvg=\"http://schemas.microsoft.com/office/drawing/2016/SVG/main\" r:{attribute}=\"\"/></a:ext></a:extLst></a:blip>");
+        //}
+
         /// <summary>
         /// The image
         /// </summary>
@@ -503,10 +510,21 @@ namespace OfficeOpenXml.Drawing
         void IPictureContainer.SetNewImage()
         {
             var relId = ((IPictureContainer)this).RelPic.Id;
-            TopNode.SelectSingleNode($"{_topPath}xdr:blipFill/a:blip/@r:embed", NameSpaceManager).Value = relId;
+            var picNode = (XmlElement)TopNode.SelectSingleNode($"{_topPath}xdr:blipFill/a:blip", NameSpaceManager);
+            picNode.SetAttribute("r:embed", relId);
             if (Image.Type == ePictureType.Svg)
             {
-                TopNode.SelectSingleNode($"{_topPath}xdr:blipFill/a:blip/a:extLst/a:ext/asvg:svgBlip/@r:embed", NameSpaceManager).Value = relId;
+                var node = TopNode.SelectSingleNode($"{_topPath}xdr:blipFill/a:blip/a:extLst/a:ext/asvg:svgBlip/@r:embed", NameSpaceManager);
+                if(node == null)
+                {
+                    var newNode = TopNode.OwnerDocument.CreateElement("extLst", "28A0092B-C50C-407E-A947-70E740481C1C");
+                    picNode.AppendChild(newNode);
+                    newNode.InnerXml = $"<a:ext uri=\"{{28A0092B-C50C-407E-A947-70E740481C1C}}\"><a14:useLocalDpi xmlns:a14=\"http://schemas.microsoft.com/office/drawing/2010/main\" val=\"0\"/></a:ext><a:ext uri=\"{{96DAC541-7B7A-43D3-8B79-37D633B846F1}}\"><asvg:svgBlip xmlns:asvg=\"http://schemas.microsoft.com/office/drawing/2016/SVG/main\" r:embed=\"{relId}\"/></a:ext>";
+                }
+                else
+                {
+                    node.Value = relId;
+                }
             }
         }
 
@@ -523,7 +541,7 @@ namespace OfficeOpenXml.Drawing
 		{
 			get
 			{
-				return GetXmlNodeAngel(_rotationPath);
+				return GetXmlNodeAngle(_rotationPath);
 			}
 			set
 			{

--- a/src/EPPlus/Drawing/ExcelPicture.cs
+++ b/src/EPPlus/Drawing/ExcelPicture.cs
@@ -341,11 +341,6 @@ namespace OfficeOpenXml.Drawing
             return xml.ToString();
         }
 
-        //private void AddSvgXml(string attribute)
-        //{
-        //    xml.Append($"<a:blip xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" r:{attribute}=\"\" cstate=\"print\"><a:extLst><a:ext uri=\"{{28A0092B-C50C-407E-A947-70E740481C1C}}\"><a14:useLocalDpi xmlns:a14=\"http://schemas.microsoft.com/office/drawing/2010/main\" val=\"0\"/></a:ext><a:ext uri=\"{{96DAC541-7B7A-43D3-8B79-37D633B846F1}}\"><asvg:svgBlip xmlns:asvg=\"http://schemas.microsoft.com/office/drawing/2016/SVG/main\" r:{attribute}=\"\"/></a:ext></a:extLst></a:blip>");
-        //}
-
         /// <summary>
         /// The image
         /// </summary>

--- a/src/EPPlus/Drawing/ExcelPicture.cs
+++ b/src/EPPlus/Drawing/ExcelPicture.cs
@@ -533,8 +533,8 @@ namespace OfficeOpenXml.Drawing
 
             if (_drawings.Part.RelationshipExists(relId))
             {
-                IPictureContainer container = this;
-                var thePart = _drawings.Part.Package.GetPart(container.UriPic);
+                IPictureContainer thisPicture = this;
+                var thePart = _drawings.Part.Package.GetPart(thisPicture.UriPic);
                 if (Part != thePart)
                 {
                     Part = thePart;

--- a/src/EPPlus/Drawing/ExcelShapeBase.cs
+++ b/src/EPPlus/Drawing/ExcelShapeBase.cs
@@ -395,7 +395,7 @@ namespace OfficeOpenXml.Drawing
         {
             get
             {
-                return GetXmlNodeAngel(_rotationPath);
+                return GetXmlNodeAngle(_rotationPath);
             }
             set
             {

--- a/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
+++ b/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
@@ -395,6 +395,7 @@ namespace OfficeOpenXml.Drawing
             if (hashes.ContainsKey(ii.Hash))
             {
                 var relID = hashes[ii.Hash].RelId;
+                hashes[ii.Hash].RefCount++;
                 container.RelPic = container.RelationDocument.RelatedPart.GetRelationship(relID);
                 container.UriPic = UriHelper.ResolvePartUri(container.RelPic.SourceUri, container.RelPic.TargetUri);
                 return relID;

--- a/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
+++ b/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
@@ -386,7 +386,40 @@ namespace OfficeOpenXml.Drawing
                     return "image/jpeg";
             }
         }
-        internal static string SavePicture(byte[] image, IPictureContainer container, ePictureType type)
+        //internal static string SavePicture(byte[] image, IPictureContainer container, ePictureType type)
+        //{
+        //    var store = container.RelationDocument.Package.PictureStore;
+        //    var ii = store.AddImage(image, container.UriPic, type);
+
+        //    container.ImageHash = ii.Hash;
+        //    var hashes = container.RelationDocument.Hashes;
+        //    if (hashes.ContainsKey(ii.Hash))
+        //    {
+        //        var relID = hashes[ii.Hash].RelId;
+        //        hashes[ii.Hash].RefCount++;
+
+        //        Console.WriteLine($"SavePicture. RelId:{relID}, HashRefCount: {hashes[ii.Hash].RefCount}");
+
+        //        container.RelPic = container.RelationDocument.RelatedPart.GetRelationship(relID);
+        //        container.UriPic = UriHelper.ResolvePartUri(container.RelPic.SourceUri, container.RelPic.TargetUri);
+        //        return relID;
+        //    }
+        //    else
+        //    {
+        //        container.UriPic = ii.Uri;
+        //        container.ImageHash = ii.Hash;
+        //    }
+
+        //    //Set the Image and save it to the package.
+        //    container.RelPic = container.RelationDocument.RelatedPart.CreateRelationship(UriHelper.GetRelativeUri(container.RelationDocument.RelatedUri, container.UriPic), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/image");
+
+        //    //AddNewPicture(img, picRelation.Id);
+        //    hashes.Add(ii.Hash, new HashInfo(container.RelPic.Id) { RefCount = 1});
+
+        //    return container.RelPic.Id;
+        //}
+
+        internal string SavePicture(byte[] image, IPictureContainer container, ePictureType type)
         {
             var store = container.RelationDocument.Package.PictureStore;
             var ii = store.AddImage(image, container.UriPic, type);
@@ -414,7 +447,7 @@ namespace OfficeOpenXml.Drawing
             container.RelPic = container.RelationDocument.RelatedPart.CreateRelationship(UriHelper.GetRelativeUri(container.RelationDocument.RelatedUri, container.UriPic), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/image");
 
             //AddNewPicture(img, picRelation.Id);
-            hashes.Add(ii.Hash, new HashInfo(container.RelPic.Id) { RefCount = 1});
+            hashes.Add(ii.Hash, new HashInfo(container.RelPic.Id) { RefCount = 1 });
 
             return container.RelPic.Id;
         }

--- a/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
+++ b/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
@@ -34,7 +34,7 @@ namespace OfficeOpenXml.Drawing
     internal class PictureStore : IDisposable
     {
         ExcelPackage _pck;
-        internal static int _id = 1;
+        internal int _id = 1;
         internal Dictionary<string, ImageInfo> _images;
         public PictureStore(ExcelPackage pck)
         {
@@ -391,7 +391,7 @@ namespace OfficeOpenXml.Drawing
         {
             var store = container.RelationDocument.Package.PictureStore;
 
-            Console.WriteLine("SavePicture ContainerPictureStore" + container.RelationDocument.Package.File.FullName);
+            Console.WriteLine("SavePicture ContainerPictureStore " + container.RelationDocument.Package.File.FullName);
 
             var ii = store.AddImage(image, container.UriPic, type);
 

--- a/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
+++ b/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
@@ -396,6 +396,9 @@ namespace OfficeOpenXml.Drawing
             {
                 var relID = hashes[ii.Hash].RelId;
                 hashes[ii.Hash].RefCount++;
+
+                Console.WriteLine($"SavePicture. RelId:{relID}, HashRefCount: {hashes[ii.Hash].RefCount}");
+
                 container.RelPic = container.RelationDocument.RelatedPart.GetRelationship(relID);
                 container.UriPic = UriHelper.ResolvePartUri(container.RelPic.SourceUri, container.RelPic.TargetUri);
                 return relID;

--- a/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
+++ b/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
@@ -221,6 +221,7 @@ namespace OfficeOpenXml.Drawing
             do
             {
                 uri = new Uri(string.Format(sUri, _id++), UriKind.Relative);
+                Console.WriteLine($"Get new Uri other: {uri.OriginalString}");
             }
             while (package.PartExists(uri));
             return uri;

--- a/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
+++ b/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
@@ -20,6 +20,7 @@ using System.IO;
 using System.Security.Cryptography;
 using OfficeOpenXml.Packaging;
 using System.Linq;
+using System.Runtime.CompilerServices;
 namespace OfficeOpenXml.Drawing
 {
     internal class ImageInfo
@@ -386,42 +387,12 @@ namespace OfficeOpenXml.Drawing
                     return "image/jpeg";
             }
         }
-        //internal static string SavePicture(byte[] image, IPictureContainer container, ePictureType type)
-        //{
-        //    var store = container.RelationDocument.Package.PictureStore;
-        //    var ii = store.AddImage(image, container.UriPic, type);
-
-        //    container.ImageHash = ii.Hash;
-        //    var hashes = container.RelationDocument.Hashes;
-        //    if (hashes.ContainsKey(ii.Hash))
-        //    {
-        //        var relID = hashes[ii.Hash].RelId;
-        //        hashes[ii.Hash].RefCount++;
-
-        //        Console.WriteLine($"SavePicture. RelId:{relID}, HashRefCount: {hashes[ii.Hash].RefCount}");
-
-        //        container.RelPic = container.RelationDocument.RelatedPart.GetRelationship(relID);
-        //        container.UriPic = UriHelper.ResolvePartUri(container.RelPic.SourceUri, container.RelPic.TargetUri);
-        //        return relID;
-        //    }
-        //    else
-        //    {
-        //        container.UriPic = ii.Uri;
-        //        container.ImageHash = ii.Hash;
-        //    }
-
-        //    //Set the Image and save it to the package.
-        //    container.RelPic = container.RelationDocument.RelatedPart.CreateRelationship(UriHelper.GetRelativeUri(container.RelationDocument.RelatedUri, container.UriPic), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/image");
-
-        //    //AddNewPicture(img, picRelation.Id);
-        //    hashes.Add(ii.Hash, new HashInfo(container.RelPic.Id) { RefCount = 1});
-
-        //    return container.RelPic.Id;
-        //}
-
-        internal string SavePicture(byte[] image, IPictureContainer container, ePictureType type)
+        internal static string SavePicture(byte[] image, IPictureContainer container, ePictureType type)
         {
             var store = container.RelationDocument.Package.PictureStore;
+
+            Console.WriteLine("SavePicture ContainerPictureStore" + container.RelationDocument.Package.File.FullName);
+
             var ii = store.AddImage(image, container.UriPic, type);
 
             container.ImageHash = ii.Hash;
@@ -430,8 +401,6 @@ namespace OfficeOpenXml.Drawing
             {
                 var relID = hashes[ii.Hash].RelId;
                 hashes[ii.Hash].RefCount++;
-
-                Console.WriteLine($"SavePicture. RelId:{relID}, HashRefCount: {hashes[ii.Hash].RefCount}");
 
                 container.RelPic = container.RelationDocument.RelatedPart.GetRelationship(relID);
                 container.UriPic = UriHelper.ResolvePartUri(container.RelPic.SourceUri, container.RelPic.TargetUri);
@@ -447,7 +416,7 @@ namespace OfficeOpenXml.Drawing
             container.RelPic = container.RelationDocument.RelatedPart.CreateRelationship(UriHelper.GetRelativeUri(container.RelationDocument.RelatedUri, container.UriPic), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/image");
 
             //AddNewPicture(img, picRelation.Id);
-            hashes.Add(ii.Hash, new HashInfo(container.RelPic.Id) { RefCount = 1 });
+            hashes.Add(ii.Hash, new HashInfo(container.RelPic.Id) { RefCount = 1});
 
             return container.RelPic.Id;
         }

--- a/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
+++ b/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
@@ -222,7 +222,6 @@ namespace OfficeOpenXml.Drawing
             do
             {
                 uri = new Uri(string.Format(sUri, _id++), UriKind.Relative);
-                Console.WriteLine($"Get new Uri other: {uri.OriginalString}");
             }
             while (package.PartExists(uri));
             return uri;
@@ -390,8 +389,6 @@ namespace OfficeOpenXml.Drawing
         internal static string SavePicture(byte[] image, IPictureContainer container, ePictureType type)
         {
             var store = container.RelationDocument.Package.PictureStore;
-
-            Console.WriteLine("SavePicture ContainerPictureStore " + container.RelationDocument.Package.File.FullName);
 
             var ii = store.AddImage(image, container.UriPic, type);
 

--- a/src/EPPlus/Drawing/Style/Coloring/ExcelColorTransformItem.cs
+++ b/src/EPPlus/Drawing/Style/Coloring/ExcelColorTransformItem.cs
@@ -85,7 +85,7 @@ namespace OfficeOpenXml.Drawing.Style.Coloring
                         return GetXmlNodePercentage("@val") ?? 0;
                     case eColorTransformDataType.Angle:
                     case eColorTransformDataType.FixedAngle90:
-                        return GetXmlNodeAngel("@val");
+                        return GetXmlNodeAngle("@val");
                     default:
                         return 1; //Boolean
                 }

--- a/src/EPPlus/Drawing/Style/Coloring/ExcelDrawingHslColor.cs
+++ b/src/EPPlus/Drawing/Style/Coloring/ExcelDrawingHslColor.cs
@@ -34,7 +34,7 @@ namespace OfficeOpenXml.Drawing.Style.Coloring
         {
             get
             {
-                return GetXmlNodeAngel("@hue");
+                return GetXmlNodeAngle("@hue");
             }
             set
             {

--- a/src/EPPlus/Drawing/Style/Effect/ExcelDrawingOuterShadowEffect.cs
+++ b/src/EPPlus/Drawing/Style/Effect/ExcelDrawingOuterShadowEffect.cs
@@ -79,7 +79,7 @@ namespace OfficeOpenXml.Drawing.Style.Effect
         {
             get
             {
-                return  GetXmlNodeAngel(_horizontalSkewAnglePath);
+                return  GetXmlNodeAngle(_horizontalSkewAnglePath);
             }
             set
             {
@@ -94,7 +94,7 @@ namespace OfficeOpenXml.Drawing.Style.Effect
         {
             get
             {
-                return GetXmlNodeAngel(_verticalSkewAnglePath);
+                return GetXmlNodeAngle(_verticalSkewAnglePath);
             }
             set
             {

--- a/src/EPPlus/Drawing/Style/Effect/ExcelDrawingReflectionEffect.cs
+++ b/src/EPPlus/Drawing/Style/Effect/ExcelDrawingReflectionEffect.cs
@@ -115,7 +115,7 @@ namespace OfficeOpenXml.Drawing.Style.Effect
         {
             get
             {
-                return GetXmlNodeAngel(_fadeDirectionPath, 90);
+                return GetXmlNodeAngle(_fadeDirectionPath, 90);
             }
             set
             {
@@ -165,7 +165,7 @@ namespace OfficeOpenXml.Drawing.Style.Effect
         {
             get
             {
-                return GetXmlNodeAngel(_horizontalSkewAnglePath);
+                return GetXmlNodeAngle(_horizontalSkewAnglePath);
             }
             set
             {
@@ -180,7 +180,7 @@ namespace OfficeOpenXml.Drawing.Style.Effect
         {
             get
             {
-                return GetXmlNodeAngel(_verticalSkewAnglePath);
+                return GetXmlNodeAngle(_verticalSkewAnglePath);
             }
             set
             {
@@ -224,7 +224,7 @@ namespace OfficeOpenXml.Drawing.Style.Effect
         {
             get
             {
-                return GetXmlNodeAngel(_directionPath);
+                return GetXmlNodeAngle(_directionPath);
             }
             set
             {

--- a/src/EPPlus/Drawing/Style/Effect/ExcelDrawingShadowEffect.cs
+++ b/src/EPPlus/Drawing/Style/Effect/ExcelDrawingShadowEffect.cs
@@ -50,7 +50,7 @@ namespace OfficeOpenXml.Drawing.Style.Effect
         {
             get
             {
-                return GetXmlNodeAngel(_directionPath);
+                return GetXmlNodeAngle(_directionPath);
             }
             set
             {

--- a/src/EPPlus/Drawing/Style/Fill/ExcelDrawingGradientFillLinearSettings.cs
+++ b/src/EPPlus/Drawing/Style/Fill/ExcelDrawingGradientFillLinearSettings.cs
@@ -23,7 +23,7 @@ namespace OfficeOpenXml.Drawing.Style.Fill
         }
         internal ExcelDrawingGradientFillLinearSettings(XmlHelper xml)
         {
-            Angel = xml.GetXmlNodeAngel("a:lin/@ang");
+            Angel = xml.GetXmlNodeAngle("a:lin/@ang");
             Scaled = xml.GetXmlNodeBool("a:lin/@scaled", false);
         }
 

--- a/src/EPPlus/Drawing/Style/Text/ExcelTextBody.cs
+++ b/src/EPPlus/Drawing/Style/Text/ExcelTextBody.cs
@@ -150,7 +150,7 @@ namespace OfficeOpenXml.Drawing
         {
             get
             {
-                return GetXmlNodeAngel($"{_path}/@rot");
+                return GetXmlNodeAngle($"{_path}/@rot");
             }
             set
             {

--- a/src/EPPlus/Drawing/Style/ThreeD/ExcelDrawingScene3DCamera.cs
+++ b/src/EPPlus/Drawing/Style/ThreeD/ExcelDrawingScene3DCamera.cs
@@ -66,7 +66,7 @@ namespace OfficeOpenXml.Drawing.Style.ThreeD
         {
             get
             {
-                return GetXmlNodeAngel(_fieldOfViewAnglePath, 0);
+                return GetXmlNodeAngle(_fieldOfViewAnglePath, 0);
             }
             set
             {

--- a/src/EPPlus/XmlHelper.cs
+++ b/src/EPPlus/XmlHelper.cs
@@ -1041,7 +1041,7 @@ namespace OfficeOpenXml
                 return defaultValue;
             }
         }
-        internal double GetXmlNodeAngel(string path, double defaultValue = 0)
+        internal double GetXmlNodeAngle(string path, double defaultValue = 0)
         {
             int a = GetXmlNodeInt(path);
             if (a < 0) return defaultValue;

--- a/src/EPPlus/XmlHelper.cs
+++ b/src/EPPlus/XmlHelper.cs
@@ -1223,8 +1223,6 @@ namespace OfficeOpenXml
             Uri uri = new Uri(string.Format(sUri, id), UriKind.Relative);
             while (package.PartExists(uri))
             {
-                Console.WriteLine($"PartExists with uri:{uri}");
-
                 uri = new Uri(string.Format(sUri, ++id), UriKind.Relative);
             }
             return uri;

--- a/src/EPPlus/XmlHelper.cs
+++ b/src/EPPlus/XmlHelper.cs
@@ -1223,6 +1223,8 @@ namespace OfficeOpenXml
             Uri uri = new Uri(string.Format(sUri, id), UriKind.Relative);
             while (package.PartExists(uri))
             {
+                Console.WriteLine($"PartExists with uri:{uri}");
+
                 uri = new Uri(string.Format(sUri, ++id), UriKind.Relative);
             }
             return uri;

--- a/src/EPPlusTest/Drawing/PictureTests.cs
+++ b/src/EPPlusTest/Drawing/PictureTests.cs
@@ -1,13 +1,9 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
 using OfficeOpenXml.Drawing;
+using OfficeOpenXml.Utils;
 using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace EPPlusTest.Drawing
@@ -247,6 +243,63 @@ namespace EPPlusTest.Drawing
 
                 var pic = ws.Drawings.AddPicture("mypic", GetResourceFile("EPPlus.png"));
                 pic.Image.SetImage(GetResourceFile("car-silhouette-color-low-poly.svg"));
+
+                SaveAndCleanup(package);
+            }
+        }
+
+
+		[TestMethod]
+		public void SwitchFromSvgToPng()
+		{
+			using (ExcelPackage package = OpenPackage("SvgToPng.xlsx", true))
+			{
+				var wb = package.Workbook;
+				var ws = wb.Worksheets.Add("NewSheet");
+
+				var originalSvg = ws.Drawings.AddPicture("svgOrig", GetResourceFile("car-silhouette-color-low-poly.svg"));
+				originalSvg.Image.SetImage(GetResourceFile("EPPlus.png"));
+
+				Assert.IsTrue(ws.Drawings.Part.RelationshipExists("rId1"));
+				var rel = ws.Drawings.Part.GetRelationship("rId1");
+
+				var relUri = UriHelper.ResolvePartUri(originalSvg.Part.Uri, rel.TargetUri);
+
+                Assert.AreEqual(originalSvg.Part.Uri, relUri);
+                Assert.AreEqual("../media/image1.png", rel.TargetUri.OriginalString);
+
+                SaveAndCleanup(package);
+            }
+		}
+
+        [TestMethod]
+        public void SwitchingFromPictureReferencedByOtherPicture()
+        {
+            using (ExcelPackage package = OpenPackage("PicturesMultipleReferences.xlsx", true))
+            {
+                var wb = package.Workbook;
+                var ws = wb.Worksheets.Add("NewSheet");
+
+				var originalSvg = ws.Drawings.AddPicture("svgOrig", GetResourceFile("car-silhouette-color-low-poly.svg"));
+
+				originalSvg.SetPosition(10, 200);
+
+                var originalPng = ws.Drawings.AddPicture("otherpic", GetResourceFile("EPPlus.png"));
+
+				originalPng.SetPosition(10, 400);
+
+                var SwitchedPicture = ws.Drawings.AddPicture("mypic", GetResourceFile("EPPlus.png"));
+
+                SwitchedPicture.Image.SetImage(GetResourceFile("car-silhouette-color-low-poly.svg"));
+                SwitchedPicture.Image.SetImage(GetResourceFile("EPPlus.png"));
+
+				Assert.IsTrue(ws.Drawings.Part.RelationshipExists("rId1"));
+				var rel = ws.Drawings.Part.GetRelationship("rId1");
+                Assert.AreEqual("../media/image1.Svg", rel.TargetUri.OriginalString);
+
+                Assert.AreEqual(SwitchedPicture.Part.Uri, originalPng.Part.Uri);
+                var rel2 = ws.Drawings.Part.GetRelationship("rId2");
+                Assert.AreEqual("../media/image1.Png", rel2.TargetUri.OriginalString);
 
                 SaveAndCleanup(package);
             }

--- a/src/EPPlusTest/Drawing/PictureTests.cs
+++ b/src/EPPlusTest/Drawing/PictureTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using System.Linq;
+using OfficeOpenXml.Drawing.Interfaces;
 
 namespace EPPlusTest.Drawing
 {
@@ -251,10 +252,16 @@ namespace EPPlusTest.Drawing
 
 
 		[TestMethod]
-		public void SwitchFromSvgToPng()
+		public void ZZZZZZZSwitchFromSvgToPng()
 		{
 			using (ExcelPackage package = OpenPackage("SvgToPng.xlsx", true))
 			{
+				ExcelPackage otherPackage = new ExcelPackage();
+				var someWs = otherPackage.Workbook.Worksheets.Add("SomeWorksheet");
+				someWs.Drawings.AddPicture("picturetiff", GetResourceFile("Code.tif"));
+                someWs.Drawings.AddPicture("pictureSvg", GetResourceFile("car-silhouette-color-low-poly.svg"));
+                someWs.Drawings.AddPicture("picturePng", GetResourceFile("EPPlus.png"));
+
                 Console.WriteLine($"Start SvgToPng");
                 var wb = package.Workbook;
 				var ws = wb.Worksheets.Add("NewSheet");
@@ -263,6 +270,9 @@ namespace EPPlusTest.Drawing
 
                 Console.WriteLine($"Creating picture");
                 var originalSvg = ws.Drawings.AddPicture("svgOrig", GetResourceFile("car-silhouette-color-low-poly.svg"));
+
+                var picRelDrawing = ((IPictureRelationDocument)ws.Drawings);
+                Console.WriteLine("PicRel drawings package: " + picRelDrawing.Package.File.Name);
 
                 Console.WriteLine($"Created picture check rels");
 
@@ -280,6 +290,12 @@ namespace EPPlusTest.Drawing
                 Console.WriteLine($"Begin change image");
 
                 originalSvg.Image.SetImage(GetResourceFile("EPPlus.png"));
+
+                var picRelDrawing2 = ((IPictureRelationDocument)ws.Drawings);
+                Console.WriteLine("PicRel drawings package After: " + picRelDrawing2.Package.File.Name);
+
+                var picRelDrawing3 = ((IPictureRelationDocument)originalSvg._drawings);
+                Console.WriteLine("PicRel drawings package After from picture: " + picRelDrawing3.Package.File.Name);
 
                 Console.WriteLine($"changed picture check rels");
 
@@ -335,6 +351,7 @@ namespace EPPlusTest.Drawing
 
                 Assert.AreEqual("../media/image1.png", rel.TargetUri.OriginalString);
 
+				otherPackage.Dispose();
                 SaveAndCleanup(package);
             }
 		}

--- a/src/EPPlusTest/Drawing/PictureTests.cs
+++ b/src/EPPlusTest/Drawing/PictureTests.cs
@@ -254,20 +254,33 @@ namespace EPPlusTest.Drawing
 		{
 			using (ExcelPackage package = OpenPackage("SvgToPng.xlsx", true))
 			{
-				var wb = package.Workbook;
+                Console.WriteLine($"Start SvgToPng");
+                var wb = package.Workbook;
 				var ws = wb.Worksheets.Add("NewSheet");
 
-				var originalSvg = ws.Drawings.AddPicture("svgOrig", GetResourceFile("car-silhouette-color-low-poly.svg"));
-				originalSvg.Image.SetImage(GetResourceFile("EPPlus.png"));
+                Console.WriteLine(string.Format("file name: {0}", wb._package.File.Name));
 
-				Assert.IsTrue(ws.Drawings.Part.RelationshipExists("rId1"));
-				var rel = ws.Drawings.Part.GetRelationship("rId1");
+                Console.WriteLine($"Creating picture");
+                var originalSvg = ws.Drawings.AddPicture("svgOrig", GetResourceFile("car-silhouette-color-low-poly.svg"));
+                Console.WriteLine($"Finish creating picture");
+
+                Console.WriteLine($"Begin change image");
+                originalSvg.Image.SetImage(GetResourceFile("EPPlus.png"));
+                Console.WriteLine($"End change image");
+
+                Console.WriteLine($"Begin rel exists");
+                Assert.IsTrue(ws.Drawings.Part.RelationshipExists("rId1"));
+                Console.WriteLine($"end rel exists");
+
+                var rel = ws.Drawings.Part.GetRelationship("rId1");
 
 				var relUri = UriHelper.ResolvePartUri(originalSvg.Part.Uri, rel.TargetUri);
 
+                Console.WriteLine($"Begin are Equal originalSvg and relUri");
                 Assert.AreEqual(originalSvg.Part.Uri, relUri);
+                Console.WriteLine($"End originalSvg and relUri");
 
-				Console.WriteLine($"Package Name:{package.File.FullName}");
+                Console.WriteLine($"Package Name:{package.File.FullName}");
 
                 Assert.AreEqual("../media/image1.png", rel.TargetUri.OriginalString);
 

--- a/src/EPPlusTest/Drawing/PictureTests.cs
+++ b/src/EPPlusTest/Drawing/PictureTests.cs
@@ -266,6 +266,9 @@ namespace EPPlusTest.Drawing
 				var relUri = UriHelper.ResolvePartUri(originalSvg.Part.Uri, rel.TargetUri);
 
                 Assert.AreEqual(originalSvg.Part.Uri, relUri);
+
+				Console.WriteLine($"Package Name:{package.File.FullName}");
+
                 Assert.AreEqual("../media/image1.png", rel.TargetUri.OriginalString);
 
                 SaveAndCleanup(package);

--- a/src/EPPlusTest/Drawing/PictureTests.cs
+++ b/src/EPPlusTest/Drawing/PictureTests.cs
@@ -245,9 +245,8 @@ namespace EPPlusTest.Drawing
                 var wb = package.Workbook;
                 var ws = wb.Worksheets.Add("NewSheet");
 
-                var pic = ws.Drawings.AddPicture("mypic", GetResourceFile("tree-solid.svg"));
-
-                //pic.Image.SetImage(GetResourceFile("tree-solid.svg"));
+                var pic = ws.Drawings.AddPicture("mypic", GetResourceFile("EPPlus.png"));
+                pic.Image.SetImage(GetResourceFile("car-silhouette-color-low-poly.svg"));
 
                 SaveAndCleanup(package);
             }

--- a/src/EPPlusTest/Drawing/PictureTests.cs
+++ b/src/EPPlusTest/Drawing/PictureTests.cs
@@ -278,6 +278,7 @@ namespace EPPlusTest.Drawing
                 Console.WriteLine($"Finish creating picture");
 
                 Console.WriteLine($"Begin change image");
+
                 originalSvg.Image.SetImage(GetResourceFile("EPPlus.png"));
 
                 Console.WriteLine($"changed picture check rels");
@@ -306,13 +307,13 @@ namespace EPPlusTest.Drawing
 
 				foreach(var image in package.PictureStore._images)
 				{
-					Console.WriteLine($"image key: {image.Key}, image value: {image.Value}");
+					Console.WriteLine($"image key: {image.Key}, image value: {image.Value.Uri}");
 				}
 				Console.WriteLine("Other package picturestore:");
 
                 foreach (var image in _pck.PictureStore._images)
                 {
-                    Console.WriteLine($"image key: {image.Key}, image value: {image.Value}");
+                    Console.WriteLine($"image key: {image.Key}, image value: {image.Value.Uri}");
                 }
 
                 var rel = ws.Drawings.Part.GetRelationship("rId1");

--- a/src/EPPlusTest/Drawing/PictureTests.cs
+++ b/src/EPPlusTest/Drawing/PictureTests.cs
@@ -5,6 +5,7 @@ using OfficeOpenXml.Utils;
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace EPPlusTest.Drawing
 {
@@ -272,9 +273,24 @@ namespace EPPlusTest.Drawing
                 Assert.IsTrue(ws.Drawings.Part.RelationshipExists("rId1"));
                 Console.WriteLine($"end rel exists");
 
+				Console.WriteLine($"Drawings count: {ws.Drawings.Count}");
+                var pics = ws.Drawings.Where(x => x.DrawingType == eDrawingType.Picture).Select(x => x.As.Picture);
+				foreach(var pic in pics)
+				{
+					Console.WriteLine($"{pic.Name}");
+                    Console.WriteLine($"{pic.Image.Type}");
+                }
+
                 var rel = ws.Drawings.Part.GetRelationship("rId1");
 
-				var relUri = UriHelper.ResolvePartUri(originalSvg.Part.Uri, rel.TargetUri);
+				foreach(var aRel in ws.Drawings.Part._rels)
+				{
+					Console.WriteLine($"Id: {aRel.Id}, Name: {rel.TargetUri.OriginalString}");
+					var resUri = UriHelper.ResolvePartUri(originalSvg.Part.Uri, aRel.TargetUri);
+					Console.WriteLine($"ResolvedUri:{resUri.OriginalString}");
+                }
+
+                var relUri = UriHelper.ResolvePartUri(originalSvg.Part.Uri, rel.TargetUri);
 
                 Console.WriteLine($"Begin are Equal originalSvg and relUri");
                 Assert.AreEqual(originalSvg.Part.Uri, relUri);

--- a/src/EPPlusTest/Drawing/PictureTests.cs
+++ b/src/EPPlusTest/Drawing/PictureTests.cs
@@ -304,6 +304,17 @@ namespace EPPlusTest.Drawing
                     Console.WriteLine($"{pic.Image.Type}");
                 }
 
+				foreach(var image in package.PictureStore._images)
+				{
+					Console.WriteLine($"image key: {image.Key}, image value: {image.Value}");
+				}
+				Console.WriteLine("Other package picturestore:");
+
+                foreach (var image in _pck.PictureStore._images)
+                {
+                    Console.WriteLine($"image key: {image.Key}, image value: {image.Value}");
+                }
+
                 var rel = ws.Drawings.Part.GetRelationship("rId1");
 
 				foreach(var aRel in ws.Drawings.Part._rels)

--- a/src/EPPlusTest/Drawing/PictureTests.cs
+++ b/src/EPPlusTest/Drawing/PictureTests.cs
@@ -252,7 +252,7 @@ namespace EPPlusTest.Drawing
 
 
 		[TestMethod]
-		public void ZZZZZZZSwitchFromSvgToPng()
+		public void SwitchFromSvgToPng()
 		{
 			using (ExcelPackage package = OpenPackage("SvgToPng.xlsx", true))
 			{
@@ -262,93 +262,20 @@ namespace EPPlusTest.Drawing
                 someWs.Drawings.AddPicture("pictureSvg", GetResourceFile("car-silhouette-color-low-poly.svg"));
                 someWs.Drawings.AddPicture("picturePng", GetResourceFile("EPPlus.png"));
 
-                Console.WriteLine($"Start SvgToPng");
                 var wb = package.Workbook;
 				var ws = wb.Worksheets.Add("NewSheet");
 
-                Console.WriteLine(string.Format("file name: {0}", wb._package.File.Name));
-
-                Console.WriteLine($"Creating picture");
                 var originalSvg = ws.Drawings.AddPicture("svgOrig", GetResourceFile("car-silhouette-color-low-poly.svg"));
-
-                var picRelDrawing = ((IPictureRelationDocument)ws.Drawings);
-                Console.WriteLine("PicRel drawings package: " + picRelDrawing.Package.File.Name);
-
-                Console.WriteLine($"Created picture check rels");
-
-                foreach (var aRel in ws.Drawings.Part._rels)
-                {
-                    Console.WriteLine($"Id: {aRel.Id}, Name: {aRel.TargetUri.OriginalString}");
-                    var resUri = UriHelper.ResolvePartUri(originalSvg.Part.Uri, aRel.TargetUri);
-                    Console.WriteLine($"ResolvedUri:{resUri.OriginalString}");
-                }
-
-                Console.WriteLine($"Created picture check rels end" );
-
-                Console.WriteLine($"Finish creating picture");
-
-                Console.WriteLine($"Begin change image");
 
                 originalSvg.Image.SetImage(GetResourceFile("EPPlus.png"));
 
-                var picRelDrawing2 = ((IPictureRelationDocument)ws.Drawings);
-                Console.WriteLine("PicRel drawings package After: " + picRelDrawing2.Package.File.Name);
-
-                var picRelDrawing3 = ((IPictureRelationDocument)originalSvg._drawings);
-                Console.WriteLine("PicRel drawings package After from picture: " + picRelDrawing3.Package.File.Name);
-
-                Console.WriteLine($"changed picture check rels");
-
-                foreach (var aRel in ws.Drawings.Part._rels)
-                {
-                    Console.WriteLine($"Id: {aRel.Id}, Name: {aRel.TargetUri.OriginalString}");
-                    var resUri = UriHelper.ResolvePartUri(originalSvg.Part.Uri, aRel.TargetUri);
-                    Console.WriteLine($"ResolvedUri:{resUri.OriginalString}");
-                }
-                Console.WriteLine($"changed picture check rels END");
-
-                Console.WriteLine($"End change image");
-
-                Console.WriteLine($"Begin rel exists");
                 Assert.IsTrue(ws.Drawings.Part.RelationshipExists("rId1"));
-                Console.WriteLine($"end rel exists");
-
-				Console.WriteLine($"Drawings count: {ws.Drawings.Count}");
-                var pics = ws.Drawings.Where(x => x.DrawingType == eDrawingType.Picture).Select(x => x.As.Picture);
-				foreach(var pic in pics)
-				{
-					Console.WriteLine($"{pic.Name}");
-                    Console.WriteLine($"{pic.Image.Type}");
-                }
-
-				foreach(var image in package.PictureStore._images)
-				{
-					Console.WriteLine($"image key: {image.Key}, image value: {image.Value.Uri}");
-				}
-				Console.WriteLine("Other package picturestore:");
-
-                foreach (var image in _pck.PictureStore._images)
-                {
-                    Console.WriteLine($"image key: {image.Key}, image value: {image.Value.Uri}");
-                }
 
                 var rel = ws.Drawings.Part.GetRelationship("rId1");
 
-				foreach(var aRel in ws.Drawings.Part._rels)
-				{
-					Console.WriteLine($"Id: {aRel.Id}, Name: {rel.TargetUri.OriginalString}");
-					var resUri = UriHelper.ResolvePartUri(originalSvg.Part.Uri, aRel.TargetUri);
-					Console.WriteLine($"ResolvedUri:{resUri.OriginalString}");
-                }
-
                 var relUri = UriHelper.ResolvePartUri(originalSvg.Part.Uri, rel.TargetUri);
 
-                Console.WriteLine($"Begin are Equal originalSvg and relUri");
                 Assert.AreEqual(originalSvg.Part.Uri, relUri);
-                Console.WriteLine($"End originalSvg and relUri");
-
-                Console.WriteLine($"Package Name:{package.File.FullName}");
-
                 Assert.AreEqual("../media/image1.png", rel.TargetUri.OriginalString);
 
 				otherPackage.Dispose();

--- a/src/EPPlusTest/Drawing/PictureTests.cs
+++ b/src/EPPlusTest/Drawing/PictureTests.cs
@@ -237,5 +237,20 @@ namespace EPPlusTest.Drawing
                 SaveAndCleanup(package);
             }
         }
+        [TestMethod]
+        public void i1688()
+        {
+            using (ExcelPackage package = OpenPackage("i1688.xlsx", true))
+            {
+                var wb = package.Workbook;
+                var ws = wb.Worksheets.Add("NewSheet");
+
+                var pic = ws.Drawings.AddPicture("mypic", GetResourceFile("tree-solid.svg"));
+
+                //pic.Image.SetImage(GetResourceFile("tree-solid.svg"));
+
+                SaveAndCleanup(package);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/Drawing/PictureTests.cs
+++ b/src/EPPlusTest/Drawing/PictureTests.cs
@@ -263,10 +263,33 @@ namespace EPPlusTest.Drawing
 
                 Console.WriteLine($"Creating picture");
                 var originalSvg = ws.Drawings.AddPicture("svgOrig", GetResourceFile("car-silhouette-color-low-poly.svg"));
+
+                Console.WriteLine($"Created picture check rels");
+
+                foreach (var aRel in ws.Drawings.Part._rels)
+                {
+                    Console.WriteLine($"Id: {aRel.Id}, Name: {aRel.TargetUri.OriginalString}");
+                    var resUri = UriHelper.ResolvePartUri(originalSvg.Part.Uri, aRel.TargetUri);
+                    Console.WriteLine($"ResolvedUri:{resUri.OriginalString}");
+                }
+
+                Console.WriteLine($"Created picture check rels end" );
+
                 Console.WriteLine($"Finish creating picture");
 
                 Console.WriteLine($"Begin change image");
                 originalSvg.Image.SetImage(GetResourceFile("EPPlus.png"));
+
+                Console.WriteLine($"changed picture check rels");
+
+                foreach (var aRel in ws.Drawings.Part._rels)
+                {
+                    Console.WriteLine($"Id: {aRel.Id}, Name: {aRel.TargetUri.OriginalString}");
+                    var resUri = UriHelper.ResolvePartUri(originalSvg.Part.Uri, aRel.TargetUri);
+                    Console.WriteLine($"ResolvedUri:{resUri.OriginalString}");
+                }
+                Console.WriteLine($"changed picture check rels END");
+
                 Console.WriteLine($"End change image");
 
                 Console.WriteLine($"Begin rel exists");

--- a/src/EPPlusTest/Issues/LegacyTests/Issues.cs
+++ b/src/EPPlusTest/Issues/LegacyTests/Issues.cs
@@ -26,6 +26,7 @@
  *******************************************************************************
   01/27/2020         EPPlus Software AB       Initial release EPPlus 5
  *******************************************************************************/
+using EPPlusTest.Properties;
 using EPPlusTest.Table;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
@@ -38,6 +39,7 @@ using OfficeOpenXml.Drawing.Chart.Style;
 using OfficeOpenXml.Drawing.Slicer;
 using OfficeOpenXml.Drawing.Style.Coloring;
 using OfficeOpenXml.FormulaParsing;
+using OfficeOpenXml.FormulaParsing.Logging;
 using OfficeOpenXml.Sparkline;
 using OfficeOpenXml.Style;
 using OfficeOpenXml.Table;
@@ -54,6 +56,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
+using static Microsoft.IO.RecyclableMemoryStreamManager;
 
 namespace EPPlusTest
 {


### PR DESCRIPTION
.SetImage did not work when switching from .png to .svg
Added svg xml if type changes to svg

Ensured a particular file can be used/removed multiple times without missmatch in other pictures that refer to the same file.
Ensured .svg can be image switched back to other filetypes (.png)
Made picturestore _id no longer static. Meaning image names in media folder should now be more correct.