### PR TITLE
Added fix for 1885 and quad intersect tables

### DIFF
--- a/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
+++ b/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
@@ -35,6 +35,7 @@ namespace OfficeOpenXml.ConditionalFormatting
         int LastPriority = 1;
         //A dict for those conditionalFormattings that are Ext, have been read in locally but not yet read in their ExtLst parts.
         internal Dictionary<string, ExcelConditionalFormattingRule> localAndExtDict = new Dictionary<string, ExcelConditionalFormattingRule>();
+        internal QuadTree<IExcelConditionalFormattingRule> CfIndex { get; set; }
 
         internal ExcelConditionalFormattingCollection(ExcelWorksheet ws)
         {
@@ -49,7 +50,6 @@ namespace OfficeOpenXml.ConditionalFormatting
                 CfIndex = new QuadTree<IExcelConditionalFormattingRule>(_ws.Dimension);
             }
         }
-        internal QuadTree<IExcelConditionalFormattingRule> CfIndex { get; set; }
 
         internal void ReadRegularConditionalFormattings(XmlReader xr)
         {

--- a/src/EPPlus/Core/RangeQuadTree/QuadTree.cs
+++ b/src/EPPlus/Core/RangeQuadTree/QuadTree.cs
@@ -154,6 +154,40 @@ namespace OfficeOpenXml.Core.RangeQuadTree
             Root.Clear(range, item);
         }
 
+        internal void UpdateAddress(ExcelAddressBase addressToClear, ExcelAddressBase addressToAdd, T item)
+        {
+            if (addressToClear != null)
+            {
+                if (addressToClear.Addresses == null)
+                {
+                    Clear(addressToClear._fromRow, addressToClear._fromCol, addressToClear._toRow, addressToClear._toCol, item);
+                }
+                else
+                {
+                    foreach (var a in addressToClear.Addresses)
+                    {
+                        Clear(a._fromRow, a._fromCol, a._toRow, a._toCol, item);
+                    }
+                }
+            }
+
+            if (addressToAdd != null)
+            {
+                if (addressToAdd.Addresses == null)
+                {
+                    Add(new QuadRange(addressToAdd), item);
+                }
+                else
+                {
+                    foreach (var a in addressToAdd.Addresses)
+                    {
+                        Add(new QuadRange(a), item);
+                    }
+                }
+            }
+        }
+
+
         internal void UpdateAddress(ExcelAddress addressToClear, ExcelAddress addressToAdd, T item)
         {
             if (addressToClear != null)

--- a/src/EPPlus/ExcelRangeBase.cs
+++ b/src/EPPlus/ExcelRangeBase.cs
@@ -1362,6 +1362,11 @@ namespace OfficeOpenXml
             _changePropMethod(this, _setIsRichTextDelegate, value);
         }
 
+        internal bool IntersectsWithTable()
+        {
+            return _worksheet.Tables.GetIntersectingRanges(this).Count > 0;
+        }
+
         /// <summary>
         /// Insert cells into the worksheet and shift the cells to the selected direction.
         /// </summary>
@@ -2122,6 +2127,17 @@ namespace OfficeOpenXml
             {
                 throw (new Exception("An array formula cannot have more than one address"));
             }
+
+            if(IntersectsWithTable())
+            {
+                //Array formulas are only allowed in tables as CalculatedColumn formula
+                //Or single-cell. Excel does not allow multi-cell array formulas in tables.
+                if(Start.Address != End.Address)
+                {
+                    throw (new InvalidOperationException("Multi-Cell array formulas are not allowed in tables."));
+                }
+            }
+
             Set_SharedFormula(this, ArrayFormula, this, true, isDynamic);
         }
         /// <summary>

--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -50,6 +50,7 @@ using System.Linq;
 using System.Text;
 using System.Xml;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
