### PR TITLE
xlookup now returns emtpy string instead of #N/A when third arg is em…

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/ExcelFunction.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/ExcelFunction.cs
@@ -13,22 +13,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using System.Globalization;
-using OfficeOpenXml.FormulaParsing;
 using OfficeOpenXml.FormulaParsing.Utilities;
 using OfficeOpenXml.FormulaParsing.Exceptions;
-using System.Collections;
-using static OfficeOpenXml.FormulaParsing.EpplusExcelDataProvider;
-using static OfficeOpenXml.FormulaParsing.ExcelDataProvider;
 using OfficeOpenXml.Compatibility;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
 using System.Runtime.CompilerServices;
-using Utils = OfficeOpenXml.Utils;
-using OfficeOpenXml.FormulaParsing.Ranges;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 {
@@ -363,7 +355,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
         protected string ArgToString(IList<FunctionArgument> arguments, int index)
         {
             var obj = arguments[index].ValueFirst;
-            return obj != null ? obj.ToString() : string.Empty;
+            return obj != null ? obj.ToString() : null;
         }
 
         /// <summary>

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/XLookup.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/XLookup.cs
@@ -56,7 +56,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             // return range
             if (!arguments[2].IsExcelRange) return CompileResult.GetDynamicArrayResultError(eErrorType.Value);
             var returnArray = arguments[2].ValueAsRangeInfo;
-            var notFoundText = string.Empty;
+            string notFoundText = null;
 
             // not found text
             if (arguments.Count() > 3 && arguments[3] != null)
@@ -104,7 +104,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
         {
             if (ix < 0 || ix > (lookupDirection == LookupRangeDirection.Vertical ? returnArray.Size.NumberOfRows - 1 : returnArray.Size.NumberOfCols - 1))
             {
-                return string.IsNullOrEmpty(notFoundText) ? CreateResult(eErrorType.NA) : CreateResult(notFoundText, DataType.String);
+                return notFoundText == null ? CreateResult(eErrorType.NA) : CreateResult(notFoundText, DataType.String);
             }
             var result = default(IRangeInfo);
             if (lookupDirection == LookupRangeDirection.Vertical)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Left.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Left.cs
@@ -10,10 +10,7 @@
  *************************************************************************************************
   01/27/2020         EPPlus Software AB       Initial release EPPlus 5
  *************************************************************************************************/
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 
@@ -31,6 +28,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
             var str = ArgToString(arguments, 0);
+            if(str == null)
+                str = string.Empty;
             var length = ArgToInt(arguments, 1, out ExcelErrorValue e1);
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             if (length < 0)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Lower.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Lower.cs
@@ -10,10 +10,7 @@
  *************************************************************************************************
   01/27/2020         EPPlus Software AB       Initial release EPPlus 5
  *************************************************************************************************/
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 
@@ -31,6 +28,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
             var arg = ArgToString(arguments, 0);
+            if (arg == null)
+                arg = string.Empty;
             return CreateResult(arg.ToLower(), DataType.String);
         }
     }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Proper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Proper.cs
@@ -10,10 +10,8 @@
  *************************************************************************************************
   01/27/2020         EPPlus Software AB       Initial release EPPlus 5
  *************************************************************************************************/
-using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
@@ -29,7 +27,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
         public override int ArgumentMinLength => 1;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var text = ArgToString(arguments, 0).ToLower(CultureInfo.InvariantCulture);
+            var text = ArgToString(arguments, 0);
+            if (text == null)
+                text = string.Empty;
+            text = text.ToLower(CultureInfo.InvariantCulture);
             var sb = new StringBuilder();
             var previousChar = '.';
             foreach (var ch in text)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Right.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Right.cs
@@ -10,10 +10,7 @@
  *************************************************************************************************
   01/27/2020         EPPlus Software AB       Initial release EPPlus 5
  *************************************************************************************************/
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 
@@ -31,6 +28,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
             var str = ArgToString(arguments, 0);
+            if (str == null)
+                str = string.Empty;
             var length = ArgToInt(arguments, 1, out ExcelErrorValue e2);
             if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
             if (length < 0) return CompileResult.GetErrorResult(eErrorType.Value);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Upper.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Upper.cs
@@ -10,10 +10,7 @@
  *************************************************************************************************
   01/27/2020         EPPlus Software AB       Initial release EPPlus 5
  *************************************************************************************************/
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 
@@ -31,6 +28,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
             var arg = ArgToString(arguments, 0);
+            if (arg == null)
+                arg = string.Empty;
             return CreateResult(Utils.ConvertUtil._invariantTextInfo.ToUpper(arg), DataType.String);
         }
     }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/XLookupTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/XLookupTests.cs
@@ -1,11 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.LookupUtils;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
 {
@@ -456,5 +452,20 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
 			Assert.AreEqual("34", _sheet.Cells["B7"].Value);
 		}
 
-	}
+        [TestMethod]
+        public void XlookupReturnEmptyString()
+        {
+            using var p = new ExcelPackage();
+            var ws = p.Workbook.Worksheets.Add("Sheet 1");
+            ws.Cells["A1"].Value = "test";
+            ws.Cells["B1"].Value = "test";
+            ws.Cells["B2"].Value = "test2";
+            ws.Cells["B3"].Value = "test3";
+            ws.Cells["C2"].Value = "good";
+            ws.Cells["C3"].Value = "bad";
+            ws.Cells["A2"].Formula = "XLOOKUP(\"test5\",B1:B3,C1:C3);\"\"";
+            ws.Cells["A2"].Calculate();
+            Assert.AreEqual("", ws.Cells["A2"].Value);
+        }
+    }
 }


### PR DESCRIPTION
…pty string.

Before submitting this pull request I have...
- [x] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [x] ensured that the functionality I have added/changed is covered by new unit tests.
- [x] merged the target branch into the PR branch and resolved any merge conflicts
- [x] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).
