### PR TITLE
Bug/i2012

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Sorting/InMemoryRangeSorter.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Sorting/InMemoryRangeSorter.cs
@@ -88,6 +88,20 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
                 }
                 rows.Add(cols);
             }
+
+            //var ws = context.CurrentWorksheet.Workbook.Worksheets.Add("Rows_Unsorted");
+            //var rowIx1 = 0;
+            //foreach (var row in rows)
+            //{
+            //    var cellIx1 = 0;
+            //    foreach (var cell in row.ToList())
+            //    {
+            //        ws.SetValue(rowIx1+1, cellIx1+1, cell.Value);
+            //        cellIx1++;
+            //    }
+            //    rowIx1++;
+            //}
+
             rows.Sort((a, b) => 
             { 
                 foreach(var colIx in colIndexes)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Sorting/InMemoryRangeSorter.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Sorting/InMemoryRangeSorter.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   22/3/2023         EPPlus Software AB           EPPlus v7
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.LookupUtils;
 using OfficeOpenXml.FormulaParsing.Ranges;
 using System;
@@ -27,7 +28,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
             var rangeDef = new RangeDefinition(sourceRange.Size.NumberOfRows, sourceRange.Size.NumberOfCols);
             var sortedRange = new InMemoryRange(rangeDef);
             var columns = new List<SortedColOrRow>();
-            for(var col = 0; col < rangeDef.NumberOfCols; col++)
+
+            var originalColNum = new Dictionary<SortedColOrRow, int>();
+
+            for (var col = 0; col < rangeDef.NumberOfCols; col++)
             {
                 var rows = new SortedColOrRow();
                 for(var row = 0; row < rangeDef.NumberOfRows; row++)
@@ -37,6 +41,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
                     rows.AddItem(row, si);
                 }
                 columns.Add(rows);
+                originalColNum.Add(rows, col);
             }
             columns.Sort((a, b) =>
             {
@@ -55,6 +60,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
                     }
                     var res = _comparer.Compare(aColVal.Value, bColVal.Value, sortOrder, context);
                     if (res != 0) return res;
+
+                    var resIndex = _comparer.Compare(originalColNum[a], originalColNum[b], sortOrder, context);
+                    return resIndex;
                 }
                 return 0;
             });
@@ -77,6 +85,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
             var rangeDef = new RangeDefinition(sourceRange.Size.NumberOfRows, sourceRange.Size.NumberOfCols);
             var sortedRange = new InMemoryRange(rangeDef);
             var rows = new List<SortedColOrRow>();
+
+            var originalRowNum = new Dictionary<SortedColOrRow, int>();
+
             for (var row = 0; row < rangeDef.NumberOfRows; row++)
             {
                 var cols = new SortedColOrRow();
@@ -87,20 +98,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
                     cols.AddItem(col, si);
                 }
                 rows.Add(cols);
+                originalRowNum.Add(cols, row);
             }
-
-            //var ws = context.CurrentWorksheet.Workbook.Worksheets.Add("Rows_Unsorted");
-            //var rowIx1 = 0;
-            //foreach (var row in rows)
-            //{
-            //    var cellIx1 = 0;
-            //    foreach (var cell in row.ToList())
-            //    {
-            //        ws.SetValue(rowIx1+1, cellIx1+1, cell.Value);
-            //        cellIx1++;
-            //    }
-            //    rowIx1++;
-            //}
 
             rows.Sort((a, b) => 
             { 
@@ -119,9 +118,13 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
                     }
                     var res = _comparer.Compare(aColVal.Value, bColVal.Value, sortOrder, context);
                     if (res != 0) return res;
+
+                    var resIndex = _comparer.Compare(originalRowNum[a], originalRowNum[b], sortOrder, context);
+                    return resIndex;
                 }
                 return 0;
             });
