### PR TITLE
Fix for issue 1951-Autofit should consider WrapText cells

### DIFF
--- a/src/EPPlus.Interfaces/Drawing/Text/ITextMeasurer.cs
+++ b/src/EPPlus.Interfaces/Drawing/Text/ITextMeasurer.cs
@@ -31,9 +31,9 @@ namespace OfficeOpenXml.Interfaces.Drawing.Text
         /// <returns></returns>
         TextMeasurement MeasureText(string text, MeasurementFont font);
         /// <summary>
-        /// Should return true if the text measurer should measure wrap text cells. Only CR, LF or CRLF should be considered
+        /// If the text measurer should measure wrap text cells. 
+        /// Only CR, LF or CRLF should be considered.
         /// </summary>
-        /// <returns>True if the measurer can be .</returns>
         bool MeasureWrappedTextCells { get; set; }
     }
 }

--- a/src/EPPlus.Interfaces/Drawing/Text/ITextMeasurer.cs
+++ b/src/EPPlus.Interfaces/Drawing/Text/ITextMeasurer.cs
@@ -30,5 +30,10 @@ namespace OfficeOpenXml.Interfaces.Drawing.Text
         /// <param name="font">The <see cref="MeasurementFont">font</see> to measure</param>
         /// <returns></returns>
         TextMeasurement MeasureText(string text, MeasurementFont font);
+        /// <summary>
+        /// Should return true if the text measurer should measure wrap text cells. Only CR, LF or CRLF should be considered
+        /// </summary>
+        /// <returns>True if the measurer can be .</returns>
+        bool MeasureWrappedTextCells { get; set; }
     }
 }

