### PR TITLE
Fix for #1829

### DIFF
--- a/src/EPPlus/Compatibility/CompatibilitySettings.cs
+++ b/src/EPPlus/Compatibility/CompatibilitySettings.cs
@@ -70,7 +70,6 @@ namespace OfficeOpenXml.Compatibility
                 if(excelPackage._workbook!=null && excelPackage._workbook._worksheets!=null)
                 {
                     excelPackage.Workbook.Worksheets.ReindexWorksheetDictionary();
-
                 }
             }
         }

--- a/src/EPPlus/ExcelWorksheets.cs
+++ b/src/EPPlus/ExcelWorksheets.cs
@@ -482,8 +482,8 @@ namespace OfficeOpenXml
                 _pck.Workbook.VbaProject.Modules.Remove(worksheet.CodeModule);
             }
 
-            _worksheets.RemoveAndShift(Index - _pck._worksheetAdd);
-            ReindexWorksheetDictionary();
+            _worksheets.RemoveAndShift(Index - _pck._worksheetAdd); 
+            ReindexWorksheetPosition(Index);
             //If the active sheet is deleted, set the next visible sheet as active.
             //If none are visible start going backwards until one isn't.
             if (_pck.Workbook.Worksheets.Count > 0)
@@ -570,6 +570,13 @@ namespace OfficeOpenXml
                 worksheets.Add(index++, entry);
             }
             _worksheets = worksheets;
+        }
+        internal void ReindexWorksheetPosition(int wsIndex)
+        {
+            for(int i= wsIndex; i<_worksheets.Count;i++)
+            {
+                _worksheets[i].PositionId = i + _pck._worksheetAdd;
+            }
         }
 
 #if Core

--- a/src/EPPlus/ExcelWorksheets.cs
+++ b/src/EPPlus/ExcelWorksheets.cs
@@ -573,7 +573,7 @@ namespace OfficeOpenXml
         }
         internal void ReindexWorksheetPosition(int wsIndex)
         {
-            for(int i= wsIndex; i<_worksheets.Count;i++)
+            for(int i= 0; i<_worksheets.Count;i++)
             {
                 _worksheets[i].PositionId = i + _pck._worksheetAdd;
             }

--- a/src/EPPlusTest/Issues/WorksheetIssues.cs
+++ b/src/EPPlusTest/Issues/WorksheetIssues.cs
@@ -664,7 +664,6 @@ namespace EPPlusTest.Issues
             p.Workbook.Worksheets.Delete(wsTemplate);
 			SaveWorkbook("Issue1794_2_Output.xlsx", p);
         }
-
         [TestMethod]
         public void DeletingWorksheetsWithParameters()
         {
@@ -682,17 +681,6 @@ namespace EPPlusTest.Issues
                 {
                     worksheets.Add($"SomeWorksheet{i}");
                 }
-
-				//Deleting worksheets with foreach
-				//Skips over index[1]
-				//Should probably throw as the enumerator changes while in it
-				//foreach (var ws in p.Workbook.Worksheets)
-				//{
-				//	if (ws.Name.StartsWith("Data ", StringComparison.OrdinalIgnoreCase))
-				//	{
-				//		p.Workbook.Worksheets.Delete(ws);
-				//	}
-				//}
 
 				for (int i=0;i<p.Workbook.Worksheets.Count;i++)
                 {
@@ -719,6 +707,54 @@ namespace EPPlusTest.Issues
                 Assert.AreEqual("SomeWorksheet1", p.Workbook.Worksheets["SomeWorksheet1"].Name);
                 Assert.AreEqual("SomeWorksheet3", p.Workbook.Worksheets["SomeWorksheet3"].Name);
                 Assert.AreEqual("SomeWorksheet4", p.Workbook.Worksheets["SomeWorksheet4"].Name);
+
+            }
+        }
+        [TestMethod]
+        public void DeletingWorksheetsWithParameters_1Base()
+        {
+            using (var p = OpenPackage("DeletingGroupOfWorksheets.xlsx", true))
+            {
+
+                p.Compatibility.IsWorksheets1Based = true;
+                var wb = p.Workbook;
+                var worksheets = wb.Worksheets;
+
+                for (int i = 1; i <= 5; i++)
+                {
+                    worksheets.Add($"Data {i}");
+                }
+
+                for (int i = 1; i <= 5; i++)
+                {
+                    worksheets.Add($"SomeWorksheet{i}");
+                }
+
+                for (int i = 1; i <= p.Workbook.Worksheets.Count; i++)
+                {
+                    var ws = p.Workbook.Worksheets[i];
+                    if (ws.Name.StartsWith("Data ", StringComparison.OrdinalIgnoreCase))
+                    {
+                        p.Workbook.Worksheets.Delete(ws);
+                        i--;
+                    }
+                }
+                var countWs = p.Workbook.Worksheets.Count;
+
+                Assert.AreEqual(countWs, 5);
+
+                worksheets.Delete($"SomeWorksheet2");
+
+                Assert.AreEqual(p.Workbook.Worksheets.Count, 4);
+                Assert.AreEqual("SomeWorksheet1", p.Workbook.Worksheets[1].Name);
+                Assert.AreEqual("SomeWorksheet3", p.Workbook.Worksheets[2].Name);
+                Assert.AreEqual("SomeWorksheet4", p.Workbook.Worksheets[3].Name);
+                Assert.AreEqual("SomeWorksheet5", p.Workbook.Worksheets[4].Name);
+
+                Assert.AreEqual("SomeWorksheet1", p.Workbook.Worksheets["SomeWorksheet1"].Name);
+                Assert.AreEqual("SomeWorksheet3", p.Workbook.Worksheets["SomeWorksheet3"].Name);
+                Assert.AreEqual("SomeWorksheet4", p.Workbook.Worksheets["SomeWorksheet4"].Name);
+                Assert.AreEqual("SomeWorksheet5", p.Workbook.Worksheets["SomeWorksheet5"].Name);
 
             }
         }