+
             var rowIx = 0;
             foreach(var row in rows)
             {

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Sorting/InMemoryRangeSorter.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Sorting/InMemoryRangeSorter.cs
@@ -10,13 +10,9 @@
  *************************************************************************************************
   22/3/2023         EPPlus Software AB           EPPlus v7
  *************************************************************************************************/
-using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.LookupUtils;
 using OfficeOpenXml.FormulaParsing.Ranges;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
 {
@@ -60,11 +56,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
                     }
                     var res = _comparer.Compare(aColVal.Value, bColVal.Value, sortOrder, context);
                     if (res != 0) return res;
-
-                    var resIndex = _comparer.Compare(originalColNum[a], originalColNum[b], sortOrder, context);
-                    return resIndex;
                 }
-                return 0;
+                var resIndex = _comparer.Compare(originalColNum[a], originalColNum[b], sortOrder, context);
+                return resIndex;
             });
             var colIx = 0;
             foreach (var col in columns)
@@ -118,11 +112,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Sorting
                     }
                     var res = _comparer.Compare(aColVal.Value, bColVal.Value, sortOrder, context);
                     if (res != 0) return res;
-
-                    var resIndex = _comparer.Compare(originalRowNum[a], originalRowNum[b], sortOrder, context);
-                    return resIndex;
                 }
-                return 0;
+                var resIndex = _comparer.Compare(originalRowNum[a], originalRowNum[b], sortOrder, context);
+                return resIndex;
             });
 
             var rowIx = 0;

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -958,7 +958,34 @@ namespace EPPlusTest.Issues
 
             Assert.AreEqual(12977661.57, result2);
         }
+		[TestMethod]
+		public void i2012_Alt_Minimized_Col()
+		{
+			using (var pck = OpenTemplatePackage("SortColumn.xlsx"))
+			{
+				var ws = pck.Workbook.Worksheets[0];
 
+				ws.Cells["A13"].Formula = "SORT(A1:BB4,2,1,TRUE)";
+
+                ws.Cells["A13"].Calculate();
+				ws.ClearFormulas();
+
+                List<string> cellValues = new();
+                foreach (var cell in ws.Cells["A7:BB10"])
+                {
+                    cellValues.Add(cell.Text);
+                }
+
+                int i = 0;
+                foreach (var cell in ws.Cells["A13:BB16"])
+                {
+                    Assert.AreEqual(cell.Text, cellValues[i]);
+                    i++;
+                }
+
+                SaveAndCleanup(pck);
+            }
+		}
 		[TestMethod]
 		public void i2012_Alt_Minimized()
 		{
@@ -971,12 +998,26 @@ namespace EPPlusTest.Issues
 
                 ws.Calculate();
 				ws.ClearFormulas();
-				SaveAndCleanup(pck);
+
+				ws.Cells["G1:J8"].CopyTranspose(ws.Cells["L1"]);
+
+                ws.Cells["U1"].Formula = "SORT(L1:S4,3,1,TRUE)";
+				//ws.Cells["U1"].IsArrayFormula = false;
+
+                ws.Calculate();
+                ws.ClearFormulas();
+
+                ws.Cells["AH1"].Formula = "SORT(L1:S4,3,1,TRUE)";
+
+                ws.Calculate();
+
+                //ws.Cells["U7"].ClearFormulas();
+
+                SaveAndCleanup(pck);
             }
 		}
 
