### PR TITLE
Fixes #1989

### DIFF
--- a/src/EPPlus/Core/Worksheet/XmlWriter/WorksheetXmlWriter.cs
+++ b/src/EPPlus/Core/Worksheet/XmlWriter/WorksheetXmlWriter.cs
@@ -1650,7 +1650,7 @@ namespace OfficeOpenXml.Core.Worksheet.XmlWriter
             }
             else if (icon.Value != double.NaN)
             {
-                cache.Append($"val=\"{icon.Value}\" ");
+                cache.Append($"val=\"{icon.Value.ToString(CultureInfo.InvariantCulture)}\" ");
             }
 
             if (icon.GreaterThanOrEqualTo == false && gteCheck == true)


### PR DESCRIPTION
Fixes #1989 

Updated the appending of `icon.Value` to use CultureInfo.InvariantCulture for consistent string representation, avoiding culture-specific formatting issues.

Before submitting this pull request I have...
- [x] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [x] ensured that the functionality I have added/changed is covered by new unit tests.
- [x] merged the target branch into the PR branch and resolved any merge conflicts
- [x] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).