+using OfficeOpenXml.Core.RangeQuadTree;
 
 namespace OfficeOpenXml
 {

--- a/src/EPPlus/Table/ExcelTable.cs
+++ b/src/EPPlus/Table/ExcelTable.cs
@@ -28,6 +28,8 @@ using System.Globalization;
 using OfficeOpenXml.Sorting;
 using OfficeOpenXml.Export.HtmlExport.Interfaces;
 using System.Linq;
+using OfficeOpenXml.Core.RangeQuadTree;
+
 
 #if !NET35 && !NET40
 using System.Threading.Tasks;
@@ -265,6 +267,11 @@ namespace OfficeOpenXml.Table
             }
             internal set
             {
+                if(_address != null && WorkSheet != null)
+                {
+                    WorkSheet.Tables.qtTables.UpdateAddress(_address, value, this);
+                }
+
                 _address = value;
                 if(value!=null)
                 {

--- a/src/EPPlus/Table/ExcelTableCollection.cs
+++ b/src/EPPlus/Table/ExcelTableCollection.cs
@@ -13,9 +13,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Xml;
 using System.Xml.Linq;
+using OfficeOpenXml.Core.RangeQuadTree;
 using OfficeOpenXml.FormulaParsing.ExcelUtilities;
 namespace OfficeOpenXml.Table
 {
@@ -26,17 +26,30 @@ namespace OfficeOpenXml.Table
     {
         List<ExcelTable> _tables = new List<ExcelTable>();
         internal Dictionary<string, int> _tableNames = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        ExcelWorksheet _ws;        
+        ExcelWorksheet _ws;
+        internal QuadTree<ExcelTable> qtTables;
+
         internal ExcelTableCollection(ExcelWorksheet ws)
         {
             var pck = ws._package.ZipPackage;
             _ws = ws;
-            foreach(XmlElement node in ws.WorksheetXml.SelectNodes("//d:tableParts/d:tablePart", ws.NameSpaceManager))
+
+            if (_ws == null || _ws.Dimension == null)
+            {
+                qtTables = new QuadTree<ExcelTable>();
+            }
+            else
+            {
+                qtTables = new QuadTree<ExcelTable>(_ws.Dimension);
+            }
+
+            foreach (XmlElement node in ws.WorksheetXml.SelectNodes("//d:tableParts/d:tablePart", ws.NameSpaceManager))
             {
                 var rel = ws.Part.GetRelationship(node.GetAttribute("id",ExcelPackage.schemaRelationships));
                 var tbl = new ExcelTable(rel, ws);
                 _tableNames.Add(tbl.Name, _tables.Count);
                 _tables.Add(tbl);
+                qtTables.Add(new QuadRange(tbl.Address), tbl);
             }
         }
         private ExcelTable Add(ExcelTable tbl)
@@ -99,7 +112,9 @@ namespace OfficeOpenXml.Table
                 }
             }
 
-            return Add(new ExcelTable(_ws, Range, name, _ws.Workbook._nextTableID, copy));
+            var tableToAdd = new ExcelTable(_ws, Range, name, _ws.Workbook._nextTableID, copy);
+            qtTables.Add(new QuadRange(tableToAdd.Address), tableToAdd);
+            return Add(tableToAdd);
         }
 
         private void ValidateName(string name)
@@ -269,6 +284,11 @@ namespace OfficeOpenXml.Table
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
             return _tables.GetEnumerator();
+        }
+
+        internal List<QuadRangeItem<ExcelTable>> GetIntersectingRanges(ExcelAddress address)
+        {
+            return qtTables.GetIntersectingRangeItems(new QuadRange(address));
         }
     }
 }

