### PR TITLE
#2010 - String issues in formula calculations

### DIFF
--- a/src/EPPlus/FormulaParsing/DependencyChain/RpnOptimizedDependencyChain.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/RpnOptimizedDependencyChain.cs
@@ -48,6 +48,10 @@ namespace OfficeOpenXml.FormulaParsing
             QuadTree<ulong> qr;
             foreach (var address in addresses)
             {
+                if(address.ExternalReferenceIx > 0)
+                {
+                    return;
+                }
                 var ix = address.WorksheetIx; ;
                 if (FormulaRangeReferences.TryGetValue(ix, out qr) == false)
                 {

--- a/src/EPPlus/FormulaParsing/DependencyChain/RpnOptimizedDependencyChain.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/RpnOptimizedDependencyChain.cs
@@ -39,6 +39,7 @@ namespace OfficeOpenXml.FormulaParsing
                 config.CacheExpressions = options.CacheExpressions;
                 config.PrecisionAndRoundingStrategy = options.PrecisionAndRoundingStrategy;
                 config.AlwaysRefreshImageFunction = options.AlwaysRefreshImageFunction;
+                config.EnableUnicodeAwareStringOperations = options.EnableUnicodeAwareStringOperations;
             });
 
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Logical/Switch.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Logical/Switch.cs
@@ -32,6 +32,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Logical
         }
         public override string NamespacePrefix => "_xlfn.";
         public override int ArgumentMinLength => 3;
+
+        public override ExcelFunctionArrayBehaviour ArrayBehaviour => ExcelFunctionArrayBehaviour.FirstArgCouldBeARange;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
             var expression = arguments[0].ValueFirst;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Sequence.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Sequence.cs
@@ -43,7 +43,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                 if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
             }
             var start = 1d;
-            if(argCount > 2)
+            if(argCount > 2 && arguments[2].DataType != DataType.Empty)
             {
                 start = ArgToDecimal(arguments, 2, out ExcelErrorValue e3);
                 if (e3 != null) return CompileResult.GetErrorResult(e3.Type);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupUtils/LookupComparerBase.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupUtils/LookupComparerBase.cs
@@ -40,7 +40,23 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.LookupUtils
             }
             else
             {
+                if (x != null && y == null) return -1;
+                if (x == null && y != null) return 1;
                 v = ComparerUtil.CompareObjects(x, y);
+            }
+            return v * (sortOrder > -1 ? 1 : -1);
+        }
+
+        public virtual int Compare(object x, object y, int sortOrder, ParsingContext context)
+        {
+            int v = 0;
+            if (_matchMode == LookupMatchMode.Wildcard || _matchMode == LookupMatchMode.ExactMatchWithWildcard)
+            {
+                v = _vm.IsMatch(x, y);
+            }
+            else
+            {
+                v = ComparerUtil.CompareObjects(x, y, context);
             }
             return v * (sortOrder > -1 ? 1 : -1);
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/SortFunction.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/SortFunction.cs
@@ -41,11 +41,33 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             }
             var range = arg1.ValueAsRangeInfo;
             var rangeDef = new RangeDefinition(range.Size.NumberOfRows, range.Size.NumberOfCols);
-            var sortIndex = 1;
+            var sortIndexes = new List<int> { 1 };
             if(arguments.Count > 1)
             {
-                sortIndex = ArgToInt(arguments, 1, out ExcelErrorValue e1, 1);
-                if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+                if (arguments[1].IsExcelRange)
+                {
+                    sortIndexes.Clear();
+                    var rng = arguments[1].ValueAsRangeInfo;
+                    for(var row = 0; row < rng.Size.NumberOfRows; row++)
+                    {
+                        for(var col = 0; col < rng.Size.NumberOfCols; col++)
+                        {
+                            var indexObj = rng.GetOffset(row, col);
+                            if(indexObj is not int index)
+                            {
+                                return CompileResult.GetErrorResult(eErrorType.Value);
+                            }
+                            sortIndexes.Add(index);
+                        }
+                    }
+                }
+                else
+                {
+                    var sortIndex = ArgToInt(arguments, 1, out ExcelErrorValue e1, 1);
+                    if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
+                    sortIndexes[0] = sortIndex;
+                }
+                
             }
             var sortOrder = 1;
             if(arguments.Count > 2)
@@ -61,17 +83,21 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 
             //Validate
             var maxIndex = byCol ? range.Size.NumberOfCols : range.Size.NumberOfRows;
-            if (sortIndex < 1 || sortIndex > maxIndex) return CreateResult(eErrorType.Value);
+            foreach(var sortIndex in sortIndexes)
+            {
+                if (sortIndex < 1 || sortIndex > maxIndex) return CreateResult(eErrorType.Value);
+            }
+            
             if (sortOrder != -1 && sortOrder != 1) return CreateResult(eErrorType.Value);
-            var sortedRange = GetSortedRange(range, sortIndex, sortOrder, byCol);
+            var sortedRange = GetSortedRange(range, sortIndexes, sortOrder, byCol, context);
             return CreateDynamicArrayResult(sortedRange, DataType.ExcelRange);
         }
 
