### PR TITLE
#1729 - fixed error handling in TEXTJOIN, TEXTSPLIT and CONCAT

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Concat.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Concat.cs
@@ -28,6 +28,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
     {
         public override string NamespacePrefix => "_xlfn.";
         public override int ArgumentMinLength => 1;
+
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
             if (arguments == null)
@@ -45,6 +46,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
                 {
                     foreach(var cell in arg.ValueAsRangeInfo)
                     {
+                        if(cell.Value != null && cell.Value is ExcelErrorValue eev)
+                        {
+                            return CompileResult.GetErrorResult(eev.Type);
+                        }
                         sb.Append(cell.Value);
                     }
                 }
@@ -53,6 +58,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
                     var v = arg.ValueFirst;
                     if (v != null)
                     {
+                        if(v is ExcelErrorValue eev)
+                        {
+                            return CompileResult.GetErrorResult(eev.Type);
+                        }
                         sb.Append(v);
                     }
                 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/TextSplit.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/TextSplit.cs
@@ -45,7 +45,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
             string rowDelimiter = string.Empty;
             var ignoreEmpty = "0";
             var matchMode = "0";
-            var padWith = "#N/A";
+            //var padWith = "#N/A";
+            object padding = ExcelErrorValue.Create(eErrorType.NA);
             if (arguments.Count > 2 && arguments[2].Value != null)
             {
                 rowDelimiter = ArgDelimiterCollectionToString(arguments, 2, out result);
@@ -64,23 +65,30 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
                     rowDelimiter += rowDelimiter.ToLower() + rowDelimiter.ToUpper();
                 }
             }
-            if (arguments.Count > 5 && arguments[5].Value != null)
+            if (arguments.Count > 5)
             {
-                padWith = ArgToString(arguments, 5);
+                if(arguments[5].Value != null)
+                {
+                    padding = ArgToString(arguments, 5);
+                }
+                else
+                {
+                    padding = 0d;
+                }
             }
 
             if (range != null)
             {
-                return CreateRangeResult(text, range, colDelimiter, rowDelimiter, ignoreEmpty, matchMode, padWith);
+                return CreateRangeResult(text, range, colDelimiter, rowDelimiter, ignoreEmpty, matchMode, padding);
             }
 
             else
             {
-                return CreateStringResult(text, colDelimiter, rowDelimiter, ignoreEmpty, matchMode, padWith);
+                return CreateStringResult(text, colDelimiter, rowDelimiter, ignoreEmpty, matchMode, padding);
             }
         }
 
