### PR TITLE
When accessing a rich texts font name, size and family and they are e…

### DIFF
--- a/docs/articles/breakingchanges.md
+++ b/docs/articles/breakingchanges.md
@@ -143,3 +143,4 @@ Misspelled property `ExcelIgnoreError.CalculatedColumm` has been renamed `Calcul
 
 ### Breaking changes from EPPlus 8.0
 * Set ExcelPackageSettings.ApplyFiltersOnSave default value to false.
+* RichText now returns font name, size and font family from cell style if not set.

--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -1455,11 +1455,12 @@ namespace OfficeOpenXml
             var isRt = _flags.GetFlagValue(row, col, CellFlags.RichText);
             if (isRt && v._value is ExcelRichTextCollection rtc)
             {
+                if (rtc._cells == null) rtc._cells = r;
                 return rtc;
             }
             else
             {
-                var text = ValueToTextHandler.GetFormattedText(v._value, Workbook, v._styleId, false);                
+                var text = ValueToTextHandler.GetFormattedText(v._value, Workbook, v._styleId, false);
                 if (string.IsNullOrEmpty(text))
                 {
                     var item = new ExcelRichTextCollection(Workbook, r);

--- a/src/EPPlus/FormulaParsing/Ranges/CellInfo.cs
+++ b/src/EPPlus/FormulaParsing/Ranges/CellInfo.cs
@@ -72,7 +72,7 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
             {
                 if (_ws._flags.GetFlagValue(_values.Row, _values.Column, CellFlags.RichText))
                 {
-                    return _ws.GetRichText(_values.Row, _values.Column).Text;
+                    return _ws.GetRichText(_values.Row, _values.Column, _ws.Cells[_values.Row, _values.Column]).Text;
                 }
                 else
                 {

--- a/src/EPPlus/Style/RichText/ExcelRichText.cs
+++ b/src/EPPlus/Style/RichText/ExcelRichText.cs
@@ -84,15 +84,39 @@ namespace OfficeOpenXml.Style
         /// </summary>
         public ExcelVerticalAlignmentFont? VerticalAlign { get; set; } = ExcelVerticalAlignmentFont.None;
 
+        private float _size = 0;
         /// <summary>
         /// Font size
         /// </summary>
-        public float Size { get; set; } = 0;
+        public float Size
+        {
+            get
+            {
+                if (_size < 1) return _collection._cells.Style.Font.Size;
+                return _size;
+            }
+            set
+            {
+                _size = value;
+            }
+        }
 
+        private string _fontName = "";
         /// <summary>
         /// Name of the font
         /// </summary>
-        public string FontName { get; set; } = "";
+        public string FontName
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_fontName)) return _collection._cells.Style.Font.Name;
+                return _fontName;
+            }
+            set
+            {
+                _fontName = value;
+            }
+        }
 
         /// <summary>
         /// Text color.
@@ -142,10 +166,22 @@ namespace OfficeOpenXml.Style
         /// </summary>
         public int Charset { get; set; } = 0;
 
+        private int _family = 0;
         /// <summary>
         /// Font family
         /// </summary>
-        public int Family { get; set; } = 0;
+        public int Family
+        {
+            get
+            {
+                if (_family == 0) return _collection._cells.Style.Font.Family;
+                return _family;
+            }
+            set
+            {
+                _family = value;
+            }
+        }
 
         /// <summary>
         /// Underline type of text
@@ -435,17 +471,17 @@ namespace OfficeOpenXml.Style
                 if (!HasDefaultValue)
                 {
                     sb.Append("<rPr>");
-                    if (!String.IsNullOrEmpty(FontName))
+                    if (!String.IsNullOrEmpty(_fontName))
                     {
-                        sb.Append($"<rFont val=\"{FontName}\"/>");
+                        sb.Append($"<rFont val=\"{_fontName}\"/>");
                     }
                     if (Charset != 0)
                     {
                         sb.Append($"<charset val=\"{Charset}\"/>");
                     }
-                    if (Family != 0)
+                    if (_family != 0)
                     {
-                        sb.Append($"<family val=\"{Family}\"/>");
+                        sb.Append($"<family val=\"{_family}\"/>");
                     }
                     if (Bold == true)
                     {
@@ -463,9 +499,9 @@ namespace OfficeOpenXml.Style
                     {
                         WriteRichTextColorAttributes(sb);
                     }
-                    if (Size > 0)
+                    if (_size > 0)
                     {
-                        sb.Append($"<sz val=\"{Size.ToString(CultureInfo.InvariantCulture)}\"/>");
+                        sb.Append($"<sz val=\"{_size.ToString(CultureInfo.InvariantCulture)}\"/>");
                     }
                     if (UnderLine)
                     {
@@ -541,11 +577,11 @@ namespace OfficeOpenXml.Style
                       Italic == false &&
                       Strike == false &&
                VerticalAlign == ExcelVerticalAlignmentFont.None &&
-                        Size == 0 &&
-             String.IsNullOrEmpty(FontName) &&
+                        _size == 0 &&
+             String.IsNullOrEmpty(_fontName) &&
                        Color == Color.Empty &&
                      Charset == 0 &&
-                      Family == 0 &&
+                      _family == 0 &&
                UnderLineType == 0;
                    //Outline == false &&
                     //Shadow == false &&

--- a/src/EPPlusTest/Style/RichTextTest.cs
+++ b/src/EPPlusTest/Style/RichTextTest.cs
@@ -265,5 +265,20 @@ namespace EPPlusTest.Style
                 Assert.AreEqual(false, rt[1].UnderLine);
             }
         }
+
+
+        [TestMethod]
+        public void CheckRichTextProperties()
+        {
+            using var p = OpenTemplatePackage("Markups.xlsx");
+            var ws = p.Workbook.Worksheets[0];
+            var C4 = ws.Cells["C4"];
+            var C5 = ws.Cells["C5"];
+
+            Assert.AreEqual(C4.Style.Font.Name, C4.RichText[0].FontName);
+            Assert.AreEqual(C4.Style.Font.Size, C4.RichText[0].Size);
+            Assert.AreEqual("Arial", C4.RichText[1].FontName);
+
+        }
     }
 }


### PR DESCRIPTION
…mpty, we return the font info from the cell styling instead.

Before submitting this pull request I have...
- [x] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [x] ensured that the functionality I have added/changed is covered by new unit tests.
- [x] merged the target branch into the PR branch and resolved any merge conflicts
- [x] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).