-        private InMemoryRange GetSortedRange(IRangeInfo sourceRange, int sortIndex, int sortOrder, bool byCol)
+        private InMemoryRange GetSortedRange(IRangeInfo sourceRange, List<int> sortIndexes, int sortOrder, bool byCol, ParsingContext context)
         {
             return byCol ?
-                _sorter.SortByCol(sourceRange, sortIndex, sortOrder) :
-                _sorter.SortByRow(sourceRange, sortIndex, sortOrder);
+                _sorter.SortByCol(sourceRange, sortIndexes, sortOrder, context) :
+                _sorter.SortByRow(sourceRange, sortIndexes, sortOrder, context);
         }
 		/// <summary>
 		/// If the function is allowed in a pivot table calculated field

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Sorting/InMemoryRangeSorter.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Sorting/InMemoryRangeSorter.cs
@@ -22,7 +22,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
     internal class InMemoryRangeSorter
     {
         private readonly LookupComparer _comparer = new LookupComparer(LookupMatchMode.ExactMatch);
-        public InMemoryRange SortByRow(IRangeInfo sourceRange, int colIndex, int sortOrder)
+        public InMemoryRange SortByCol(IRangeInfo sourceRange, List<int> rowIndexes, int sortOrder, ParsingContext context)
         {
             var rangeDef = new RangeDefinition(sourceRange.Size.NumberOfRows, sourceRange.Size.NumberOfCols);
             var sortedRange = new InMemoryRange(rangeDef);
@@ -38,28 +38,59 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
                 }
                 columns.Add(rows);
             }
-            var colIx = colIndex - 1;
-            var colToSortList = columns[colIx].ToList();
-            var sortedList = colToSortList.Where(x => x.Value != null).ToList();
-            sortedList.Sort((a, b) => _comparer.Compare(a.Value, b.Value, sortOrder));
-            var nullValues = colToSortList.Where(x => x.Value == null);
-            sortedList.AddRange(nullValues);
-            for (var row = 0; row < sortedList.Count; row++)
+            //var colIx = colIndex - 1;
+            //var colToSortList = columns[colIx].ToList();
+            //var sortedList = colToSortList.Where(x => x.Value != null).ToList();
+            //sortedList.Sort((a, b) => _comparer.Compare(a.Value, b.Value, sortOrder));
+            //var nullValues = colToSortList.Where(x => x.Value == null);
+            //sortedList.AddRange(nullValues);
+            //for (var row = 0; row < sortedList.Count; row++)
+            //{
+            //    var sortedColItem = sortedList[row];
+            //    sortedRange.SetValue(row, colIx, sortedColItem.Value);
+            //    for (var col = 0; col < columns.Count; col++)
+            //    {
+            //        if (col == colIx) continue;
+            //        var colItem = columns[col].GetByOriginalIndex(sortedColItem.OriginalIndex);
+            //        sortedRange.SetValue(row, col, colItem.Value);
+
+            //    }
+            //}
+            columns.Sort((a, b) =>
             {
-                var sortedColItem = sortedList[row];
-                sortedRange.SetValue(row, colIx, sortedColItem.Value);
-                for (var col = 0; col < columns.Count; col++)
+                foreach (var rowIx in rowIndexes)
                 {
-                    if (col == colIx) continue;
-                    var colItem = columns[col].GetByOriginalIndex(sortedColItem.OriginalIndex);
-                    sortedRange.SetValue(row, col, colItem.Value);
-                    
+                    var aColVal = a.GetByOriginalIndex(rowIx - 1);
+                    var bColVal = b.GetByOriginalIndex(rowIx - 1);
+                    if (aColVal.Value == null)
+                    {
+                        if (bColVal.Value == null) return 0;
+                        return 1;
+                    }
+                    else if (bColVal.Value == null)
+                    {
+                        return -1;
+                    }
+                    var res = _comparer.Compare(aColVal.Value, bColVal.Value, sortOrder, context);
+                    if (res != 0) return res;
                 }
+                return 0;
+            });
+            var colIx = 0;
+            foreach (var col in columns)
+            {
+                var cellIx = 0;
+                foreach (var cell in col.ToList())
+                {
+                    sortedRange.SetValue(cellIx, colIx, cell.Value);
+                    cellIx++;
+                }
+                colIx++;
             }
             return sortedRange;
         }
 
-        public InMemoryRange SortByCol(IRangeInfo sourceRange, int rowIndex, int sortOrder)
+        public InMemoryRange SortByRow(IRangeInfo sourceRange, List<int> colIndexes, int sortOrder, ParsingContext context)
         {
             var rangeDef = new RangeDefinition(sourceRange.Size.NumberOfRows, sourceRange.Size.NumberOfCols);
             var sortedRange = new InMemoryRange(rangeDef);
@@ -75,22 +106,93 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
                 }
                 rows.Add(cols);
             }
