### PR TITLE
Bug/show leader lines

### DIFF
--- a/src/EPPlus/Drawing/Chart/ExcelChartDataLabelStandard.cs
+++ b/src/EPPlus/Drawing/Chart/ExcelChartDataLabelStandard.cs
@@ -12,6 +12,7 @@
  *************************************************************************************************/
 using System;
 using System.Collections.Generic;
+using System.Reflection.Emit;
 using System.Xml;
 using OfficeOpenXml.Drawing.Chart.DataLabling;
 
@@ -23,19 +24,19 @@ namespace OfficeOpenXml.Drawing.Chart
     public class ExcelChartDataLabelStandard : ExcelChartDataLabel
     {
         Guid _guidId;
+        string extPath = "c:extLst/c:ext";
 
         internal ExcelChartDataLabelStandard(ExcelChart chart, XmlNamespaceManager ns, XmlNode node, string nodeName, string[] schemaNodeOrder)
            : base(chart, ns, node, nodeName, "c")
         {
+
+            NameSpaceManager.AddNamespace("c15", ExcelPackage.schemaChart2012);
             if (nodeName == "dLbl" || nodeName == "")
             {
                 SchemaNodeOrder = LabelNodeHolder.DataLabel.NodeOrder;
 
                 TopNode = node;
-                
-                var extPath = "c:extLst/c:ext";
 
-                NameSpaceManager.AddNamespace("c15", ExcelPackage.schemaChart2012);
                 NameSpaceManager.AddNamespace("c16", ExcelPackage.schemaChart2014);
 
                 XmlElement el = (XmlElement)CreateNode($"{extPath}");
@@ -64,7 +65,12 @@ namespace OfficeOpenXml.Drawing.Chart
                     topNode.InnerXml = "<c:showLegendKey val=\"0\" /><c:showVal val=\"0\" /><c:showCatName val=\"0\" /><c:showSerName val=\"0\" /><c:showPercent val=\"0\" /><c:showBubbleSize val=\"0\" /> <c:separator>\r\n</c:separator><c:showLeaderLines val=\"0\" />";
                 }
                 TopNode = topNode;
+
                 SchemaNodeOrder = LabelNodeHolder.DataLabels.NodeOrder;
+
+                XmlElement el = (XmlElement)CreateNode($"{extPath}");
+                el.SetAttribute("xmlns:c15", ExcelPackage.schemaChart2012);
+                SetXmlNodeString($"{extPath}/@uri", "{CE6537A1-D6FC-4f65-9D91-7224C49458BB}");
             }
         }
 
@@ -154,6 +160,8 @@ namespace OfficeOpenXml.Drawing.Chart
             }
         }
         const string showLeaderLinesPath = "c:showLeaderLines/@val";
+        const string showLeaderLinesPathExt = "c:extLst/c:ext/c15:showLeaderLines/@val";
+
         /// <summary>
         /// Show the leader lines
         /// </summary>
