### PR TITLE
#2007 - fix for CircularReferenceException with dynamic arrays

### DIFF
--- a/src/EPPlus/FormulaParsing/DependencyChain/RpnFormulaExecution.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/RpnFormulaExecution.cs
@@ -2,6 +2,7 @@
 using OfficeOpenXml.Core.CellStore;
 using OfficeOpenXml.Core.RangeQuadTree;
 using OfficeOpenXml.FormulaParsing.Excel.Functions;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.LookupUtils;
 using OfficeOpenXml.FormulaParsing.Excel.Operators;
 using OfficeOpenXml.FormulaParsing.Exceptions;
@@ -915,16 +916,25 @@ namespace OfficeOpenXml.FormulaParsing
         private static void CheckCircularReferences(RpnOptimizedDependencyChain depChain, RpnFormula f, FormulaRangeAddress address, ExcelCalculationOption options)
         {
             if (f._ws == null) return;
-            if(f._arrayIndex>=0)
+            var wsIx = f._ws?.IndexInList ?? ushort.MaxValue;
+            if (f._arrayIndex>=0)
             {
                 var sf = f._ws._sharedFormulas[f._arrayIndex];
                 var fa = new FormulaRangeAddress(depChain._parsingContext) { FromRow = sf.StartRow, ToRow = sf.EndRow, FromCol = sf.StartCol, ToCol = sf.EndCol, WorksheetIx = f._ws.IndexInList };
                 if (fa.CollidesWith(address) != eAddressCollition.No)
                 {
-                    throw new CircularReferenceException($"Circular reference in array formula: {fa.Address}");
+                    if(!options.AllowCircularReferences)
+                    {
+                        throw new CircularReferenceException($"Circular reference in array formula: {fa.Address}");
+                    }
+                    else
+                    {
+                        var toCell = ExcelCellBase.GetCellId(wsIx, sf.StartRow, sf.StartCol);
+                        var fromCell = ExcelCellBase.GetCellId(f._ws.IndexInList, f._row, f._column);
+                        depChain._circularReferences.Add(new CircularReference(fromCell, toCell));
+                    }
                 }
             }
-            var wsIx=f._ws?.IndexInList ?? ushort.MaxValue;
             if (address.CollidesWith(wsIx, f._row, f._column))
             {
                 var fId = ExcelCellBase.GetCellId(f._ws.IndexInList, f._row, f._column);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/ChooseBaseFunction.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/ChooseBaseFunction.cs
@@ -21,6 +21,16 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
     {
         public override string NamespacePrefix => "_xlfn.";
         public override int ArgumentMinLength => 2;
+
+        public override ExcelFunctionParametersInfo ParametersInfo => new ExcelFunctionParametersInfo(new Func<int, FunctionParameterInformation>((argumentIndex) =>
+        {
+            if (argumentIndex == 0)
+            {
+                return FunctionParameterInformation.IgnoreAddress;
+            }
+            return FunctionParameterInformation.Normal;
+        }));
+
         protected List<int> GetChooseColumns(IList<FunctionArgument> arguments, out eErrorType? ev)
         {
             var cols = new List<int>();

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -962,7 +962,7 @@ namespace EPPlusTest.Issues
 		[TestMethod]
 		public void Issue864()
 		{
-			using var p1 = new ExcelPackage(@"C:\Temp\EPPlus Supportcases\Supportcase864\Test.xlsx");
+			using var p1 = OpenTemplatePackage(@"sc864.xlsx");
 			var sheet = p1.Workbook.Worksheets["Aico data"];
 			try
 			{

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -958,6 +958,24 @@ namespace EPPlusTest.Issues
 
             Assert.AreEqual(12977661.57, result2);
         }
+
+		[TestMethod]
+		public void Issue864()
+		{
+			using var p1 = new ExcelPackage(@"C:\Temp\EPPlus Supportcases\Supportcase864\Test.xlsx");
+			var sheet = p1.Workbook.Worksheets["Aico data"];
+			try
+			{
+                sheet.Calculate(o => o.AllowCircularReferences = true);
+            }
+			catch(Exception ex)
+			{
+				int i = 0;
+			}
+			
+			var f = sheet.Cells["C42"].Formula;
+			var v = sheet.Cells["C42"].Value;
+		}
     }
 }
 


### PR DESCRIPTION
See #2007 . This PR also contains a configuration where the ChooseBase abstract class for ChooseCols/ChooseRows ignores the first arg for circular reference checks.