-            var rowIx = rowIndex - 1;
-            var rowToSortList = rows[rowIx].ToList();
-            rowToSortList.Sort((a, b) => _comparer.Compare(a.Value, b.Value, sortOrder));
-            for (var col = 0; col < rowToSortList.Count; col++)
-            {
-                var sortedRowItem = rowToSortList[col];
-                sortedRange.SetValue(rowIx, col, sortedRowItem.Value);
-                for (var row = 0; row < rows.Count; row++)
-                {
-                    if (row == rowIx) continue;
-                    var colItem = rows[row].GetByOriginalIndex(sortedRowItem.OriginalIndex);
-                    sortedRange.SetValue(row, col, colItem.Value);
+            //var rowIx = rowIndex - 1;
+            //var rowToSortList = rows[rowIx].ToList();
+            //rowToSortList.Sort((a, b) => _comparer.Compare(a.Value, b.Value, sortOrder));
+            //for (var col = 0; col < rowToSortList.Count; col++)
+            //{
+            //    var sortedRowItem = rowToSortList[col];
+            //    sortedRange.SetValue(rowIx, col, sortedRowItem.Value);
+            //    for (var row = 0; row < rows.Count; row++)
+            //    {
+            //        if (row == rowIx) continue;
+            //        var colItem = rows[row].GetByOriginalIndex(sortedRowItem.OriginalIndex);
+            //        sortedRange.SetValue(row, col, colItem.Value);
 
+            //    }
+            //}
+
+            rows.Sort((a, b) => 
+            { 
+                foreach(var colIx in colIndexes)
+                {
+                    var aColVal = a.GetByOriginalIndex(colIx - 1);
+                    var bColVal = b.GetByOriginalIndex(colIx - 1);
+                    if(aColVal.Value == null)
+                    {
+                        if (bColVal.Value == null) return 0;
+                        return 1;
+                    }
+                    else if(bColVal.Value == null)
+                    {
+                        return -1;
+                    }
+                    var res = _comparer.Compare(aColVal.Value, bColVal.Value, sortOrder, context);
+                    if (res != 0) return res;
                 }
+                return 0;
+            });
+            var rowIx = 0;
+            foreach(var row in rows)
+            {
+                var cellIx = 0;
+                foreach(var cell in row.ToList())
+                {
+                    sortedRange.SetValue(rowIx, cellIx, cell.Value);
+                    cellIx++;
+                }
+                rowIx++;
             }
             return sortedRange;
+        }
+
+        static int CompareExcelStyle(string s1, string s2)
+        {
+            // Konvertera strängarna till fullständiga Unicode-koder
+            var s1Codes = EnumerateRunes(s1).ToArray();
+            var s2Codes = EnumerateRunes(s2).ToArray();
+
+            // Jämför tecken för tecken baserat på deras Unicode-värden
+            int minLength = Math.Min(s1Codes.Length, s2Codes.Length);
+            for (int i = 0; i < minLength; i++)
+            {
+                if (s1Codes[i] != s2Codes[i])
+                    return s1Codes[i].CompareTo(s2Codes[i]);
+            }
+
+            // Om strängarna är identiska upp till minLength, jämför längden
+            return s1Codes.Length.CompareTo(s2Codes.Length);
+        }
+
+        static IEnumerable<int> EnumerateRunes(string input)
+        {
+            for (int i = 0; i < input.Length; i++)
+            {
+                char c = input[i];
+
+                // Kontrollera om det är en högställig surrogat (starten på ett par)
+                if (char.IsHighSurrogate(c) && i + 1 < input.Length && char.IsLowSurrogate(input[i + 1]))
+                {
+                    // Kombinera högställig och lågställig surrogat till en fullständig Unicode-kodpunkt
+                    yield return char.ConvertToUtf32(c, input[i + 1]);
+                    i++; // Hoppa över nästa tecken eftersom det är en del av surrogatparet
+                }
+                else
+                {
+                    // Enskilt tecken
+                    yield return c;
+                }
+            }
         }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Sorting/InMemoryRangeSorter.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Sorting/InMemoryRangeSorter.cs
@@ -38,24 +38,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
                 }
                 columns.Add(rows);
             }
-            //var colIx = colIndex - 1;
-            //var colToSortList = columns[colIx].ToList();
-            //var sortedList = colToSortList.Where(x => x.Value != null).ToList();
-            //sortedList.Sort((a, b) => _comparer.Compare(a.Value, b.Value, sortOrder));
-            //var nullValues = colToSortList.Where(x => x.Value == null);
-            //sortedList.AddRange(nullValues);
-            //for (var row = 0; row < sortedList.Count; row++)
-            //{
-            //    var sortedColItem = sortedList[row];
-            //    sortedRange.SetValue(row, colIx, sortedColItem.Value);
-            //    for (var col = 0; col < columns.Count; col++)
-            //    {
-            //        if (col == colIx) continue;
-            //        var colItem = columns[col].GetByOriginalIndex(sortedColItem.OriginalIndex);
-            //        sortedRange.SetValue(row, col, colItem.Value);
-
-            //    }
-            //}
             columns.Sort((a, b) =>
             {
                 foreach (var rowIx in rowIndexes)
@@ -106,22 +88,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
                 }
                 rows.Add(cols);
             }
-            //var rowIx = rowIndex - 1;
-            //var rowToSortList = rows[rowIx].ToList();
-            //rowToSortList.Sort((a, b) => _comparer.Compare(a.Value, b.Value, sortOrder));
-            //for (var col = 0; col < rowToSortList.Count; col++)
-            //{
-            //    var sortedRowItem = rowToSortList[col];
-            //    sortedRange.SetValue(rowIx, col, sortedRowItem.Value);
-            //    for (var row = 0; row < rows.Count; row++)
-            //    {
-            //        if (row == rowIx) continue;
-            //        var colItem = rows[row].GetByOriginalIndex(sortedRowItem.OriginalIndex);
-            //        sortedRange.SetValue(row, col, colItem.Value);
-
-            //    }
-            //}
-
             rows.Sort((a, b) => 
             { 
                 foreach(var colIx in colIndexes)
@@ -154,45 +120,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
                 rowIx++;
             }
             return sortedRange;
-        }
-
-        static int CompareExcelStyle(string s1, string s2)
-        {
-            // Konvertera strängarna till fullständiga Unicode-koder
-            var s1Codes = EnumerateRunes(s1).ToArray();
-            var s2Codes = EnumerateRunes(s2).ToArray();
-
-            // Jämför tecken för tecken baserat på deras Unicode-värden
-            int minLength = Math.Min(s1Codes.Length, s2Codes.Length);
-            for (int i = 0; i < minLength; i++)
-            {
-                if (s1Codes[i] != s2Codes[i])
-                    return s1Codes[i].CompareTo(s2Codes[i]);
-            }
-
-            // Om strängarna är identiska upp till minLength, jämför längden
-            return s1Codes.Length.CompareTo(s2Codes.Length);
-        }
-
-        static IEnumerable<int> EnumerateRunes(string input)
-        {
-            for (int i = 0; i < input.Length; i++)
-            {
-                char c = input[i];
-
-                // Kontrollera om det är en högställig surrogat (starten på ett par)
-                if (char.IsHighSurrogate(c) && i + 1 < input.Length && char.IsLowSurrogate(input[i + 1]))
-                {
-                    // Kombinera högställig och lågställig surrogat till en fullständig Unicode-kodpunkt
-                    yield return char.ConvertToUtf32(c, input[i + 1]);
-                    i++; // Hoppa över nästa tecken eftersom det är en del av surrogatparet
-                }
-                else
-                {
-                    // Enskilt tecken
-                    yield return c;
-                }
-            }
         }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Sorting/SortByComparer.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Sorting/SortByComparer.cs
