### PR TITLE
Added fix for #1673

### DIFF
--- a/src/EPPlus/Drawing/ExcelPicture.cs
+++ b/src/EPPlus/Drawing/ExcelPicture.cs
@@ -62,11 +62,13 @@ namespace OfficeOpenXml.Drawing
 
             if(picNode != null)
             {
-                if (picNode.Attributes["embed", ExcelPackage.schemaRelationships] != null)
+
+                var embedAttr = picNode.Attributes["embed", ExcelPackage.schemaRelationships];
+                if (embedAttr != null && string.IsNullOrEmpty(embedAttr.Value) == false)
                 {
                     LocationType = LocationType | PictureLocation.Embed;
                     IPictureContainer container = this;
-                    container.RelPic = drawings.Part.GetRelationship(picNode.Attributes["embed", ExcelPackage.schemaRelationships].Value);
+                    container.RelPic = drawings.Part.GetRelationship(embedAttr.Value);
                     container.UriPic = UriHelper.ResolvePartUri(drawings.UriDrawing, container.RelPic.TargetUri);
 
                     if (drawings.Part.Package.PartExists(container.UriPic))
@@ -104,11 +106,14 @@ namespace OfficeOpenXml.Drawing
                     container.ImageHash = ii.Hash;
                 }
 
-                if (picNode.Attributes["link", ExcelPackage.schemaRelationships] != null)
+                var linkAttr = picNode.Attributes["link", ExcelPackage.schemaRelationships];
+
+                if (linkAttr != null && string.IsNullOrEmpty(linkAttr.Value) == false )
                 {
                     LocationType = LocationType | PictureLocation.Link;
-                    LinkedImageRel = drawings.Part.GetRelationship(picNode.Attributes["link", ExcelPackage.schemaRelationships].Value);
+                    LinkedImageRel = drawings.Part.GetRelationship(linkAttr.Value);
                     IPictureContainer container = this;
+
                     if(container.RelPic == null && container.UriPic == null)
                     {
                         container.RelPic = LinkedImageRel;

--- a/src/EPPlusTest/Issues/DrawingIssues.cs
+++ b/src/EPPlusTest/Issues/DrawingIssues.cs
@@ -57,6 +57,20 @@ namespace EPPlusTest.Issues
                 SaveAndCleanup(package);
             }
         }
+
+        [TestMethod]
+        public void i1673()
+        {
+            using (var package = OpenTemplatePackage("i1673.xlsx"))
+            {
+                var wb = package.Workbook;
+                var ws = package.Workbook.Worksheets[0];
+                ws.Drawings.Count();
+
+                SaveAndCleanup(package);
+            }
+        }
+
         public void CopyRows(ExcelWorksheet excelWorksheet, int sourceFrom, int sourceTo, int destFrom, int destTo)
         {
             for (int i = destFrom; i <= destTo; i++)


### PR DESCRIPTION
Fix for #1673
Our support for Linked images did not check if the attribute value was empty if the attribute existed