--- a/src/EPPlus.System.Drawing/Drawing/Text/SystemDrawingTextMeasurer.cs
+++ b/src/EPPlus.System.Drawing/Drawing/Text/SystemDrawingTextMeasurer.cs
@@ -8,6 +8,10 @@ namespace OfficeOpenXml.SystemDrawing.Text
 #pragma warning disable CA1416 // Platform compatibility warning
     public class SystemDrawingTextMeasurer : ITextMeasurer, IDisposable
     {
+        /// <summary>
+        /// If the text measurer should measure wrap text cells. 
+        /// Only CR, LF or CRLF should be considered.
+        /// </summary>
         public bool MeasureWrappedTextCells
         {
             get;

--- a/src/EPPlus.System.Drawing/Drawing/Text/SystemDrawingTextMeasurer.cs
+++ b/src/EPPlus.System.Drawing/Drawing/Text/SystemDrawingTextMeasurer.cs
@@ -8,11 +8,16 @@ namespace OfficeOpenXml.SystemDrawing.Text
 #pragma warning disable CA1416 // Platform compatibility warning
     public class SystemDrawingTextMeasurer : ITextMeasurer, IDisposable
     {
+        public bool MeasureWrappedTextCells
+        {
+            get;
+            set;
+        }
         public SystemDrawingTextMeasurer()
         {
             if (Environment.OSVersion.Platform == PlatformID.Win32NT &&
             Environment.OSVersion.Version.Major >= 6 &&
-            Environment.OSVersion.Version.Minor >= 1)
+            Environment.OSVersion.Version.Minor >= 0)
             {
                 _stringFormat = StringFormat.GenericDefault;
                 _bmp = new Bitmap(1, 1);
@@ -81,7 +86,7 @@ namespace OfficeOpenXml.SystemDrawing.Text
             float dpiCorrectX, dpiCorrectY;
             try
             {
-                //Check for missing GDI+, then use WPF istead.
+                //Check for missing GDI+, then use WPF instead.
                 _graphics.PageUnit = GraphicsUnit.Pixel;
                 dpiCorrectX = 96 / _graphics.DpiX;
                 dpiCorrectY = 96 / _graphics.DpiY;

--- a/src/EPPlus/Core/AutofitHelper.cs
+++ b/src/EPPlus/Core/AutofitHelper.cs
@@ -16,6 +16,7 @@ using OfficeOpenXml.Core.Worksheet.Core.Worksheet.Fonts.GenericMeasurements;
 using OfficeOpenXml.Interfaces.Drawing.Text;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using static OfficeOpenXml.ExcelAddressBase;
 
 namespace OfficeOpenXml.Core
@@ -87,7 +88,7 @@ namespace OfficeOpenXml.Core
             if (normalFont.Strike) fontStyle |= MeasurementFontStyles.Strikeout;
             var normalSize = Convert.ToSingle(FontSize.GetWidthPixels(normalFont.Name, normalFont.Size));
 
-            //Get any autofilter to widen these columns
+            //Get any auto filter to widen these columns
             var afAddr = new List<ExcelAddressBase>();
             if (worksheet.AutoFilter.Address != null)
             {
@@ -108,6 +109,7 @@ namespace OfficeOpenXml.Core
                     afAddr[afAddr.Count - 1]._ws = _range.WorkSheetName;
                 }
             }
+ 
             for (int col = fromCol; col <= toCol; col++)
             {
                 if (worksheet.Column(col).Hidden)    //Issue 15338
@@ -132,7 +134,8 @@ namespace OfficeOpenXml.Core
                 foreach (var cell in worksheet.Cells[fromRow, col, toRow, col])
                 {
                     var cellStyleId = styles.CellXfs[cell.StyleID];
-                    if (cell.Merge == true || cellStyleId.WrapText) continue;
+                    if (cell.Merge == true) continue;
+                    if (cellStyleId.WrapText && _textSettings.MeasureWrappedTextCells == false) continue;
                     currentMaxWidth = GetTextLength(cell, textLengthCache, styles, cellStyleId, normalSize, MaximumWidth, currentMaxWidth);
                     if (currentMaxWidth >= MaximumWidth)
                     {
@@ -173,16 +176,21 @@ namespace OfficeOpenXml.Core
                 };
                 _fontCache.Add(fontID, measurementFont);
             }
+
             var indent = cellStyleId.Indent;
             var textForWidth = cell.TextForWidth;
             var text = textForWidth + (indent > 0 && !string.IsNullOrEmpty(textForWidth) ? new string('_', indent) : "");
             if (text.Length > 32000) { text = text.Substring(0, 32000); } //Issue
+            
+            if(cell.Style.WrapText==false)
+            {
+                text = text.Replace("\r","").Replace("\n","");
+            }
 
             if (textLengthCache.ContainsKey(measurementFont) && text.Length < textLengthCache[measurementFont] * _textSettings.textLengthThreshold)
             {
                 return currentMaxWidth;
             }
-
             var size = MeasureString(text, fontID, measureCache);
 
             double width;

--- a/src/EPPlus/Core/Worksheet/Fonts/GenericFontMetrics/GenericFontMetricsTextMeasurer.cs
+++ b/src/EPPlus/Core/Worksheet/Fonts/GenericFontMetrics/GenericFontMetricsTextMeasurer.cs
@@ -19,6 +19,12 @@ namespace OfficeOpenXml.Core.Worksheet.Core.Worksheet.Fonts.GenericMeasurements
 {
     internal class GenericFontMetricsTextMeasurer : GenericFontMetricsTextMeasurerBase, ITextMeasurer
     {
+        public bool MeasureWrappedTextCells 
+{
+            get; 
+            set; 
+        }
+
         /// <summary>
         /// Measures the supplied text
         /// </summary>
@@ -29,7 +35,7 @@ namespace OfficeOpenXml.Core.Worksheet.Core.Worksheet.Fonts.GenericMeasurements
         {
             var fontKey = GetKey(font.FontFamily, font.Style);
             if (!IsValidFont(fontKey)) return TextMeasurement.Empty;
-            return MeasureTextInternal(text, fontKey, font.Style, font.Size);
+            return MeasureTextInternal(text, fontKey, font.Style, font.Size, MeasureWrappedTextCells);
         }
 
         public bool ValidForEnvironment()

--- a/src/EPPlus/Core/Worksheet/Fonts/GenericFontMetrics/GenericFontMetricsTextMeasurer.cs
+++ b/src/EPPlus/Core/Worksheet/Fonts/GenericFontMetrics/GenericFontMetricsTextMeasurer.cs
@@ -19,12 +19,15 @@ namespace OfficeOpenXml.Core.Worksheet.Core.Worksheet.Fonts.GenericMeasurements
 {
     internal class GenericFontMetricsTextMeasurer : GenericFontMetricsTextMeasurerBase, ITextMeasurer
     {
+        /// <summary>
+        /// If the text measurer should measure wrap text cells. 
+        /// Only CR, LF or CRLF should be considered.
+        /// </summary>
         public bool MeasureWrappedTextCells 
 {
             get; 
             set; 
         }
-
         /// <summary>
         /// Measures the supplied text
         /// </summary>

--- a/src/EPPlus/Core/Worksheet/Fonts/GenericFontMetrics/GenericFontMetricsTextMeasurerBase.cs
+++ b/src/EPPlus/Core/Worksheet/Fonts/GenericFontMetrics/GenericFontMetricsTextMeasurerBase.cs
@@ -47,17 +47,30 @@ namespace OfficeOpenXml.Core.Worksheet.Fonts.GenericFontMetrics
             return _fonts.ContainsKey(fontKey);
         }
 
-        internal protected TextMeasurement MeasureTextInternal(string text, uint fontKey, MeasurementFontStyles style, float size)
+        internal protected TextMeasurement MeasureTextInternal(string text, uint fontKey, MeasurementFontStyles style, float size, bool wrapText = false)
         {
             var sFont = _fonts[fontKey];
             var width = 0f;
+            var maxWidth = 0f;
             var widthEA = 0f;
-            var chars = text.ToCharArray();
-            for (var x = 0; x < chars.Length; x++)
+            for (var x = 0; x < text.Length; x++)
             {
                 var fnt = sFont;
-                var c = chars[x];
-                // if east asian char use default regardless of actual font.
+                var c = text[x];
+                if(wrapText && (c=='\n' || c=='\r'))
+                {
+                    if(x>0 && c=='\r' && text[x-1]=='\n')
+                    {
+                        continue; //CRLF should be handled as one new line.
+                    }
+                    if(width>maxWidth)
+                    {
+                        maxWidth = width;
+                        width = 0;
+                    }
+                }
+
+                //If east Asian char use default regardless of actual font.
                 if (IsEastAsianChar(c))
                 {
                     widthEA += GetEastAsianCharWidth(c, style);
@@ -70,12 +83,15 @@ namespace OfficeOpenXml.Core.Worksheet.Fonts.GenericFontMetrics
                         if (Char.IsDigit(c)) fw *= FontScaleFactors.DigitsScalingFactor;
                         width += fw;
                     }
-                    else
+                    else if (char.IsControl(c)==false)
                     {
                         width += sFont.ClassWidths[fnt.DefaultWidthClass];
                     }
                 }
-
+            }
+            if(maxWidth > width)
+            {
+                width = maxWidth;
             }
             width *= size;
             widthEA *= size;

--- a/src/EPPlus/ExcelTextSettings.cs
+++ b/src/EPPlus/ExcelTextSettings.cs
@@ -27,28 +27,49 @@ namespace OfficeOpenXml
             PrimaryTextMeasurer = new GenericFontMetricsTextMeasurer();
             AutofitScaleFactor = 1f;
         }
-
+        ITextMeasurer _primaryTextMeasurer = null;
+        ITextMeasurer _fallbackTextMeasurer = null;
         /// <summary>
         /// This is the primary text measurer
         /// </summary>
-        public ITextMeasurer PrimaryTextMeasurer { get; set; }
-
+        public ITextMeasurer PrimaryTextMeasurer 
+        { 
+            get 
+            {
+                return _primaryTextMeasurer;
+            } 
+            set 
+            { 
+                _primaryTextMeasurer = value;
+                _primaryTextMeasurer.MeasureWrappedTextCells = _measureWrappedTextCells;
+            } 
+        }
         /// <summary>
         /// If the primary text measurer fails to measure the text, this one will be used.
         /// </summary>
-        public ITextMeasurer FallbackTextMeasurer { get; set; }
-
+        public ITextMeasurer FallbackTextMeasurer
+        {
+            get
+            {
+                return _fallbackTextMeasurer;
+            }
+            set
+            {
+                _fallbackTextMeasurer = value;
+                _fallbackTextMeasurer.MeasureWrappedTextCells = _measureWrappedTextCells;
+            }
+        }
         /// <summary>
         /// All measurements of texts will be multiplied with this value. Default is 1.
         /// </summary>
         public float AutofitScaleFactor { get; set; }
         /// <summary>
-        /// A percentage of the widest text. Since charaters in different fonts have different widths we use this threshold remove characters from the longer string for comparing to the current text.
+        /// A percentage of the widest text. Since characters in different fonts have different widths we use this threshold remove characters from the longer string for comparing to the current text.
         /// This is so we can skip obvious shorter strings and save time on calculating it's actual width.
         /// </summary>
         public double textLengthThreshold = 0.5d;
         /// <summary>
-        /// The ammount of rows to check for when autofitting, starts from top. A value set to 0 or lower means checking all rows in the column.
+        /// The amount of rows to check for when autofitting, starts from top. A value set to 0 or lower means checking all rows in the column.
         /// </summary>
         public int AutofitRows = 5000;
         /// <summary>
@@ -66,5 +87,23 @@ namespace OfficeOpenXml
         /// Measures a text with default settings when there is no other option left...
         /// </summary>
         internal DefaultTextMeasurer DefaultTextMeasurer { get; set; }
+        /// <summary>
+        /// Should return true if the text measurer should measure wrap text cells. Only CR, LF or CRLF should be considered
+        /// </summary>
+        /// <returns>True if the measurer can be .</returns>
+        bool _measureWrappedTextCells=false;
+        internal bool MeasureWrappedTextCells 
+        { 
+            get
+            {
+                return _measureWrappedTextCells;
+            }
+            set
+            {
+                _measureWrappedTextCells = value;
+                PrimaryTextMeasurer.MeasureWrappedTextCells = value;
+                if (FallbackTextMeasurer != null) FallbackTextMeasurer.MeasureWrappedTextCells = value;
+            }
+        }
     }
 }

--- a/src/EPPlusTest/EPPlus.Test.csproj
+++ b/src/EPPlusTest/EPPlus.Test.csproj
@@ -36,6 +36,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\EPPlus\EPPlus.csproj" />
+		<ProjectReference Include="..\EPPlus.System.Drawing\EPPlus.System.Drawing.csproj" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="FakeItEasy" />

--- a/src/EPPlusTest/Issues/WorksheetIssues.cs
+++ b/src/EPPlusTest/Issues/WorksheetIssues.cs
@@ -802,22 +802,46 @@ namespace EPPlusTest.Issues
         {
             using (var p = OpenPackage("I1951.xlsx", true))
             {
+                var ws = p.Workbook.Worksheets.Add("GenericTM");
+
+                AddMeasureSheet(p, ws);
+                
 				p.Settings.TextSettings.PrimaryTextMeasurer = new SystemDrawingTextMeasurer();
-				p.Settings.TextSettings.MeasureWrappedTextCells = true;
-                var ws = p.Workbook.Worksheets.Add("Sheet1");
-
-                string multiLineText = "Line one" + Environment.NewLine + "Line two is longer" + "\n" + "Extra line";
-
-                ws.Cells["A1"].Value = multiLineText;
-                ws.Cells["A1"].Style.WrapText = true;
-
-                ws.Cells["B2"].Value = multiLineText;
-
-                // AutoFitColumns - calculates width as if there were no line breaks.
-                ws.Cells[ws.Dimension.Address].AutoFitColumns();
+                ws = p.Workbook.Worksheets.Add("SystemDrawingTM");
+                AddMeasureSheet(p, ws);
 
                 SaveAndCleanup(p);
-             }
+            }
+        }
+
+        private static void AddMeasureSheet(ExcelPackage p, ExcelWorksheet ws)
+        {
+            string multiLineText = "Line one" + Environment.NewLine + "Line two is longer" + "\n" + "Extra line";
+
+            ws.Cells["A1"].Value = multiLineText;
+            ws.Cells["A1"].Style.WrapText = true;
+
+            ws.Cells["B2"].Value = multiLineText;
+
+            ws.Cells["C1"].Value = multiLineText;
+            ws.Cells["A1"].Style.WrapText = true;
+
+            ws.Cells["B2"].Value = multiLineText;
+
+            p.Settings.TextSettings.MeasureWrappedTextCells = true;
+            // AutoFitColumns - calculates width as if there were no line breaks.
+            ws.Cells["A1:B2"].AutoFitColumns();
+
+
+            p.Settings.TextSettings.MeasureWrappedTextCells = false;
+
+            ws.Cells["C1"].Value = multiLineText;
+            ws.Cells["C1"].Style.WrapText = true;
+
+            ws.Cells["D2"].Value = multiLineText;
+
+            // AutoFitColumns - calculates width as if there were no line breaks.
+            ws.Cells["C1:D2"].AutoFitColumns();
         }
     }
 }

--- a/src/EPPlusTest/Issues/WorksheetIssues.cs
+++ b/src/EPPlusTest/Issues/WorksheetIssues.cs
@@ -832,12 +832,9 @@ namespace EPPlusTest.Issues
             // AutoFitColumns - calculates width as if there were no line breaks.
             ws.Cells["A1:B2"].AutoFitColumns();
 
-
             p.Settings.TextSettings.MeasureWrappedTextCells = false;
-
             ws.Cells["C1"].Value = multiLineText;
             ws.Cells["C1"].Style.WrapText = true;
-
             ws.Cells["D2"].Value = multiLineText;
 
             // AutoFitColumns - calculates width as if there were no line breaks.

--- a/src/EPPlusTest/Issues/WorksheetIssues.cs
+++ b/src/EPPlusTest/Issues/WorksheetIssues.cs
@@ -2,6 +2,8 @@
 using OfficeOpenXml;
 using OfficeOpenXml.Core;
 using OfficeOpenXml.FormulaParsing;
+using OfficeOpenXml.SystemDrawing.Image;
+using OfficeOpenXml.SystemDrawing.Text;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -795,6 +797,27 @@ namespace EPPlusTest.Issues
                 Assert.AreEqual(timeSpanCell.Ticks, new TimeSpan(12, 30, 45).Ticks);
             }
         }
