### PR TITLE
Fix for issue 1878

### DIFF
--- a/src/EPPlus/Table/PivotTable/ExcelPivotTableCacheField.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotTableCacheField.cs
@@ -156,13 +156,11 @@ namespace OfficeOpenXml.Table.PivotTable
                 AppendSharedItems(shNode);
             }
             var noTypes = GetNoOfTypes(flags);
-            if (noTypes > 1 && 
-                flags != (DataTypeFlags.Int | DataTypeFlags.Number) &&
-                flags != (DataTypeFlags.Float | DataTypeFlags.Number) &&
-                flags != (DataTypeFlags.Int | DataTypeFlags.Float | DataTypeFlags.Number) &&
-                flags != (DataTypeFlags.Int | DataTypeFlags.Number | DataTypeFlags.Empty) &&
-                flags != (DataTypeFlags.Float | DataTypeFlags.Number | DataTypeFlags.Empty) &&
-                flags != (DataTypeFlags.Int | DataTypeFlags.Float | DataTypeFlags.Number | DataTypeFlags.Empty) &&
+            var checkFlags = flags & (~(DataTypeFlags.Empty | DataTypeFlags.Error));
+            if (noTypes > 1 &&
+                checkFlags != (DataTypeFlags.Int | DataTypeFlags.Number) &&
+                checkFlags != (DataTypeFlags.Float | DataTypeFlags.Number) &&
+                checkFlags != (DataTypeFlags.Int | DataTypeFlags.Float | DataTypeFlags.Number) &&
                 SharedItems.Count > 1)
             {
                 shNode.SetAttribute("containsMixedTypes", "1");
@@ -365,7 +363,7 @@ namespace OfficeOpenXml.Table.PivotTable
             int types = 0;
             foreach (DataTypeFlags v in Enum.GetValues(typeof(DataTypeFlags)))
             {
-                if (v!=DataTypeFlags.Empty && (flags & v)==v)
+                if (v!=DataTypeFlags.Empty && v != DataTypeFlags.Error && (flags & v)==v)
                 {
                     types++;
                 }

--- a/src/EPPlus/Utils/ConvertUtil.cs
+++ b/src/EPPlus/Utils/ConvertUtil.cs
@@ -567,16 +567,15 @@ namespace OfficeOpenXml.Utils
                     }
                 }
 #endif  
-                return (T)(object)dt;
+                if (dt != null)
+                {
+                    return (T)(object)dt;
+                }
             }
             else if (conversion.ReturnType.IsTimeSpan)
             {
                 TimeSpan? ts=null;
-                if (conversion.TryGetTimeSpan(out object tso))
-                {
-                    ts = (TimeSpan)tso;
-                }
-                else if (value is DateTime dt)
+                if (value is DateTime dt)
                 {                    
                     ts = new TimeSpan((long)(dt.ToOADate() * TimeSpan.TicksPerDay));
                 }
@@ -589,10 +588,14 @@ namespace OfficeOpenXml.Utils
                 {
                     ts=new TimeSpan((long)dateOnly.ToDateTime(TimeOnly.MinValue).ToOADate() * TimeSpan.TicksPerDay);
                 }
+                else if (conversion.TryGetTimeSpan(out object tso))
+                {
+                    ts = (TimeSpan)tso;
+                }
 #endif
 
 #if (NET8_0_OR_GREATER)
-                if(conversion.ReturnType.Type == typeof(TimeOnly))
+                if (conversion.ReturnType.Type == typeof(TimeOnly))
                 {
                     if (ts.HasValue == false && value is TimeSpan tsc)
                     {

--- a/src/EPPlus/Utils/ConvertUtil.cs
+++ b/src/EPPlus/Utils/ConvertUtil.cs
@@ -588,11 +588,11 @@ namespace OfficeOpenXml.Utils
                 {
                     ts=new TimeSpan((long)dateOnly.ToDateTime(TimeOnly.MinValue).ToOADate() * TimeSpan.TicksPerDay);
                 }
+#endif
                 else if (conversion.TryGetTimeSpan(out object tso))
                 {
                     ts = (TimeSpan)tso;
                 }
-#endif
 
 #if (NET8_0_OR_GREATER)
                 if (conversion.ReturnType.Type == typeof(TimeOnly))

--- a/src/EPPlus/Utils/ConvertUtil.cs
+++ b/src/EPPlus/Utils/ConvertUtil.cs
@@ -530,7 +530,7 @@ namespace OfficeOpenXml.Utils
         {
             var conversion = new TypeConvertUtil<T>(value);
 
-            if(value == null || (conversion.ReturnType.IsNullable && conversion.Value.IsEmptyString))
+            if (value == null || (conversion.ReturnType.IsNullable && conversion.Value.IsEmptyString))
             {
                 return default;
             }
@@ -542,13 +542,69 @@ namespace OfficeOpenXml.Utils
             {
                 return (T)conversion.ConvertToReturnType();
             }
-            else if (conversion.ReturnType.IsDateTime && conversion.TryGetDateTime(out object returnDate))
+            else if (conversion.ReturnType.IsDateTime)
             {
-                return (T)returnDate;
+                DateTime? dt=null;
+                if(conversion.TryGetDateTime(out object returnDate))
+                {
+                    dt = (DateTime)returnDate;
+                }
+#if(NET8_0_OR_GREATER)
+                else if (value is DateOnly dateOnly)
+                {
+                    dt = dateOnly.ToDateTime(TimeOnly.MinValue);
+                }
+
+                if (conversion.ReturnType.Type == typeof(DateOnly))
+                {
+                    if (dt.HasValue)
+                    {
+                        return (T)(object)DateOnly.FromDateTime(dt.Value);
+                    }
+                    else
+                    {
+                        return (T)(object)DateOnly.FromDateTime((DateTime)value);
+                    }
+                }
+#endif  
+                return (T)(object)dt;
             }
-            else if (conversion.ReturnType.IsTimeSpan && conversion.TryGetTimeSpan(out object ts))
+            else if (conversion.ReturnType.IsTimeSpan)
             {
-                return (T)ts;
+                TimeSpan? ts=null;
+                if (conversion.TryGetTimeSpan(out object tso))
+                {
+                    ts = (TimeSpan)tso;
+                }
+                else if (value is DateTime dt)
+                {                    
+                    ts = new TimeSpan((long)(dt.ToOADate() * TimeSpan.TicksPerDay));
+                }
+#if (NET8_0_OR_GREATER)
+                else if (value is TimeOnly timeOnly)
+                {
+                    ts = timeOnly.ToTimeSpan();
+                }
+                else if (value is DateOnly dateOnly)
+                {
+                    ts=new TimeSpan((long)dateOnly.ToDateTime(TimeOnly.MinValue).ToOADate() * TimeSpan.TicksPerDay);
+                }
+#endif
+
+#if (NET8_0_OR_GREATER)
+                if(conversion.ReturnType.Type == typeof(TimeOnly))
+                {
+                    if (ts.HasValue == false && value is TimeSpan tsc)
+                    {
+                        ts = tsc;
+                    }
+                    return (T)(object)TimeOnly.FromTimeSpan(new TimeSpan(ts.Value.Ticks - ts.Value.Days*TimeSpan.TicksPerDay));
+                }
+#endif
+                if (ts.HasValue)
+                {
+                    return (T)(object)ts;
+                }
             }
             if(returnDefaultIfException)
             {

--- a/src/EPPlusTest/Core/Worksheet/WorksheetCoreTests.cs
+++ b/src/EPPlusTest/Core/Worksheet/WorksheetCoreTests.cs
@@ -28,7 +28,9 @@
  *******************************************************************************/
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
+using System;
 using System.Drawing;
+using System.Linq;
 
 namespace EPPlusTest.Core.Worksheet
 {
@@ -233,5 +235,121 @@ namespace EPPlusTest.Core.Worksheet
                 Assert.AreEqual("B6:D13", ws.DimensionByValue.Address);
             }
         }
+        [TestMethod]
+        public void ValidateWorksheetGetValue_Timespan()
+        {
+            var p = new ExcelPackage();
+            var ws = p.Workbook.Worksheets.Add("Sheet1");
+            ws.SetValue("A1", new TimeSpan(12, 30, 45));
+            ws.Cells["A1"].Style.Numberformat.Format = "hh:MM:ss";
+
+
+            p.Save();
+            using (var p2 = new ExcelPackage(p.Stream))
+            {
+                var ws2 = p.Workbook.Worksheets.First();
+
+                var timeSpanCell = ws2.GetValue<TimeSpan>(1, 1);
+
+                Assert.AreEqual(timeSpanCell.Ticks, new TimeSpan(12, 30, 45).Ticks);
+            }
+        }
+#if (Core)
+        [TestMethod]
+        public void ValidateWorksheetGetValue_TimeOnlyToTimeOnly()
+        {
+            var p = new ExcelPackage();
+            var ws = p.Workbook.Worksheets.Add("Sheet1");
+            ws.SetValue("A1", new TimeOnly(12, 30, 45));
+            ws.Cells["A1"].Style.Numberformat.Format = "hh:MM:ss";
+
+            p.Save();
+            using (var p2 = new ExcelPackage(p.Stream))
+            {
+                var ws2 = p.Workbook.Worksheets.First();
+
+                var timeSpanCell = ws2.GetValue<TimeSpan>(1, 1);
+
+                Assert.AreEqual(timeSpanCell.Ticks, new TimeSpan(12, 30, 45).Ticks);
+            }
+        }
+        [TestMethod]
+        public void ValidateWorksheetGetValue_ToTimeOnlyFromTimeSpan()
+        {
+            var p = new ExcelPackage();
+            var ws = p.Workbook.Worksheets.Add("Sheet1");
+            var timeSpan = new TimeSpan(12, 30, 45);
+            ws.SetValue("A1", timeSpan);
+            ws.Cells["A1"].Style.Numberformat.Format = "hh:MM:ss";
+
+            p.Save();
+            using (var p2 = new ExcelPackage(p.Stream))
+            {
+                var ws2 = p.Workbook.Worksheets.First();
+
+                var timeSpanCell = ws2.GetValue<TimeOnly>(1, 1);
+
+                Assert.AreEqual(timeSpanCell.Ticks, timeSpan.Ticks);
+            }
+        }
+        [TestMethod]
+        public void ValidateWorksheetGetValue_ToTimeOnlyFromNumber()
+        {
+            var p = new ExcelPackage();
+            var ws = p.Workbook.Worksheets.Add("Sheet1");
+            var timeSpan = new TimeSpan(12, 30, 45);
+            ws.SetValue("A1", new DateTime(timeSpan.Ticks).ToOADate());
+            ws.Cells["A1"].Style.Numberformat.Format = "hh:MM:ss";
+
+            p.Save();
+            using (var p2 = new ExcelPackage(p.Stream))
+            {
+                var ws2 = p.Workbook.Worksheets.First();
+
+                var timeSpanCell = ws2.GetValue<TimeOnly>(1, 1);
+
+                Assert.AreEqual(timeSpanCell.Ticks, timeSpan.Ticks);
+            }
+        }
+        [TestMethod]
+        public void ValidateWorksheetGetValue_ToDateOnlyFromDateTime()
+        {
+            var p = new ExcelPackage();
+            var ws = p.Workbook.Worksheets.Add("Sheet1");
+            var dateTime = new DateTime(2025, 2, 3);
+            ws.SetValue("A1", dateTime);
+            ws.Cells["A1"].Style.Numberformat.Format = "hh:MM:ss";
+
+            p.Save();
+            using (var p2 = new ExcelPackage(p.Stream))
+            {
+                var ws2 = p.Workbook.Worksheets.First();
+
+                var dateOnlyCell = ws2.GetValue<DateOnly>(1, 1);
+
+                Assert.AreEqual(dateOnlyCell.ToDateTime(TimeOnly.MinValue).Ticks, dateTime.Ticks);
+            }
+        }
+        [TestMethod]
+        public void ValidateWorksheetGetValue_ToDateOnlyFromNumber()
+        {
+            var p = new ExcelPackage();
+            var ws = p.Workbook.Worksheets.Add("Sheet1");
+            var dateTime = new DateTime(2025, 2, 3);
+            ws.SetValue("A1", dateTime.ToOADate());
+            ws.Cells["A1"].Style.Numberformat.Format = "hh:MM:ss";
+
+            p.Save();
+            using (var p2 = new ExcelPackage(p.Stream))
+            {
+                var ws2 = p.Workbook.Worksheets.First();
+
+                var dateOnlyCell = ws2.GetValue<DateOnly>(1, 1);
+
+                Assert.AreEqual(dateOnlyCell.ToDateTime(TimeOnly.MinValue).Ticks, dateTime.Ticks);
+            }
+        }
+
+#endif
     }
 }

--- a/src/EPPlusTest/Issues/PivotTableIssues.cs
+++ b/src/EPPlusTest/Issues/PivotTableIssues.cs
@@ -316,5 +316,18 @@ namespace EPPlusTest.Issues
                 SaveAndCleanup(package);
             }
         }