@@ -27,10 +27,18 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
 
         public override int Compare(object x, object y)
         {
-            return Compare(x, y, 1);
+            if (x == null && y != null)
+            {
+                return 1;
+            }
+            else if (x != null && y == null)
+            {
+                return -1;
+            }
+            return ComparerUtil.CompareObjects(x, y) * 1;
         }
 
-        public override int Compare(object x, object y, int sortOrder)
+        public override int Compare(object x, object y, int sortOrder, ParsingContext context)
         {
             // null values should always be sorted last
             if(x == null && y != null)
@@ -41,7 +49,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
             {
                 return -1;
             }
-            return ComparerUtil.CompareObjects(x, y) * sortOrder;
+            return ComparerUtil.CompareObjects(x, y, context) * sortOrder;
         }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Left.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Left.cs
@@ -13,6 +13,7 @@
 using System.Collections.Generic;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
+using OfficeOpenXml.Utils;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
 {
@@ -38,6 +39,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
             }
             if (str.Length < length)
                 length = str.Length;
+            if(context.Configuration.EnableUnicodeAwareStringOperations)
+            {
+                return CreateResult(str.UnitcodeSubstring(length), DataType.String);
+            }
             return CreateResult(str.Substring(0, length), DataType.String);
         }
     }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Rept.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Rept.cs
@@ -26,6 +26,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
     internal class Rept : ExcelFunction
     {
         public override int ArgumentMinLength => 2;
+
+        public override ExcelFunctionArrayBehaviour ArrayBehaviour => ExcelFunctionArrayBehaviour.Custom;
+
+        public override void ConfigureArrayBehaviour(ArrayBehaviourConfig config)
+        {
+            config.SetArrayParameterIndexes(0, 1);
+        }
+
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
             var str = ArgToString(arguments, 0);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Right.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Right.cs
@@ -13,6 +13,7 @@
 using System.Collections.Generic;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
+using OfficeOpenXml.Utils;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
 {
@@ -36,6 +37,35 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
             var startIx = str.Length - length;
             if (startIx < 0)
                 startIx = 0;
+
+            int startIndex = str.Length;
+            if(context.Configuration.EnableUnicodeAwareStringOperations)
+            {
+                int unicodeLength = 0;
+                for (int i = str.Length - 1; i >= 0; i--)
+                {
+                    char c = str[i];
+
+                    // Handle surrogate pairs correctly
+                    if (char.IsLowSurrogate(c) && i > 0 && char.IsHighSurrogate(str[i - 1]))
+                    {
+                        i--; // Move past the high surrogate
+                    }
+
+                    unicodeLength++;
+
+                    if (unicodeLength == length)
+                    {
+                        startIndex = i; // Set the correct start position
+                        break;
+                    }
+                }
+            }
+            if (context.Configuration.EnableUnicodeAwareStringOperations)
+            {
+                var res = str.UnitcodeSubstring(startIndex, str.Length - startIx);
+                return CreateResult(res, DataType.String);
+            }
             return CreateResult(str.Substring(startIx, str.Length - startIx), DataType.String);
         }
     }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Text.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Text.cs
@@ -33,6 +33,11 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
         /// Minimum arguments
         /// </summary>
         public override int ArgumentMinLength => 1;
+
+        /// <summary>
+        /// First arg could be a range
+        /// </summary>
+        public override ExcelFunctionArrayBehaviour ArrayBehaviour => ExcelFunctionArrayBehaviour.FirstArgCouldBeARange;
         /// <summary>
         /// Execute function
         /// </summary>

--- a/src/EPPlus/FormulaParsing/Excel/Operators/RangeOperationsOperator.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Operators/RangeOperationsOperator.cs
@@ -60,7 +60,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
             }
         }
 
-        private static object ApplyOperator(string l, string r, Operators op, out bool error)
+        private static object ApplyOperator(string l, string r, Operators op, out bool error, ParsingContext context)
         {
             error = false;
             switch(op)
@@ -78,7 +78,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
                     }
                     if (string.IsNullOrEmpty(l) == true && string.IsNullOrEmpty(r) == true)
                         return false;
-                    return string.Compare(l, r, StringComparison.InvariantCultureIgnoreCase) < 0;
+                    return StringUtil.Compare(l, r, StringComparison.CurrentCultureIgnoreCase, context) < 0;
                 case Operators.LessThanOrEqual:
                     if (string.IsNullOrEmpty(l) == true && string.IsNullOrEmpty(r) == false)
                     {
@@ -90,7 +90,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
                     }
                     if (string.IsNullOrEmpty(l) == true && string.IsNullOrEmpty(r) == true)
                         return true;
-                    return string.Compare(l, r, StringComparison.InvariantCultureIgnoreCase) <= 0;
+                    return StringUtil.Compare(l, r, StringComparison.CurrentCultureIgnoreCase, context) <= 0;
                 case Operators.GreaterThan:
                     if (string.IsNullOrEmpty(l) == true && string.IsNullOrEmpty(r) == false)
                     {
@@ -102,7 +102,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
                     }
                     if (string.IsNullOrEmpty(l) == true && string.IsNullOrEmpty(r) == true)
                         return false;