@@ -163,15 +171,21 @@ namespace OfficeOpenXml.Drawing.Chart
             {
                 if(TopNode.LocalName == "dLbl" && TopNode.SelectSingleNode("c:idx", NameSpaceManager) == null)
                 {
-                    return GetXmlNodeBool(showLeaderLinesPath, TopNode.ParentNode);
+                    return GetXmlNodeBool(showLeaderLinesPathExt, TopNode.ParentNode);
                 }
                 return GetXmlNodeBool(showLeaderLinesPath);
             }
             set
             {
-                if (TopNode.LocalName == "dLbl" && TopNode.SelectSingleNode("c:idx", NameSpaceManager) == null)
+                if (TopNode.LocalName == "dLbl")
                 {
-                    SetXmlNodeString(TopNode.ParentNode, showLeaderLinesPath, value ? "1" : "0");
+                    var pNode = TopNode.ParentNode;
+
+                    if(pNode.SelectSingleNode(showLeaderLinesPathExt, NameSpaceManager) == null)
+                    {
+                        CreateNode(pNode, showLeaderLinesPathExt);
+                    }
+                    SetXmlNodeString(pNode, showLeaderLinesPathExt, value ? "1" : "0");
                 }
                 else
                 {

--- a/src/EPPlus/Drawing/Chart/ExcelChartDataLabelStandard.cs
+++ b/src/EPPlus/Drawing/Chart/ExcelChartDataLabelStandard.cs
@@ -169,9 +169,18 @@ namespace OfficeOpenXml.Drawing.Chart
         {
             get
             {
-                if(TopNode.LocalName == "dLbl" && TopNode.SelectSingleNode("c:idx", NameSpaceManager) == null)
+                if(TopNode.LocalName == "dLbl")
                 {
-                    return GetXmlNodeBool(showLeaderLinesPathExt, TopNode.ParentNode);
+                    var pNode = TopNode.ParentNode;
+                    var showLeaderLines = pNode.SelectSingleNode(showLeaderLinesPathExt, NameSpaceManager);
+                    if (showLeaderLines != null)
+                    {
+                        return GetXmlNodeBool(showLeaderLinesPathExt, pNode);
+                    }
+                    else
+                    {
+                        return GetXmlNodeBool(showLeaderLinesPath, pNode);
+                    }
                 }
                 return GetXmlNodeBool(showLeaderLinesPath);
             }

--- a/src/EPPlus/Drawing/Chart/ExcelChartStandardSerie.cs
+++ b/src/EPPlus/Drawing/Chart/ExcelChartStandardSerie.cs
@@ -308,8 +308,11 @@ namespace OfficeOpenXml.Drawing.Chart
             {
                 if(node.LocalName == "pt")
                 {
-                    var txt = node.InnerText;
-                    numLits.Add(Convert.ToDouble(txt));
+                    if(double.TryParse(node.InnerText, NumberStyles.Any, CultureInfo.InvariantCulture, out double numLit) == false)
+                    {
+                        throw new InvalidDataException($"numberLiteral in xml node:'{node.Name}' in chart:'{_chart.Name}' with value:'{node.InnerText}' could not be parsed as double. Chart cannot be read.");
+                    }
+                    numLits.Add(numLit);
                 }
             }
             numberLiterals = numLits.ToArray();

--- a/src/EPPlus/XmlHelper.cs
+++ b/src/EPPlus/XmlHelper.cs
@@ -1013,7 +1013,7 @@ namespace OfficeOpenXml
         {
             var tempNode = TopNode;
             TopNode = parentNode;
-            var retVal = GetXmlNodeBool(path, TopNode);
+            var retVal = GetXmlNodeBool(path);
             TopNode = tempNode;
             return retVal;
         }

--- a/src/EPPlusTest/Drawing/Chart/DatalabelTest.cs
+++ b/src/EPPlusTest/Drawing/Chart/DatalabelTest.cs
@@ -55,6 +55,29 @@ namespace EPPlusTest.Drawing.Chart
             SaveAndCleanup(_pck);
         }
 
+        [TestMethod]
+        public void ReadingDataLabel()
+        {
+            using (var p = OpenTemplatePackage("leaderlinesSome.xlsx"))
+            {
+                var cSheet = p.Workbook.Worksheets[0];
+
+                var aChart = cSheet.Drawings[0].As.Chart.BarChart;
+
+                for (int i = 0; i < aChart.Series.Count; i++)
+                {
+                    var label = aChart.Series[i].DataLabel;
+
+                    if(label.DataLabels.Count > 0)
+                    {
+                        var firstLabelOfLabelsInSeries = label.DataLabels[0];
+
+                        var showLines = firstLabelOfLabelsInSeries.ShowLeaderLines;
+                    }
+                }
+            }
+        }
+
         // s679
         //Manual layout when labels are atop eachother
         [TestMethod]

--- a/src/EPPlusTest/Drawing/Chart/DatalabelTest.cs
+++ b/src/EPPlusTest/Drawing/Chart/DatalabelTest.cs
@@ -68,12 +68,44 @@ namespace EPPlusTest.Drawing.Chart
                 {
                     var label = aChart.Series[i].DataLabel;
 
-                    if(label.DataLabels.Count > 0)
+                    if (label.DataLabels.Count > 0)
                     {
-                        var firstLabelOfLabelsInSeries = label.DataLabels[0];
+                        var labelIndividual = label.DataLabels[0];
 
-                        var showLines = firstLabelOfLabelsInSeries.ShowLeaderLines;
+                        if(i > 0 && i< 3)
+                        {
+                            Assert.AreEqual(true, labelIndividual.ShowLeaderLines);
+                        }
+                        else
+                        {
+                            Assert.AreEqual(false, labelIndividual.ShowLeaderLines);
+                        }
                     }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ReadingMultipleSeriesMultipleLabels()
+        {
+            using (var p = OpenTemplatePackage("3StackedColumns.xlsx"))
+            {
+                var cSheet = p.Workbook.Worksheets[0];
+
+                var aChart = cSheet.Drawings[0].As.Chart.BarChart;
+
+                for (int i = 0; i < aChart.Series.Count; i++)
+                {
+                    var label = aChart.Series[i].DataLabel;
+
+                    for(int j = 0; j < label.DataLabels.Count; j++)
+                    {
+                        //Ensure individual labels return correctly
+                        Assert.AreEqual(true, label.DataLabels[j].ShowLeaderLines);
+                    }
+
+                    //Ensure parent label returns correctly
+                    Assert.AreEqual(label.ShowLeaderLines, false);
                 }
             }
         }
@@ -383,6 +415,25 @@ namespace EPPlusTest.Drawing.Chart
             //Offset the data label 10% of the charts height to the top
             //AKA remove 10 from y coordinate
             dl.Layout.ManualLayout.Top = -10;
+        }
+
+
+        [TestMethod]
+        public void ReadChart()
+        {
+            using (ExcelPackage p = OpenTemplatePackage("leaderlinesSome.xlsx"))
+            {
+                var wb = p.Workbook;
+                var ws = p.Workbook.Worksheets[0];
+
+                var aChart = ws.Drawings[0].As.Chart.BarChart;
+
+                var label = aChart.Series[1].DataLabel.DataLabels[0];
+                var label2 = aChart.Series[3].DataLabel.DataLabels[0];
+
+                label2.ShowLeaderLines = true;
+                SaveAndCleanup(p);
+            }
         }
     }
 }


### PR DESCRIPTION
Ensured ooxml is read and generated correctly for leaderlines in charts.
It no longer causes warnings/exceptions in productivity tool.