+        [TestMethod]
+        public void PivotCacheIssue()
+        {
+            using (var package = OpenTemplatePackage("Issues\\PivotCache\\Sample.xlsx"))
+            {
+                var wb = package.Workbook;
+                foreach (var ws in wb.Worksheets)
+                {
+                    if (ws.PivotTables.Any()) Console.WriteLine(ws.Name);
+                }
+                SaveWorkbook("SampleNew.xlsx", package);
+            }
+        }
     }
 }

--- a/src/EPPlusTest/Issues/WorksheetIssues.cs
+++ b/src/EPPlusTest/Issues/WorksheetIssues.cs
@@ -808,5 +808,18 @@ namespace EPPlusTest.Issues
             Assert.AreEqual("2", loadedSheet.Cells["B1"].Comment.Text);
             Assert.AreEqual("3", loadedSheet.Cells["B2"].Comment.Text);
         }
+		[TestMethod]
+		public void i1878()
+		{
+            using (var p = OpenTemplatePackage("i1878.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets.First();
+
+                var timeSpanCell = ws.GetValue<TimeSpan>(1,1);
+
+                Assert.AreEqual(timeSpanCell.Ticks, new TimeSpan(12, 30, 45).Ticks);
+            }
+        }
+
     }
 }

--- a/src/EPPlusTest/Utils/GetTypedCellValueTests.cs
+++ b/src/EPPlusTest/Utils/GetTypedCellValueTests.cs
@@ -35,7 +35,7 @@ using System.Text;
 namespace EPPlusTest.Utils
 {
     [TestClass]
-    public class GetTypedCellValueTests
+    public class GetTypedCellValueTests : TestBase
     {
         [TestMethod]
         public void DoubleToNullableInt()
@@ -151,8 +151,10 @@ namespace EPPlusTest.Utils
         [TestMethod]
         public void StringToTimeSpan()
         {
+            SwitchToCulture();
             var expected = new TimeSpan(10, 11, 12);
             Assert.AreEqual(expected, ConvertUtil.GetTypedCellValue<TimeSpan>(expected.ToString()));
+            SwitchBackToCurrentCulture();
         }
         [TestMethod]
         public void TimeSpanToDateTime()


### PR DESCRIPTION
Fix for issue #1878.
* TimeSpan sometimes converted to the wrong value in ExcelWorksheet.GetValue().
* Better support for DateOnly and TimeOnly in ExcelWorksheet.GetValue()
* Added fix for Error values in Pivot Caches.