### PR TITLE
Fix issue with double read from input stream

### DIFF
--- a/src/EPPlus/ExcelPackage.cs
+++ b/src/EPPlus/ExcelPackage.cs
@@ -1276,11 +1276,6 @@ namespace OfficeOpenXml
                     ms.Dispose();
                     ms = decrStream;
                 }
-                else
-                {
-                    ms = RecyclableMemory.GetStream();
-                    StreamUtil.CopyStream(input, ref ms);
-                }
 
                 try
                 {


### PR DESCRIPTION
Before submitting this pull request I have...
- [X] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [X] ensured that the functionality I have added/changed is covered by new unit tests.
- [X] merged the target branch into the PR branch and resolved any merge conflicts
- [X] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).

Fix in loading stream with CanSeek false. Input is copied twice to memory stream without resetting the position of the input stream. I do not see a reason why this copy is done twice. Seems to be a bug introduced in following feature: https://github.com/EPPlusSoftware/EPPlus/pull/1780/files#diff-ead7af3bec72900002aac92ad558326228312e0d9dc3ce86b7f6ced5afa6ddf6
I removed the second copy so the memory stream is correctly filled.