--- a/src/EPPlusTest/FormulaParsing/ArrayFormulaTests.cs
+++ b/src/EPPlusTest/FormulaParsing/ArrayFormulaTests.cs
@@ -111,6 +111,7 @@ namespace EPPlusTest.FormulaParsing
             }
         }
         [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
         public void DynamicArrayFormulaWithTwoCellsInTableGenerateCorruptWorkbook()
         {
             using (var package = OpenPackage("DynamicArrayTableNew.xlsx", true))
@@ -127,6 +128,7 @@ namespace EPPlusTest.FormulaParsing
         }
 
         [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
         public void DynamicArrayFormulaWithTwoCellsInTableGenerateCorruptWorkbook2()
         {
             using (var package = OpenPackage("DynamicArrayTableNew.xlsx", true))

--- a/src/EPPlusTest/Issues/TableIssues.cs
+++ b/src/EPPlusTest/Issues/TableIssues.cs
@@ -82,5 +82,87 @@ namespace EPPlusTest.Issues
 
             SaveAndCleanup(package);
         }
+
+        /// <summary>
+        /// i1885
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void EpplusShouldThrowOnMultiCellArrayFormulaInTable()
+        {
+            using (var package = OpenPackage("Multi-CellArrayFormulaInTable.xlsx", true))
+            {
+                var wb = package.Workbook;
+                var sheet = wb.Worksheets.Add("newWorksheet");
+
+                var excelTable = sheet.Tables.Add(sheet.Cells["A1:D4"], "TableTest");
+
+                sheet.Cells["D2:D3"].CreateArrayFormula("SUM(A2:B2 * 1)", true);
+
+                SaveAndCleanup(package);
+            }
+        }
+
+        [TestMethod]
+        public void IntersectTableShouldWork()
+        {
+            using (var package = OpenPackage("TableIntersect.xlsx", true))
+            {
+                var wb = package.Workbook;
+                var ws = wb.Worksheets.Add("newWorksheet");
+
+                var excelTable = ws.Tables.Add(ws.Cells["E3:H10"], "TableTest");
+
+                var intersectsCovered = ws.Cells["F5"].IntersectsWithTable();
+                var intersectsLeft = ws.Cells["D4:E4"].IntersectsWithTable();
+                var intersectsTop = ws.Cells["E2:E3"].IntersectsWithTable();
+
+                var noIntersectTop = ws.Cells["E2:F2"].IntersectsWithTable();
+                var noIntersectBot = ws.Cells["E11:E12"].IntersectsWithTable();
+
+                Assert.IsTrue(intersectsCovered);
+                Assert.IsTrue(intersectsLeft);
+                Assert.IsTrue(intersectsTop);
+
+                Assert.IsFalse(noIntersectTop);
+                Assert.IsFalse(noIntersectBot);
+
+                SaveAndCleanup(package);
+            }
+        }
+
+        [TestMethod]
+        public void IntersectTableShouldWorkInsertDelete()
+        {
+            using (var package = OpenPackage("TableIntersectInsertDelete.xlsx", true))
+            {
+                var wb = package.Workbook;
+                var ws = wb.Worksheets.Add("newWorksheet");
+
+                var excelTable = ws.Tables.Add(ws.Cells["E3:H10"], "TableTest");
+
+                ws.InsertColumn(2, 1);
+
+                //False after insert
+                var intersectsLeft = ws.Cells["D4:E4"].IntersectsWithTable();
+                Assert.IsFalse(intersectsLeft);
+
+                //True after insert
+                var intersectsRight = ws.Cells["I4:I4"].IntersectsWithTable();
+                Assert.IsTrue(intersectsRight);
+
+                ws.DeleteColumn(2);
+
+                //True after delete
+                intersectsLeft = ws.Cells["D4:E4"].IntersectsWithTable();
+                Assert.IsTrue(intersectsRight);
+
+                //False after delete
+                intersectsRight = ws.Cells["I4:I4"].IntersectsWithTable();
+                Assert.IsFalse(intersectsRight);
+
+                SaveAndCleanup(package);
+            }
+        }
     }
 }


### PR DESCRIPTION
Before submitting this pull request I have...
- [x] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [x] ensured that the functionality I have added/changed is covered by new unit tests.
- [x] merged the target branch into the PR branch and resolved any merge conflicts
- [x] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).

Fix for #1885 
Additionally made cell ranges able to detect if intersecting with tables.
Currently not public/does not return the relevant table(s)