### PR TITLE
Ensured images width isn't swapped for height when setting image

### DIFF
--- a/src/EPPlus/Drawing/ExcelImage.cs
+++ b/src/EPPlus/Drawing/ExcelImage.cs
@@ -343,7 +343,7 @@ namespace OfficeOpenXml.Drawing
 
             using (var ms = RecyclableMemory.GetStream(image))
             {
-                if (_container.RelationDocument.Package.Settings.ImageSettings.GetImageBounds(ms, pictureType, out double height, out double width, out double horizontalResolution, out double verticalResolution))
+                if (_container.RelationDocument.Package.Settings.ImageSettings.GetImageBounds(ms, pictureType, out double width, out double height, out double horizontalResolution, out double verticalResolution))
                 {
                     Bounds.Width = width;
                     Bounds.Height = height;

--- a/src/EPPlusTest/Drawing/PictureTests.cs
+++ b/src/EPPlusTest/Drawing/PictureTests.cs
@@ -5,8 +5,6 @@ using OfficeOpenXml.Utils;
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using System.Linq;
-using OfficeOpenXml.Drawing.Interfaces;
 
 namespace EPPlusTest.Drawing
 {


### PR DESCRIPTION
In SetImageContainer the reference to 
_container.RelationDocument.Package.Settings.ImageSettings.GetImageBounds
was missmatched when it came to width and height input arguments.

This rarely mattered but is notable in the test;
PictureTests.SwitchFromSvgToPng