-                    return string.Compare(l, r, StringComparison.InvariantCultureIgnoreCase) > 0;
+                    return StringUtil.Compare(l, r, StringComparison.CurrentCultureIgnoreCase, context) > 0;
                 case Operators.GreaterThanOrEqual:
                     if (string.IsNullOrEmpty(l) == true && string.IsNullOrEmpty(r) == false)
                     {
@@ -114,7 +114,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
                     }
                     if (string.IsNullOrEmpty(l) == true && string.IsNullOrEmpty(r) == true)
                         return true;
-                    return string.Compare(l, r, StringComparison.InvariantCultureIgnoreCase) >= 0;
+                    return StringUtil.Compare(l, r, StringComparison.CurrentCultureIgnoreCase, context) >= 0;
                 case Operators.Equals:
                     if (string.IsNullOrEmpty(l) == true && string.IsNullOrEmpty(r) == false)
                     {
@@ -126,7 +126,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
                     }
                     if (string.IsNullOrEmpty(l) == true && string.IsNullOrEmpty(r) == true)
                         return true;
-                    return string.Compare(l, r, StringComparison.InvariantCultureIgnoreCase) == 0;
+                    return StringUtil.Compare(l, r, StringComparison.CurrentCultureIgnoreCase, context) == 0;
                 case Operators.NotEqualTo:
                     if (string.IsNullOrEmpty(l)==true && string.IsNullOrEmpty(r)==false)
                     {
@@ -138,7 +138,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
                     }
                     if (string.IsNullOrEmpty(l) == true && string.IsNullOrEmpty(r) == true)
                         return false;
-                    return string.Compare(l, r, StringComparison.InvariantCultureIgnoreCase) != 0;
+                    return StringUtil.Compare(l, r, StringComparison.CurrentCultureIgnoreCase, context) != 0;
                 default:
                     error = true;
                     return null;
@@ -217,7 +217,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
             }
             else
             {
-                var sResult = ApplyOperator(leftVal?.ToString(), rightVal?.ToString(), op, out bool error);
+                var sResult = ApplyOperator(leftVal?.ToString(), rightVal?.ToString(), op, out bool error, context);
                 SetValue(resultRange, row, col, sResult, error);
             }
         }

--- a/src/EPPlus/FormulaParsing/ExcelCalculationOption.cs
+++ b/src/EPPlus/FormulaParsing/ExcelCalculationOption.cs
@@ -106,6 +106,14 @@ namespace OfficeOpenXml.FormulaParsing
         {
             get; 
             set; 
-        } = false; 
+        } = false;
+
+        /// <summary>
+        /// Enables Unicode-aware string operations, ensuring correct handling of surrogate pairs for comparisons, substrings, and sorting within the library.
+        /// </summary>
+        public bool EnableUnicodeAwareStringOperations
+        {
+            get; set;
+        } = false;
     }
 }

--- a/src/EPPlus/FormulaParsing/ParsingConfiguration.cs
+++ b/src/EPPlus/FormulaParsing/ParsingConfiguration.cs
@@ -45,6 +45,16 @@ namespace OfficeOpenXml.FormulaParsing
         /// If false(default), EPPlus will only download images that don't exist in the package.
         /// </summary>
         public bool AlwaysRefreshImageFunction { get; set; } = false;
+
+        /// <summary>
+        /// Enables Unicode-aware string operations, ensuring correct handling of surrogate pairs for comparisons, substrings, and sorting within the library.
+        /// </summary>
+        public bool EnableUnicodeAwareStringOperations
+        {
+            get; 
+            set;
+        } = false;
+
         /// <summary>
         /// The <see cref="IFormulaParserLogger"/> of the parser
         /// </summary>

--- a/src/EPPlus/Utils/ComparerUtil.cs
+++ b/src/EPPlus/Utils/ComparerUtil.cs
@@ -10,12 +10,56 @@
  *************************************************************************************************
   14/1/2025         EPPlus Software AB           EPPlus v7
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace OfficeOpenXml.Utils
 {
     internal static class ComparerUtil
     {
+        internal static int CompareObjects(object x1, object y1, ParsingContext context)
+        {
+            int ret;
+            var isNumX = ConvertUtil.IsNumericOrDate(x1);
+            var isNumY = ConvertUtil.IsNumericOrDate(y1);
+            if (isNumX && isNumY)   //Numeric Compare
+            {
+                var d1 = ConvertUtil.GetValueDouble(x1);
+                var d2 = ConvertUtil.GetValueDouble(y1);
+                if (double.IsNaN(d1))
+                {
+                    d1 = double.MaxValue;
+                }
+                if (double.IsNaN(d2))
+                {
+                    d2 = double.MaxValue;
+                }
+                ret = d1 < d2 ? -1 : d1 > d2 ? 1 : 0;
+            }
+            else if (isNumX == false && isNumY == false)   //String Compare
+            {
+                var s1 = x1 == null ? "" : x1.ToString();
+                var s2 = y1 == null ? "" : y1.ToString();
+                if (context.Configuration.EnableUnicodeAwareStringOperations)
+                {
+                    ret = StringUtil.CompareStringUnicode(s1, s2);
+                }
+                else
+                {
+                    ret = string.Compare(s1, s2, StringComparison.CurrentCultureIgnoreCase);
+                }
+            }
+            else
+            {
+                ret = isNumX ? -1 : 1;
+            }
+
+            return ret;
+        }
+
+
         internal static int CompareObjects(object x1, object y1)
         {
             int ret;

--- a/src/EPPlus/Utils/StringExtensions.cs
+++ b/src/EPPlus/Utils/StringExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using OfficeOpenXml.VBA;
+using System.Collections.Generic;
 using System.Text;
 
 namespace OfficeOpenXml.Utils
@@ -42,6 +43,16 @@ namespace OfficeOpenXml.Utils
                 }
             }
             return true;
+        }
+
+        internal static string UnitcodeSubstring(this string s, int length)
+        {
+            return StringUtil.UnicodeSubstring(s, length);
+        }
+
+        internal static string UnitcodeSubstring(this string s, int start, int length)
+        {
+            return StringUtil.UnicodeSubstring(s, start, length);
         }
     }
 }