-                //Epplusexample.xlsx
-                [TestMethod]
+        [TestMethod]
 		public void i2012_Alt()
 		{
 			using (var pck = OpenTemplatePackage("BrokeOutProblem.xlsx"))
@@ -1011,11 +1052,9 @@ namespace EPPlusTest.Issues
 			using (var pck = OpenTemplatePackage("i2012.xlsx"))
 			{
 				var ws = pck.Workbook.Worksheets["Summary by Contract"];
-
 				var str = ws.Cells["A12"].Formula;
 
 				List<string> cellValues = new();
-
                 foreach (var cell in ws.Cells["D12:D100"])
 				{
 					cellValues.Add(cell.Text);
@@ -1024,83 +1063,19 @@ namespace EPPlusTest.Issues
 				ws.Cells["A12:D200"].Clear();
 
 				ws.Cells["A12"].Formula = "IF('Contract Details'!F12 = \"[none]\", {\"[none]\",\"\",\"\",\"\"},\r\n _xlfn.VSTACK(\r\n_xlfn._xlws.SORT(_xlfn.VSTACK(\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_Current,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"Current\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0))),\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_NonCurrent,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"Non-Current\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0))),\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_Total,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"🔼 Sub-Total\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)))\r\n), 2,1,FALSE),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Current,\"Current\"),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_NonCurrent,\"Non-Current\"),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Total,\"🔼 Total\")\r\n))";
-
-				//var testws = pck.Workbook.Worksheets.Add("SomeTestTempWs");
-
-    //            testws.Cells["A12"].Formula = "IF('Contract Details'!F12 = \"[none]\", {\"[none]\",\"\",\"\",\"\"},\r\n _xlfn.VSTACK(\r\n_xlfn._xlws.SORT(_xlfn.VSTACK(\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_Current,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"Current\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0))),\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_NonCurrent,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"Non-Current\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0))),\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_Total,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"🔼 Sub-Total\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)))\r\n), 2,1,FALSE),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Current,\"Current\"),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_NonCurrent,\"Non-Current\"),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Total,\"Total\")\r\n))";
-				//testws.Calculate();
-
-				//var someOtherValue = testws.Cells["A12"].Value;
-
-                //ws.Cells["A12"].Formula = "IF('Contract Details'!F12 = \"[none]\", {\"[none]\",\"\",\"\",\"\"},\r\n _xlfn.VSTACK(\r\n_xlfn._xlws.SORT(_xlfn.VSTACK(\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_Current,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"Current\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0))),\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_NonCurrent,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"Non-Current\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0))),\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_Total,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"🔼 Sub-Total\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)))\r\n), {2,4} ,1,FALSE),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Current,\"Current\"),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_NonCurrent,\"Non-Current\"),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Total,\"🔼 Total\")\r\n))";
-
-                //            var smallResultRangePre = ws.Cells["D12:D26"];
-
-                //ws.Cells["A12"].Formula = "IF('Contract Details'!F12 = \"[none]\", {\"[none]\",\"\",\"\",\"\"}," +
-                //	" VSTACK(SORT(VSTACK(" +
-                //	"HSTACK(UNIQUE(HSTACK('Contract Details'!A12#,'Contract Details'!B12#)), REPT(name_Account_GL_Current,SEQUENCE(COUNTA(UNIQUE(HSTACK('Contract Details'!B12#))),1,1,0)), REPT(\"Current\",SEQUENCE(COUNTA(UNIQUE(HSTACK('Contract Details'!B12#))),1,1,0)))," +
-                //	"HSTACK(UNIQUE(HSTACK('Contract Details'!A12#,'Contract Details'!B12#)), REPT(name_Account_GL_NonCurrent,SEQUENCE(COUNTA(UNIQUE(HSTACK('Contract Details'!B12#))),1,1,0)), REPT(\"Non-Current\",SEQUENCE(COUNTA(UNIQUE(HSTACK('Contract Details'!B12#))),1,1,0)))," +
-                //	"HSTACK(UNIQUE(HSTACK('Contract Details'!A12#,'Contract Details'!B12#)), REPT(name_Account_GL_Total,SEQUENCE(COUNTA(UNIQUE(HSTACK('Contract Details'!B12#))),1,1,0)), REPT(\"🔼 Sub-Total\",SEQUENCE(COUNTA(UNIQUE(HSTACK('Contract Details'!B12#))),1,1,0)))" +
-                //	"), {2,4},1,FALSE)," +
-                //	"HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Current,\"Current\")," +
-                //	"HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_NonCurrent,\"Non-Current\")," +
-                //	"HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Total,\"🔼 Total\")))";
-
                 ws.Cells["A12"].Calculate();
 
                 List<string> cellValuesAfter = new();
 				int i = 0;
                 foreach (var cell in ws.Cells["D12:D100"])
                 {
-					if(cell.Text != cellValues[i])
-					{
-						string test = "Something wrong";
-					}
+					Assert.AreEqual(cell.Text, cellValues[i]);
 					i++;
                 }
 