-        private CompileResult CreateStringResult(string text, string colDelimiter, string rowDelimiter, string ignoreEmpty, string matchMode, string padWith)
+        private CompileResult CreateStringResult(string text, string colDelimiter, string rowDelimiter, string ignoreEmpty, string matchMode, object padding)
         {
             var rows = new string[] { text };
             if (!string.IsNullOrEmpty(rowDelimiter))
@@ -96,14 +104,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
                 {
                     if (rowCols.Length < cols.Length && col >= rowCols.Length)
                     {
-                        if (padWith == "#N/A")
-                        {
-                            returnRange.SetValue(row, col, ExcelErrorValue.Create(eErrorType.NA));
-                        }
-                        else
-                        {
-                            returnRange.SetValue(row, col, padWith);
-                        }
+                        returnRange.SetValue(row, col, padding);
                     }
                     else
                     {
@@ -114,7 +115,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
             return CreateDynamicArrayResult(returnRange, DataType.ExcelRange);
         }
 
-        private CompileResult CreateRangeResult(string text, IRangeInfo range, string colDelimiter, string rowDelimiter, string ignoreEmpty, string matchMode, string padWith)
+        private CompileResult CreateRangeResult(string text, IRangeInfo range, string colDelimiter, string rowDelimiter, string ignoreEmpty, string matchMode, object padding)
         {
             int row = range == null ? 0 : range.Address.FromRow;
             int col = range == null ? 0 : range.Address.FromCol;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Textjoin.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Textjoin.cs
@@ -43,6 +43,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
                 {
                     foreach(var cell in arg.ValueAsRangeInfo)
                     {
+                        if(cell.Value != null && cell.Value is ExcelErrorValue eev)
+                        {
+                            return CompileResult.GetErrorResult(eev.Type);
+                        }
                         var val = cell.Value != null ? cell.Value.ToString() : string.Empty;
                         if (ignoreEmpty && string.IsNullOrEmpty(val)) continue;
                         str.Append(val);
@@ -57,6 +61,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
                     {
                         foreach(var item in items)
                         {
+                            if (item.Value != null && item.Value is ExcelErrorValue eev)
+                            {
+                                return CompileResult.GetErrorResult(eev.Type);
+                            }
                             var val = item.Value != null ? item.Value.ToString() : string.Empty;
                             if (ignoreEmpty && string.IsNullOrEmpty(val)) continue;
                             str.Append(val);
@@ -67,6 +75,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
                 }
                 else
                 {
+                    if (arg.Value != null && arg.Value is ExcelErrorValue eev)
+                    {
+                        return CompileResult.GetErrorResult(eev.Type);
+                    }
                     var val = arg.Value != null ? arg.Value.ToString() : string.Empty;
                     if (ignoreEmpty && string.IsNullOrEmpty(val)) continue;
                     str.Append(val);

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/TextFunctions/TextSplitTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/TextFunctions/TextSplitTests.cs
@@ -242,5 +242,43 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.TextFunctions
             SaveAndCleanup(package);
         }
 
+        [TestMethod]
+        public void TextSplit_ShouldReturnNAerrorDefault()
+        {
+            using var package = OpenPackage("TextSplit.xlsx", true);
+            var sheet = package.Workbook.Worksheets.Add("Sheet1");
+            sheet.Cells["A1"].Value = "ScottxMatsXJimmyxxCameron-xLutherXJoshxx";
+            sheet.Cells["D3"].Formula = "TEXTSPLIT(A1, \"x\",\"-\",1,1)";
+            sheet.Calculate();
+            var naError = ExcelErrorValue.Create(eErrorType.NA);
+            Assert.AreEqual("Scott", sheet.Cells["D3"].Value);
+            Assert.AreEqual("Mats", sheet.Cells["E3"].Value);
+            Assert.AreEqual("Jimmy", sheet.Cells["F3"].Value);
+            Assert.AreEqual("Cameron", sheet.Cells["G3"].Value);
+            Assert.AreEqual("Luther", sheet.Cells["D4"].Value);
+            Assert.AreEqual("Josh", sheet.Cells["E4"].Value);
+            Assert.AreEqual(naError, sheet.Cells["F4"].Value);
+            Assert.AreEqual(naError, sheet.Cells["G4"].Value);
+        }
+
+        [TestMethod]
+        public void TextSplit_ShouldReturn0IfEmptyArg()
+        {
+            using var package = OpenPackage("TextSplit.xlsx", true);
+            var sheet = package.Workbook.Worksheets.Add("Sheet1");
+            sheet.Cells["A1"].Value = "ScottxMatsXJimmyxxCameron-xLutherXJoshxx";
+            sheet.Cells["D3"].Formula = "TEXTSPLIT(A1, \"x\",\"-\",1,1,)";
+            sheet.Calculate();
+            var naError = ExcelErrorValue.Create(eErrorType.NA);
+            Assert.AreEqual("Scott", sheet.Cells["D3"].Value);
+            Assert.AreEqual("Mats", sheet.Cells["E3"].Value);
+            Assert.AreEqual("Jimmy", sheet.Cells["F3"].Value);
+            Assert.AreEqual("Cameron", sheet.Cells["G3"].Value);
+            Assert.AreEqual("Luther", sheet.Cells["D4"].Value);
+            Assert.AreEqual("Josh", sheet.Cells["E4"].Value);
+            Assert.AreEqual(0d, sheet.Cells["F4"].Value);
+            Assert.AreEqual(0d, sheet.Cells["G4"].Value);
+        }
+
     }
 }

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -526,5 +526,31 @@ namespace EPPlusTest.Issues
                 Assert.AreEqual("two", sheet1.Cells["C3"].Value);
             }
         }
+
+		[TestMethod]
+		public void i1729()
+		{
+			using var package = new ExcelPackage();
+			var worksheet = package.Workbook.Worksheets.Add("Sheet1");
+			worksheet.Cells["A1"].Value = "A";
+			worksheet.Cells["A2"].Formula = "VLOOKUP(1,B1:C2,2,FALSE)"; //Return #N/A
+            worksheet.Cells["A3"].Value = "B";
+            worksheet.Cells["A4"].Formula = "TEXTJOIN(\"\",TRUE,A1:A3)";
+            worksheet.Cells["A5"].Formula = "TEXTJOIN(\"\",TRUE,A1,A2,A3)";
+            worksheet.Cells["A6"].Formula = "CONCAT(A1:A3)";
+            worksheet.Cells["A7"].Formula = "CONCAT(A1,A2,A3)";
+			worksheet.Calculate();
+			var a4 = worksheet.Cells["A4"].Value;
+            var a5 = worksheet.Cells["A5"].Value;
+            var a6 = worksheet.Cells["A6"].Value;
+            var a7 = worksheet.Cells["A7"].Value;
+
+			var naError = ExcelErrorValue.Create(eErrorType.NA);
+
+			Assert.AreEqual(naError, a4);
+			Assert.AreEqual(naError, a5);
+			Assert.AreEqual(naError, a6);
+			Assert.AreEqual(naError, a7);
+        }
     }
 }


### PR DESCRIPTION
Errors were handled as strings, in some cases the function returned an error as part of the result.