--- a/src/EPPlus/Utils/StringUtil.cs
+++ b/src/EPPlus/Utils/StringUtil.cs
@@ -1,0 +1,154 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  01/27/2025         EPPlus Software AB       EPPlus 8
+ *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OfficeOpenXml.Utils
+{
+    internal static class StringUtil
+    {
+        internal static string UnicodeSubstring(string input, int length)
+        {
+            if (string.IsNullOrEmpty(input) || length <= 0) return string.Empty;
+
+            List<char> result = new List<char>();
+            int count = 0;
+
+            for (int i = 0; i < input.Length; i++)
+            {
+                if (count >= length) break; // Stop once we've extracted the required number of Unicode characters
+
+                char c = input[i];
+
+                // Handle surrogate pairs correctly
+                if (char.IsHighSurrogate(c) && i + 1 < input.Length && char.IsLowSurrogate(input[i + 1]))
+                {
+                    if (count + 1 <= length) // Ensure the full Unicode character fits within the limit
+                    {
+                        result.Add(c);
+                        result.Add(input[i + 1]);
+                        count++;
+                    }
+                    break; // Stop after adding the surrogate pair if it exceeds the length
+                }
+                else
+                {
+                    // Single-character Unicode code point
+                    result.Add(c);
+                    count++;
+                }
+            }
+
+            return new string(result.ToArray());
+        }
+
+        internal static string UnicodeSubstring(string input, int start, int length)
+        {
+            if (string.IsNullOrEmpty(input) || length <= 0 || start < 0) return string.Empty;
+
+            List<char> result = new List<char>();
+            int count = 0;
+            int unicodeIndex = 0; // Tracks full Unicode character positions
+
+            for (int i = 0; i < input.Length; i++)
+            {
+                if (unicodeIndex < start)
+                {
+                    // Skip characters until we reach the start position
+                    char c = input[i];
+
+                    if (char.IsHighSurrogate(c) && i + 1 < input.Length && char.IsLowSurrogate(input[i + 1]))
+                        i++; // Move past surrogate pairs correctly
+
+                    unicodeIndex++;
+                    continue;
+                }
+
+                if (count >= length) break; // Stop once we extract enough Unicode characters
+
+                char c2 = input[i];
+
+                // Handle surrogate pairs properly
+                if (char.IsHighSurrogate(c2) && i + 1 < input.Length && char.IsLowSurrogate(input[i + 1]))
+                {
+                    if (count + 1 <= length) // Ensure we don't exceed the requested length
+                    {
+                        result.Add(c2);
+                        result.Add(input[i + 1]);
+                        count++;
+                    }
+                    break; // Stop if we exceed the desired length
+                    i++; // Skip next char (part of the surrogate pair)
+                }
+                else
+                {
+                    result.Add(c2);
+                    count++;
+                }
+            }
+
+            return new string(result.ToArray());
+        }
+
+        internal static int Compare(string l, string r, StringComparison comparison, ParsingContext context)
+        {
+            if(context.Configuration.EnableUnicodeAwareStringOperations)
+            {
+                return CompareStringUnicode(l, r);
+            }
+            return string.Compare(l, r, comparison);
+        }
+
+        internal static int CompareStringUnicode(string s1, string s2)
+        {
+            // Convert strings to full Unicode code points
+            var s1Codes = EnumerateRunes(s1).ToArray();
+            var s2Codes = EnumerateRunes(s2).ToArray();
+
+            // Compare character by character based on their Unicode values
+            int minLength = Math.Min(s1Codes.Length, s2Codes.Length);
+            for (int i = 0; i < minLength; i++)
+            {
+                if (s1Codes[i] != s2Codes[i])
+                    return s1Codes[i].CompareTo(s2Codes[i]);
+            }
+
+            // If strings are identical up to minLength, compare by length
+            return s1Codes.Length.CompareTo(s2Codes.Length);
+        }
+
+        static IEnumerable<int> EnumerateRunes(string input)
+        {
+            for (int i = 0; i < input.Length; i++)
+            {
+                char c = input[i];
+
+                // Check if this is a high surrogate (start of a pair)
+                if (char.IsHighSurrogate(c) && i + 1 < input.Length && char.IsLowSurrogate(input[i + 1]))
+                {
+                    // Combine high and low surrogates into a full Unicode code point
+                    yield return char.ConvertToUtf32(c, input[i + 1]);
+                    i++; // Skip the next character since it's part of the surrogate pair
+                }
+                else
+                {
+                    // Single character (not part of a surrogate pair)
+                    yield return c;
+                }
+            }
+        }
+    }
+}

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/SortTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/SortTests.cs
@@ -216,5 +216,104 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
             Assert.AreEqual(0D, _sheet.Cells[8, 1].Value);
 
         }