-
-
                 ws.ClearFormulas();
-				//testws.ClearFormulas();
-
                 SaveAndCleanup(pck);
 			}
-
-			//    using var epplusCalculated = OpenTemplatePackage("i2012.xlsx");
-
-			//    using var excelCalculated = OpenTemplatePackage("i2012.xlsx");
-
-			//    epplusCalculated.Workbook.CalcMode = ExcelCalcMode.Manual;
-
-			//    epplusCalculated.Workbook.Calculate(new OfficeOpenXml.FormulaParsing.ExcelCalculationOption
-
-			//    {
-
-			//        PrecisionAndRoundingStrategy = OfficeOpenXml.FormulaParsing.PrecisionAndRoundingStrategy.Excel,
-
-			//        AllowCircularReferences = true,
-
-			//    });
-
-
-			//    foreach (var wsEpplusCalculated in epplusCalculated.Workbook.Worksheets)
-			//    {
-			//        var wsExcelCalculated = excelCalculated.Workbook.Worksheets[wsEpplusCalculated.Name];
-			//        for (int row = 1; row <= wsEpplusCalculated.Dimension.End.Row; row++)
-			//        {
-			//            for (int col = 1; col <= wsEpplusCalculated.Dimension.End.Column; col++)
-			//            {
-			//                var cellEPPlusCalculated = wsEpplusCalculated.Cells[row, col];
-			//                var cellExcelCalculated = wsExcelCalculated.Cells[row, col];
-
-			//                if (cellEPPlusCalculated.Value?.ToString() != cellExcelCalculated.Value?.ToString())
-			//                    Console.WriteLine($"Cell value mismatch in worksheet '{wsEpplusCalculated.Name}' at {cellEPPlusCalculated.Address}. Expected: '{cellExcelCalculated.Value?.ToString()}' Actual '{cellEPPlusCalculated.Value?.ToString()}'");
-
-			//            }
-			//        }
-			//    }
-			//}
 		}
     }
 }

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -958,6 +958,150 @@ namespace EPPlusTest.Issues
 
             Assert.AreEqual(12977661.57, result2);
         }
