### PR TITLE
Reverted faulty change from i1806 ensured original worked

### DIFF
--- a/src/EPPlus/Drawing/Chart/ExcelChartStandard.cs
+++ b/src/EPPlus/Drawing/Chart/ExcelChartStandard.cs
@@ -95,14 +95,7 @@ namespace OfficeOpenXml.Drawing.Chart
                 {
                     var ptName = ptSource.Substring(ptSource.LastIndexOf("!") + 1);
                     PivotTableSource = ws.PivotTables[ptName];
-                    if (PivotTableSource == null)
-                    {
-                        _chartXmlHelper.SetXmlNodeString("c:pivotSource/c:name", originalPtSource);
-                    }
-                    else
-                    {
-                        _chartXmlHelper.SetXmlNodeString("c:pivotSource/c:name", ptSource);
-                    }
+                    _chartXmlHelper.SetXmlNodeString("c:pivotSource/c:name", "[]" + ptSource);
                 }
             }
 

--- a/src/EPPlus/Table/PivotTable/ExcelPivotTable.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotTable.cs
@@ -165,7 +165,8 @@ namespace OfficeOpenXml.Table.PivotTable
                     DataFields.AddInternal(dataField);
                 }
             }
-
+            DeleteNode("d:rowItems");
+            DeleteNode("d:colItems");
             Styles = new ExcelPivotTableAreaStyleCollection(this);
             ConditionalFormattings = new ExcelPivotTableConditionalFormattingCollection(this);
         }

--- a/src/EPPlusTest/Table/PivotTable/Calculation/PivotCacheStoreTests.cs
+++ b/src/EPPlusTest/Table/PivotTable/Calculation/PivotCacheStoreTests.cs
@@ -125,6 +125,10 @@ namespace EPPlusTest.Table.PivotTable.Calculation
             using (var pck = OpenTemplatePackage("s789_original_issue.xlsx"))
             {
                 var wb = pck.Workbook;
+
+                var ws = wb.Worksheets.GetByName("PivotTables");
+                var table = ws.PivotTables[0];
+
                 SaveAndCleanup(pck);
             }
         }

--- a/src/EPPlusTest/Table/PivotTable/Calculation/PivotCacheStoreTests.cs
+++ b/src/EPPlusTest/Table/PivotTable/Calculation/PivotCacheStoreTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
 using OfficeOpenXml.Table.PivotTable.Calculation;
 using OfficeOpenXml.Table.PivotTable.Calculation.Functions;
 
@@ -107,5 +108,25 @@ namespace EPPlusTest.Table.PivotTable.Calculation
 			Assert.IsTrue(PivotFunction.IsNonTopLevel(new int[] { PivotCalculationStore.SumLevelValue, PivotCalculationStore.SumLevelValue, 0 }, 1));
 			Assert.IsTrue(PivotFunction.IsNonTopLevel(new int[] { 0, PivotCalculationStore.SumLevelValue, 0 }, 1));
 		}
-	}
+
+        [TestMethod]
+        public void s789_charts()
+        {
+            using(var pck = OpenTemplatePackage("s789_charts_justOne.xlsx"))
+            {
+                var wb = pck.Workbook;
+                SaveAndCleanup(pck);
+            }
+        }
+
+        [TestMethod]
+        public void s789_orignals()
+        {
+            using (var pck = OpenTemplatePackage("s789_original_issue.xlsx"))
+            {
+                var wb = pck.Workbook;
+                SaveAndCleanup(pck);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Removing the `[ ]` symbols in i1806 caused charts to no longer be connected to their pivot tables. This fix ensures charts stay connected to their pivot tables.