+
+        [TestMethod]
+        public void SortShouldHandleArrayWithIndexes()
+        {
+            _sheet.Cells[1, 1].Value = 150;
+            _sheet.Cells[2, 1].Value = 150;
+            _sheet.Cells[3, 1].Value = 150;
+            _sheet.Cells[4, 1].Value = 150;
+            _sheet.Cells[5, 1].Value = 150;
+            _sheet.Cells[6, 1].Value = 150;
+
+            _sheet.Cells[1, 2].Value = 2100;
+            _sheet.Cells[2, 2].Value = 2110;
+            _sheet.Cells[3, 2].Value = 2105;
+            _sheet.Cells[4, 2].Value = 2100;
+            _sheet.Cells[5, 2].Value = 2110;
+            _sheet.Cells[6, 2].Value = 2105;
+
+            _sheet.Cells[1, 3].Value = "Sub-Total for EUR";
+            _sheet.Cells[2, 3].Value = "Total for G/L";
+            _sheet.Cells[3, 3].Value = "Sub-Total for EUR";
+            _sheet.Cells[4, 3].Value = "Total for G/L";
+            _sheet.Cells[5, 3].Value = "Sub-Total for EUR";
+            _sheet.Cells[6, 3].Value = "Total for G/L";
+
+            _sheet.Cells[1, 3].Value = "EUR";
+            _sheet.Cells[2, 3].Value = "[n/a]";
+            _sheet.Cells[3, 3].Value = "EUR";
+            _sheet.Cells[4, 3].Value = "[n/a]";
+            _sheet.Cells[5, 3].Value = "EUR";
+            _sheet.Cells[6, 3].Value = "[n/a]";
+
+            _sheet.Cells["A10"].Formula = "SORT(A1:D6,{1,2},1,FALSE)";
+            _sheet.Calculate();
+
+            Assert.AreEqual(150, _sheet.Cells[10, 1].Value);
+            Assert.AreEqual(150, _sheet.Cells[11, 1].Value);
+            Assert.AreEqual(150, _sheet.Cells[12, 1].Value);
+            Assert.AreEqual(150, _sheet.Cells[13, 1].Value);
+
+            Assert.AreEqual(2100, _sheet.Cells[10, 2].Value, "Cell B10 was not 2100 as expected, result: " + _sheet.Cells[10, 2].Value);
+            Assert.AreEqual(2100, _sheet.Cells[11, 2].Value, "Cell B11 was not 2100 as expected, result: " + _sheet.Cells[11, 2].Value);
+            Assert.AreEqual(2105, _sheet.Cells[12, 2].Value, "Cell B12 was not 2105 as expected, result: " + _sheet.Cells[12, 2].Value);
+
+        }
+
+        [TestMethod]
+        public void SortShouldHandleArrayWithIndexes2()
+        {
+            _sheet.Cells[1, 1].Value = 150;
+            _sheet.Cells[2, 1].Value = 150;
+            _sheet.Cells[3, 1].Value = 150;
+            _sheet.Cells[4, 1].Value = 150;
+            _sheet.Cells[5, 1].Value = 150;
+            _sheet.Cells[6, 1].Value = 150;
+
+            _sheet.Cells[1, 2].Value = 210000;
+            _sheet.Cells[2, 2].Value = 210100;
+            _sheet.Cells[3, 2].Value = 210050;
+            _sheet.Cells[4, 2].Value = 210000;
+            _sheet.Cells[5, 2].Value = 210100;
+            _sheet.Cells[6, 2].Value = 210050;
+
+            _sheet.Cells[1, 3].Value = "Sub-Total for EUR";
+            _sheet.Cells[2, 3].Value = "Sub-Total for EUR";
+            _sheet.Cells[3, 3].Value = "Sub-Total for EUR";
+            _sheet.Cells[4, 3].Value = "Total for G/L";
+            _sheet.Cells[5, 3].Value = "Total for G/L";
+            _sheet.Cells[6, 3].Value = "Total for G/L";
+
+            _sheet.Cells[1, 4].Value = "EUR";
+            _sheet.Cells[2, 4].Value = "EUR";
+            _sheet.Cells[3, 4].Value = "EUR";
+            _sheet.Cells[4, 4].Value = "[n/a]";
+            _sheet.Cells[5, 4].Value = "[n/a]";
+            _sheet.Cells[6, 4].Value = "[n/a]";
+
+            _sheet.Cells["A10"].Formula = "SORT(A1:D6,{1,2,3},1,FALSE)";
+            _sheet.Calculate();
+
+            Assert.AreEqual(150, _sheet.Cells[10, 1].Value);
+            Assert.AreEqual(150, _sheet.Cells[11, 1].Value);
+            Assert.AreEqual(150, _sheet.Cells[12, 1].Value);
+            Assert.AreEqual(150, _sheet.Cells[13, 1].Value);
+
+            Assert.AreEqual(210000, _sheet.Cells[10, 2].Value, "Cell B10 was not 2100 as expected, result: " + _sheet.Cells[10, 2].Value);
+            Assert.AreEqual(210000, _sheet.Cells[11, 2].Value, "Cell B11 was not 2100 as expected, result: " + _sheet.Cells[11, 2].Value);
+            Assert.AreEqual(210050, _sheet.Cells[12, 2].Value, "Cell B12 was not 2105 as expected, result: " + _sheet.Cells[12, 2].Value);
+            Assert.AreEqual(210050, _sheet.Cells[13, 2].Value, "Cell B13 was not 2105 as expected, result: " + _sheet.Cells[13, 2].Value);
+
+            Assert.AreEqual("Sub-Total for EUR", _sheet.Cells[10, 3].Value);
+            Assert.AreEqual("Total for G/L", _sheet.Cells[11, 3].Value);
+            Assert.AreEqual("Sub-Total for EUR", _sheet.Cells[12, 3].Value);
+            Assert.AreEqual("Total for G/L", _sheet.Cells[13, 3].Value);
+
+            Assert.AreEqual("EUR", _sheet.Cells[10, 4].Value);
+            Assert.AreEqual("[n/a]", _sheet.Cells[11, 4].Value);
+
+        }
     }
 }

--- a/src/EPPlusTest/FormulaParsing/IntegrationTests/BuiltInFunctions/TextFunctionsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/IntegrationTests/BuiltInFunctions/TextFunctionsTests.cs
@@ -266,5 +266,22 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
             var elapsed = sw.Elapsed;
             Console.WriteLine(string.Format("{0} seconds", elapsed.TotalSeconds));
         }