+        [TestMethod]
+        public void i1951()
+        {
+            using (var p = OpenPackage("I1951.xlsx", true))
+            {
+				p.Settings.TextSettings.PrimaryTextMeasurer = new SystemDrawingTextMeasurer();
+				p.Settings.TextSettings.MeasureWrappedTextCells = true;
+                var ws = p.Workbook.Worksheets.Add("Sheet1");
 
+                string multiLineText = "Line one" + Environment.NewLine + "Line two is longer" + "\n" + "Extra line";
+
+                ws.Cells["A1"].Value = multiLineText;
+                ws.Cells["A1"].Style.WrapText = true;
+
+                ws.Cells["B2"].Value = multiLineText;
+
+                // AutoFitColumns - calculates width as if there were no line breaks.
+                ws.Cells[ws.Dimension.Address].AutoFitColumns();
+
+                SaveAndCleanup(p);
+             }
+        }
     }
 }


### PR DESCRIPTION
Added new functionality to auto fit columns with the WrapText style set.
* Added MeasureWrappedTextCells to TextSettings.
* Added MeasureWrappedTextCells to ITextMeasurer.MeasureWrappedTextCells
* Implemented new interface in GenericFontMetricsTextMeasurer and SystemDrawingTextMeasurer classes.

Fix for issue #1951