--- a/src/EPPlusTest/Issues/WorksheetIssues.cs
+++ b/src/EPPlusTest/Issues/WorksheetIssues.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
+using OfficeOpenXml.Core;
 using OfficeOpenXml.FormulaParsing;
 using System;
 using System.Collections.Generic;
@@ -662,6 +663,64 @@ namespace EPPlusTest.Issues
 			wsTemplate.View.SetTabSelected(false);
             p.Workbook.Worksheets.Delete(wsTemplate);
 			SaveWorkbook("Issue1794_2_Output.xlsx", p);
+        }
+
+        [TestMethod]
+        public void DeletingWorksheetsWithParameters()
+        {
+            using (var p = OpenPackage("DeletingGroupOfWorksheets.xlsx", true))
+            {
+                var wb = p.Workbook;
+                var worksheets = wb.Worksheets;
+
+                for (int i = 0; i < 5; i++)
+                {
+                    worksheets.Add($"Data {i}");
+                }
+
+                for (int i = 0; i < 5; i++)
+                {
+                    worksheets.Add($"SomeWorksheet{i}");
+                }
+
+				//Deleting worksheets with foreach
+				//Skips over index[1]
+				//Should probably throw as the enumerator changes while in it
+				//foreach (var ws in p.Workbook.Worksheets)
+				//{
+				//	if (ws.Name.StartsWith("Data ", StringComparison.OrdinalIgnoreCase))
+				//	{
+				//		p.Workbook.Worksheets.Delete(ws);
+				//	}
+				//}
+
+				for (int i=0;i<p.Workbook.Worksheets.Count;i++)
+                {
+					var ws = p.Workbook.Worksheets[i];
+                    if (ws.Name.StartsWith("Data ", StringComparison.OrdinalIgnoreCase))
+                    {
+                        p.Workbook.Worksheets.Delete(ws);
+						i--;
+                    }
+                }
+                var countWs = p.Workbook.Worksheets.Count;
+
+                Assert.AreEqual(countWs, 5);
+
+                worksheets.Delete($"SomeWorksheet2");
+
+                Assert.AreEqual(p.Workbook.Worksheets.Count, 4);
+				Assert.AreEqual("SomeWorksheet0", p.Workbook.Worksheets[0].Name);
+                Assert.AreEqual("SomeWorksheet1", p.Workbook.Worksheets[1].Name);
+                Assert.AreEqual("SomeWorksheet3", p.Workbook.Worksheets[2].Name);
+                Assert.AreEqual("SomeWorksheet4", p.Workbook.Worksheets[3].Name);
+
+                Assert.AreEqual("SomeWorksheet0", p.Workbook.Worksheets["SomeWorksheet0"].Name);
+                Assert.AreEqual("SomeWorksheet1", p.Workbook.Worksheets["SomeWorksheet1"].Name);
+                Assert.AreEqual("SomeWorksheet3", p.Workbook.Worksheets["SomeWorksheet3"].Name);
+                Assert.AreEqual("SomeWorksheet4", p.Workbook.Worksheets["SomeWorksheet4"].Name);
+
+            }
         }
     }
 }


### PR DESCRIPTION
Fix for #1829. Enumerator for worksheets will not allow change, will be applied in EPPlus 8, as it's a breaking change