+
+        [TestMethod]
+        public void TextFunctionShouldHandleArrayArg()
+        {
+            using var p = new ExcelPackage();
+            var ws = p.Workbook.Worksheets.Add("Sheet1");
+            ws.Cells["A1"].Formula = "HSTACK(SEQUENCE(12,1,2025,0),TEXT(SEQUENCE(12,1,1,1),\"000\"))";
+            ws.Calculate();
+            var a1 = ws.Cells["A1"].Value;
+            var b1 = ws.Cells["B1"].Value;
+            var a2 = ws.Cells["A2"].Value;
+            var b2 = ws.Cells["B2"].Value;
+            Assert.AreEqual(2025d, a1);
+            Assert.AreEqual("001", b1);
+            Assert.AreEqual(2025d, a2);
+            Assert.AreEqual("002", b2);
+        }
     }
 }

--- a/src/EPPlusTest/FormulaParsing/UnicodeTests.cs
+++ b/src/EPPlusTest/FormulaParsing/UnicodeTests.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace EPPlusTest.FormulaParsing
+{
+    [TestClass]
+    public class UnicodeTests
+    {
+        [TestMethod]
+        public void LeftFunctionAndEqualsOperatorShouldHandleUnicode()
+        {
+            using var package = new ExcelPackage();
+            var ws = package.Workbook.Worksheets.Add("Sheet1");
+            ws.Cells[1, 1].Value = "🔼 test";
+            ws.Cells[2, 1].Formula = "LEFT(A1, 1) = \"🔼\"";
+            ws.Calculate(o => o.EnableUnicodeAwareStringOperations = true);
+            Assert.IsInstanceOfType(ws.Cells[2, 1].Value, typeof(bool));
+            Assert.IsTrue((bool)ws.Cells[2, 1].Value);
+        }
+
+        [TestMethod]
+        public void RightFunctionAndEqualsOperatorShouldHandleUnicode()
+        {
+            using var package = new ExcelPackage();
+            var ws = package.Workbook.Worksheets.Add("Sheet1");
+            ws.Cells[1, 1].Value = "test 🔼";
+            ws.Cells[2, 1].Formula = "RIGHT(A1, 1) = \"🔼\"";
+            ws.Calculate(o => o.EnableUnicodeAwareStringOperations = true);
+            Assert.IsInstanceOfType(ws.Cells[2, 1].Value, typeof(bool));
+            Assert.IsTrue((bool)ws.Cells[2, 1].Value);
+        }
+
+        [TestMethod]
+        public void EqualsOperatorShouldWorkWithUnicode()
+        {
+            using var package = new ExcelPackage();
+            var ws = package.Workbook.Worksheets.Add("Sheet1");
+            ws.Cells[1, 1].Value = "Test 🔼";
+            ws.Cells[2, 1].Formula = "A1=\"Test 🔼\"";
+            ws.Calculate();
+            Assert.IsInstanceOfType(ws.Cells[2, 1].Value, typeof(bool));
+            Assert.IsTrue((bool)ws.Cells[2, 1].Value);
+        }
+
+        [TestMethod]
+        public void NotEqualsOperatorShouldWorkWithUnicode()
+        {
+            using var package = new ExcelPackage();
+            var ws = package.Workbook.Worksheets.Add("Sheet1");
+            ws.Cells[1, 1].Value = "Test 🔼";
+            ws.Cells[2, 1].Formula = "A1<>\"Test 🔼\"";
+            ws.Calculate();
+            Assert.IsInstanceOfType(ws.Cells[2, 1].Value, typeof(bool));
+            Assert.IsFalse((bool)ws.Cells[2, 1].Value);
+        }
+
+        [TestMethod]
+        public void GreaterThanOperatorShouldWorkWithUnicode()
+        {
+            using var package = new ExcelPackage();
+            var ws = package.Workbook.Worksheets.Add("Sheet1");
+            ws.Cells[1, 1].Value = "🔼 test";
+            ws.Cells[2, 1].Formula = "A1>\"S\"";
+            ws.Calculate();
+            Assert.IsInstanceOfType(ws.Cells[2, 1].Value, typeof(bool));
+            Assert.IsTrue((bool)ws.Cells[2, 1].Value);
+        }
+
+        [TestMethod]
+        public void LessThanOperatorShouldWorkWithUnicode()
+        {
+            using var package = new ExcelPackage();
+            var ws = package.Workbook.Worksheets.Add("Sheet1");
+            ws.Cells[1, 1].Value = "🔼 test";
+            ws.Cells[2, 1].Formula = "A1<\"S\"";
+            ws.Calculate();
+            Assert.IsInstanceOfType(ws.Cells[2, 1].Value, typeof(bool));
+            Assert.IsFalse((bool)ws.Cells[2, 1].Value);
+        }
+    }
+}

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -958,6 +958,17 @@ namespace EPPlusTest.Issues
 
             Assert.AreEqual(12977661.57, result2);
         }
+
+        [TestMethod]
+        public void s866case1()
+        {
+            using var p1 = OpenTemplatePackage("Tecan spillover tests.xlsx");
+            var aicoDataWs = p1.Workbook.Worksheets["Aico Data"];
+			var summaryWs = p1.Workbook.Worksheets["Summary"];
+            summaryWs.Cells["C12"].Calculate(o => o.EnableUnicodeAwareStringOperations = true);
+            var result1 = summaryWs.Cells["C12"].Value;
+            Assert.AreEqual("Sub-Total for EUR", result1);
+        }
     }
 }
 


### PR DESCRIPTION
- During formula calculation, EPPlus does not handle double char Unicodes characters (starting with a high-surrogate char and ending with a low-surrogate char) correctly.
- The TEXT function should handle arrays as input and be able to return an array instead of a single value.
- The SORT function did not handle multiple indexes (second arg) correctly.
- The SWITCH function did not handle an array as the first argument.
- Fixed an issue that caused an Exception during calculation if an external workbook was not available.
