### PR TITLE
Added fix for #1683 and one related bug

### DIFF
--- a/src/EPPlus/Export/ToDataTable/DataTableMapper.cs
+++ b/src/EPPlus/Export/ToDataTable/DataTableMapper.cs
@@ -1,9 +1,11 @@
 ﻿using OfficeOpenXml.FormulaParsing.Utilities;
+using OfficeOpenXml.RichData;
 using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Text;
+using OfficeOpenXml.Style;
 
 namespace OfficeOpenXml.Export.ToDataTable
 {
@@ -54,6 +56,12 @@ namespace OfficeOpenXml.Export.ToDataTable
             for(var col = _range.Start.Column; col <= _range.End.Column; col++)
             {
                 var cellVal = _range.Worksheet.GetValueInner(row, col);
+
+                if(cellVal is ExcelRichTextCollection)
+                {
+                    cellVal = ((ExcelRichTextCollection)cellVal).Text;
+                }
+
                 if (cellVal == null) continue;
                 if (string.Compare(columnName, cellVal.ToString(), StringComparison.OrdinalIgnoreCase) == 0)
                 {

--- a/src/EPPlus/Table/PivotTable/PivotTableCacheInternal.cs
+++ b/src/EPPlus/Table/PivotTable/PivotTableCacheInternal.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Security;
 using System.Text;
 using System.Xml;
+using OfficeOpenXml.Style;
 
 namespace OfficeOpenXml.Table.PivotTable
 {
@@ -592,7 +593,17 @@ namespace OfficeOpenXml.Table.PivotTable
             xml += string.Format("<cacheFields count=\"{0}\">", sourceRange._toCol - sourceRange._fromCol + 1);
             for (int col = sourceRange._fromCol; col <= sourceRange._toCol; col++)
             {
-                var name = sourceWorksheet?.GetValueInner(sourceRange._fromRow, col);
+                var innerValue = sourceWorksheet?.GetValueInner(sourceRange._fromRow, col);
+                string name = "";
+                if(innerValue is ExcelRichTextCollection)
+                {
+                    name = ((ExcelRichTextCollection)innerValue).Text;
+                }
+                else
+                {
+                    name = innerValue.ToString();
+                }
+
                 if (name == null || name.ToString() == "")
                 {
                     xml += string.Format("<cacheField name=\"Column{0}\" numFmtId=\"0\">", col - sourceRange._fromCol + 1);

--- a/src/EPPlusTest/Issues/LegacyTests/Issues.cs
+++ b/src/EPPlusTest/Issues/LegacyTests/Issues.cs
@@ -6248,7 +6248,5 @@ namespace EPPlusTest
                 SaveAndCleanup(package);
             }
         }
-
-        
     }
 }

--- a/src/EPPlusTest/Issues/PivotTableIssues.cs
+++ b/src/EPPlusTest/Issues/PivotTableIssues.cs
@@ -4,6 +4,8 @@ using System.Xml;
 using System.Linq;
 using System;
 using System.IO;
+using OfficeOpenXml.Table.PivotTable;
+
 namespace EPPlusTest.Issues
 {
     [TestClass]
@@ -48,12 +50,12 @@ namespace EPPlusTest.Issues
                 foreach (ExcelWorksheet worksheet in p.Workbook.Worksheets)
                 {
                     foreach (var table in worksheet.PivotTables)
-                    {                        
+                    {
                         table.Calculate(refreshCache: true);
                     }
                 }
 
-                SaveWorkbook("s692-2.xlsx",p);
+                SaveWorkbook("s692-2.xlsx", p);
             }
         }
         [TestMethod]
@@ -61,19 +63,19 @@ namespace EPPlusTest.Issues
         {
             using (ExcelPackage p = OpenTemplatePackage("s713.xlsx"))
             {
-               ExcelWorkbook workbook = p.Workbook;
-               workbook.Worksheets.Delete("pivot");
+                ExcelWorkbook workbook = p.Workbook;
+                workbook.Worksheets.Delete("pivot");
 
                 var ns = new XmlNamespaceManager(new NameTable());
                 ns.AddNamespace("d", @"http://schemas.openxmlformats.org/spreadsheetml/2006/main");
 
-                var node = workbook.WorkbookXml.SelectSingleNode("//d:pivotCaches", ns); 
+                var node = workbook.WorkbookXml.SelectSingleNode("//d:pivotCaches", ns);
                 if (node != null && node.ChildNodes.Count == 0)
                 {
                     node.ParentNode.RemoveChild(node);
                 }
 
-               SaveAndCleanup(p);
+                SaveAndCleanup(p);
             }
         }
         [TestMethod]
@@ -93,7 +95,7 @@ namespace EPPlusTest.Issues
                 cf.Refresh();
                 Assert.IsTrue(cf.SharedItems[0] is DateTime);
                 Assert.IsTrue(cf.SharedItems[1] is DateTime);
-                SaveWorkbook("i1554-SecondDate.xlsx",package);
+                SaveWorkbook("i1554-SecondDate.xlsx", package);
             }
         }
 
@@ -185,7 +187,7 @@ namespace EPPlusTest.Issues
 
                 var ws2 = workbook.Worksheets["High Level Summary"];
                 var pt = ws2.PivotTables[0];
-                var slicer1 =ws2.Drawings[0].As.Slicer.PivotTableSlicer;
+                var slicer1 = ws2.Drawings[0].As.Slicer.PivotTableSlicer;
 
                 Assert.AreEqual(pt.Fields[0].Items.Count, 5);
                 Assert.AreEqual(4, slicer1.Cache.Data.Items.Count);


### PR DESCRIPTION
ExcelRichTextCollection did not play nice with Pivot Table Names.

Essentially both cases assumed ToString() would work on the object.
Fixed that and one more bug of the same nature with Datatables.