+
+		[TestMethod]
+		public void i2012_Alt_Minimized()
+		{
+			using (var pck = OpenTemplatePackage("MinimizedSort.xlsx"))
+			{
+				var ws = pck.Workbook.Worksheets.Add("EpplusSort");
+
+				ws.Cells["A1"].Formula = "SORT(Data!A1:D3,2,1,FALSE)";
+				ws.Cells["G1"].Formula = "SORT(Data!A5:D12,2,1,FALSE)";
+
+                ws.Calculate();
+				ws.ClearFormulas();
+				SaveAndCleanup(pck);
+            }
+		}
+
+                //Epplusexample.xlsx
+                [TestMethod]
+		public void i2012_Alt()
+		{
+			using (var pck = OpenTemplatePackage("BrokeOutProblem.xlsx"))
+			{
+				var wsExcel = pck.Workbook.Worksheets[0];
+				var wsEpplus = pck.Workbook.Worksheets.Add("EpplusCalc");
+
+				wsEpplus.Cells["A1"].Formula = wsExcel.Cells["A1"].Formula;
+
+                int i = 0;
+				wsEpplus.Cells["H1"].Formula = "SORT(Sheet2!A1:D54,{2,4},1,FALSE)";
+                wsEpplus.Calculate();
+
+                wsEpplus.ClearFormulas();
+
+                foreach (var cell in wsEpplus.Cells["B1:B55"])
+                {
+                    if (cell.Text != wsExcel.Cells[cell.Start.Row, cell.Start.Column].Text)
+                    {
+						cell.EntireRow.Style.Fill.SetBackground(System.Drawing.Color.DarkRed);
+                    }
+                    i++;
+                }
+
+                SaveAndCleanup(pck);
+            }
+		}
+
+        [TestMethod]
+		public void i2012()
+		{
+			using (var pck = OpenTemplatePackage("i2012.xlsx"))
+			{
+				var ws = pck.Workbook.Worksheets["Summary by Contract"];
+
+				var str = ws.Cells["A12"].Formula;
+
+				List<string> cellValues = new();
+
+                foreach (var cell in ws.Cells["D12:D100"])
+				{
+					cellValues.Add(cell.Text);
+				}
+
+				ws.Cells["A12:D200"].Clear();
+
+				ws.Cells["A12"].Formula = "IF('Contract Details'!F12 = \"[none]\", {\"[none]\",\"\",\"\",\"\"},\r\n _xlfn.VSTACK(\r\n_xlfn._xlws.SORT(_xlfn.VSTACK(\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_Current,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"Current\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0))),\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_NonCurrent,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"Non-Current\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0))),\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_Total,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"🔼 Sub-Total\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)))\r\n), 2,1,FALSE),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Current,\"Current\"),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_NonCurrent,\"Non-Current\"),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Total,\"🔼 Total\")\r\n))";
+
+				//var testws = pck.Workbook.Worksheets.Add("SomeTestTempWs");
+
+    //            testws.Cells["A12"].Formula = "IF('Contract Details'!F12 = \"[none]\", {\"[none]\",\"\",\"\",\"\"},\r\n _xlfn.VSTACK(\r\n_xlfn._xlws.SORT(_xlfn.VSTACK(\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_Current,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"Current\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0))),\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_NonCurrent,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"Non-Current\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0))),\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_Total,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"🔼 Sub-Total\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)))\r\n), 2,1,FALSE),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Current,\"Current\"),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_NonCurrent,\"Non-Current\"),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Total,\"Total\")\r\n))";
+				//testws.Calculate();
+
+				//var someOtherValue = testws.Cells["A12"].Value;
+
+                //ws.Cells["A12"].Formula = "IF('Contract Details'!F12 = \"[none]\", {\"[none]\",\"\",\"\",\"\"},\r\n _xlfn.VSTACK(\r\n_xlfn._xlws.SORT(_xlfn.VSTACK(\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_Current,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"Current\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0))),\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_NonCurrent,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"Non-Current\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0))),\r\n_xlfn.HSTACK(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!A12),_xlfn.ANCHORARRAY('Contract Details'!B12))), REPT(name_Account_GL_Total,_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)), REPT(\"🔼 Sub-Total\",_xlfn.SEQUENCE(COUNTA(_xlfn.UNIQUE(_xlfn.HSTACK(_xlfn.ANCHORARRAY('Contract Details'!B12)))),1,1,0)))\r\n), {2,4} ,1,FALSE),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Current,\"Current\"),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_NonCurrent,\"Non-Current\"),\r\n_xlfn.HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Total,\"🔼 Total\")\r\n))";
+
+                //            var smallResultRangePre = ws.Cells["D12:D26"];
+
+                //ws.Cells["A12"].Formula = "IF('Contract Details'!F12 = \"[none]\", {\"[none]\",\"\",\"\",\"\"}," +
+                //	" VSTACK(SORT(VSTACK(" +
+                //	"HSTACK(UNIQUE(HSTACK('Contract Details'!A12#,'Contract Details'!B12#)), REPT(name_Account_GL_Current,SEQUENCE(COUNTA(UNIQUE(HSTACK('Contract Details'!B12#))),1,1,0)), REPT(\"Current\",SEQUENCE(COUNTA(UNIQUE(HSTACK('Contract Details'!B12#))),1,1,0)))," +
+                //	"HSTACK(UNIQUE(HSTACK('Contract Details'!A12#,'Contract Details'!B12#)), REPT(name_Account_GL_NonCurrent,SEQUENCE(COUNTA(UNIQUE(HSTACK('Contract Details'!B12#))),1,1,0)), REPT(\"Non-Current\",SEQUENCE(COUNTA(UNIQUE(HSTACK('Contract Details'!B12#))),1,1,0)))," +
+                //	"HSTACK(UNIQUE(HSTACK('Contract Details'!A12#,'Contract Details'!B12#)), REPT(name_Account_GL_Total,SEQUENCE(COUNTA(UNIQUE(HSTACK('Contract Details'!B12#))),1,1,0)), REPT(\"🔼 Sub-Total\",SEQUENCE(COUNTA(UNIQUE(HSTACK('Contract Details'!B12#))),1,1,0)))" +
+                //	"), {2,4},1,FALSE)," +
+                //	"HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Current,\"Current\")," +
+                //	"HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_NonCurrent,\"Non-Current\")," +
+                //	"HSTACK(name_CompanyCode,\"[All Contracts]\",name_Account_GL_Total,\"🔼 Total\")))";
+
+                ws.Cells["A12"].Calculate();
+
+                List<string> cellValuesAfter = new();
+				int i = 0;
+                foreach (var cell in ws.Cells["D12:D100"])
+                {
+					if(cell.Text != cellValues[i])
+					{
+						string test = "Something wrong";
+					}
+					i++;
+                }
+
+
+
+                ws.ClearFormulas();
+				//testws.ClearFormulas();
+
+                SaveAndCleanup(pck);
+			}
+
+			//    using var epplusCalculated = OpenTemplatePackage("i2012.xlsx");
+
+			//    using var excelCalculated = OpenTemplatePackage("i2012.xlsx");
+
+			//    epplusCalculated.Workbook.CalcMode = ExcelCalcMode.Manual;
+
+			//    epplusCalculated.Workbook.Calculate(new OfficeOpenXml.FormulaParsing.ExcelCalculationOption
+
+			//    {
+
+			//        PrecisionAndRoundingStrategy = OfficeOpenXml.FormulaParsing.PrecisionAndRoundingStrategy.Excel,
+
+			//        AllowCircularReferences = true,
+
+			//    });
+
+
+			//    foreach (var wsEpplusCalculated in epplusCalculated.Workbook.Worksheets)
+			//    {
+			//        var wsExcelCalculated = excelCalculated.Workbook.Worksheets[wsEpplusCalculated.Name];
+			//        for (int row = 1; row <= wsEpplusCalculated.Dimension.End.Row; row++)
+			//        {
+			//            for (int col = 1; col <= wsEpplusCalculated.Dimension.End.Column; col++)
+			//            {
+			//                var cellEPPlusCalculated = wsEpplusCalculated.Cells[row, col];
+			//                var cellExcelCalculated = wsExcelCalculated.Cells[row, col];
+
+			//                if (cellEPPlusCalculated.Value?.ToString() != cellExcelCalculated.Value?.ToString())
+			//                    Console.WriteLine($"Cell value mismatch in worksheet '{wsEpplusCalculated.Name}' at {cellEPPlusCalculated.Address}. Expected: '{cellExcelCalculated.Value?.ToString()}' Actual '{cellEPPlusCalculated.Value?.ToString()}'");
+
+			//            }
+			//        }
+			//    }
+			//}
+		}
     }
 }
 


### PR DESCRIPTION
Ensured EPPlus SORT function works more similar to Excel. The function now orders the results with matching values after their original sorting.

Before submitting this pull request I have...
- [x] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [x] ensured that the functionality I have added/changed is covered by new unit tests.
- [x] merged the target branch into the PR branch and resolved any merge conflicts
- [x] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).
