### PR TITLE
Get RangeInfo ByValue

### DIFF
--- a/src/EPPlus/ExternalReferences/ExcelExternalWorksheet.cs
+++ b/src/EPPlus/ExternalReferences/ExcelExternalWorksheet.cs
@@ -66,5 +66,23 @@ namespace OfficeOpenXml.ExternalReferences
         {
             return Name;
         }
+        /// <summary>
+        /// Dimension address for the worksheet for cells with a value or a style set. 
+        /// Top left cell to Bottom right.
+        /// If the worksheet has no cells, null is returned        
+        /// </summary>
+        public ExcelAddressBase GetDimension()
+        {
+            //CheckSheetTypeAndNotDisposed();
+            int fromRow, fromCol, toRow, toCol;
+            if (CellValues._values.GetDimension(out fromRow, out fromCol, out toRow, out toCol))
+            {
+                return new ExcelAddressBase(fromRow, fromCol, toRow, toCol);
+            }
+            else
+            {
+                return null;
+            }
+        }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupUtils/LookupBinarySearch.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupUtils/LookupBinarySearch.cs
@@ -22,7 +22,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.LookupUtils
     {
         private static int SearchAsc(object s, IRangeInfo lookupRange, IComparer<object> comparer, LookupRangeDirection? direction = null)
         {
-            var searchRange = LookupRangeReader.GetLookupRange(lookupRange, ref direction);
+            var valueSubRange = lookupRange.GetRangeInfoByValue();
+            var subrangeAdjustment = valueSubRange.Address.FromRow > 0 ? (valueSubRange.Address.FromRow - lookupRange.Address.FromRow) : 0;
+
+            var searchRange = LookupRangeReader.GetLookupRange(valueSubRange, ref direction);
 
             var nRows = direction == LookupRangeDirection.Vertical ? searchRange.Count : 1;
             var nCols = direction == LookupRangeDirection.Horizontal ? searchRange.Count : 1;
@@ -52,14 +55,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.LookupUtils
                 }
                 else
                 {
-                    return searchRangeCell.Index;
+                    return subrangeAdjustment + searchRangeCell.Index;
                 }
             }
             if (low < 1)
             {
-                return ~low;
+                return ~(low + subrangeAdjustment);
             }
-            return ~(searchRange[low - 1].Index + 1);
+            return ~(searchRange[low - 1].Index + subrangeAdjustment + 1);
         }
 
         private static int SearchDesc(object s, IRangeInfo lookupRange, IComparer<object> comparer)

--- a/src/EPPlus/FormulaParsing/IRangeInfo.cs
+++ b/src/EPPlus/FormulaParsing/IRangeInfo.cs
@@ -97,6 +97,12 @@ namespace OfficeOpenXml.FormulaParsing
         /// <param name="index">The index of the address.</param>
         /// <returns>The address adjusted within the dimension of the worksheet.</returns>
         public FormulaRangeAddress GetAddressDimensionAdjusted(int index);
+
+        /// <summary>
+        /// Gets dimension of rang excluding null values
+        /// </summary>
+        /// <returns></returns>
+        IRangeInfo GetRangeInfoByValue();
     }
     /// <summary>
     /// Address info

--- a/src/EPPlus/FormulaParsing/Ranges/EpplusExcelExternalRangeInfo.cs
+++ b/src/EPPlus/FormulaParsing/Ranges/EpplusExcelExternalRangeInfo.cs
@@ -10,17 +10,19 @@
  *************************************************************************************************
   01/27/2020         EPPlus Software AB       Initial release EPPlus 5
  *************************************************************************************************/
+using OfficeOpenXml.Core.CellStore;
+using OfficeOpenXml.ExternalReferences;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
+using OfficeOpenXml.FormulaParsing.ExcelUtilities;
+using OfficeOpenXml.FormulaParsing.Exceptions;
+using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
+using OfficeOpenXml.Style.XmlAccess;
+using OfficeOpenXml.Table;
+using OfficeOpenXml.Utils;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using OfficeOpenXml.FormulaParsing.ExcelUtilities;
-using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
-using OfficeOpenXml.Utils;
-using OfficeOpenXml.Style.XmlAccess;
-using OfficeOpenXml.Core.CellStore;
-using OfficeOpenXml.Table;
-using System;
-using OfficeOpenXml.FormulaParsing.Exceptions;
-using OfficeOpenXml.ExternalReferences;
+using System.Net;
 
 namespace OfficeOpenXml.FormulaParsing.Ranges
 {
@@ -62,7 +64,7 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
                 ToRow = toRow,
                 ToCol = toCol
             };
-            _size = new RangeDefinition(toRow + fromCol + 1, (short)(toCol - fromCol + 1));
+            _size = new RangeDefinition(toRow - fromRow + 1, (short)(toCol - fromCol + 1));
             if (externalReferenceIx > 0 && ctx.Package != null && ctx.Package.Workbook.ExternalLinks.Count >= externalReferenceIx)
             {
                 var externalWb = ctx.Package.Workbook.ExternalLinks[externalReferenceIx-1].As.ExternalWorkbook;
@@ -370,6 +372,27 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         public FormulaRangeAddress GetAddressDimensionAdjusted(int index)
         {
             return _address;
+        }
+
+        public IRangeInfo GetRangeInfoByValue()
+        {
+            var cellValues = _externalWs.CellValues._values;
+            var address = Address.Clone();
+
+            if (_externalWs != null)
+            {
+                var dimension = _externalWs.GetDimension();
+                address.ToRow = dimension._toRow < Address.ToRow ? dimension._toRow : Address.ToRow;
+                address.ToCol = dimension._toCol < Address.ToCol ? dimension._toCol : Address.ToCol;
+            }
+
+            var fvc = ValueFinder.FirstValueCell(address, cellValues);
+            var lvc = ValueFinder.LastValueCell(address, cellValues);
+
+            var subrangeAddress = ValueFinder.IterateColumns(fvc, lvc, address, cellValues);
+
+            var subRange = GetOffset(subrangeAddress.FromRow, subrangeAddress.FromCol, subrangeAddress.ToRow, subrangeAddress.ToCol);
+            return subRange;
         }
     }
     /// <summary>

--- a/src/EPPlus/FormulaParsing/Ranges/EpplusExcelExternalRangeInfo.cs
+++ b/src/EPPlus/FormulaParsing/Ranges/EpplusExcelExternalRangeInfo.cs
@@ -391,8 +391,7 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
 
             var subrangeAddress = ValueFinder.IterateColumns(fvc, lvc, address, cellValues);
 
-            var subRange = GetOffset(subrangeAddress.FromRow, subrangeAddress.FromCol, subrangeAddress.ToRow, subrangeAddress.ToCol);
-            return subRange;
+            return GetOffset(subrangeAddress.FromRow, subrangeAddress.FromCol, subrangeAddress.ToRow, subrangeAddress.ToCol);
         }
     }
     /// <summary>

--- a/src/EPPlus/FormulaParsing/Ranges/InMemoryRange.cs
+++ b/src/EPPlus/FormulaParsing/Ranges/InMemoryRange.cs
@@ -370,5 +370,10 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         {
             return _address;
         }
+
+        public IRangeInfo GetRangeInfoByValue()
+        {
+            return this;
+        }
     }
 }

--- a/src/EPPlus/FormulaParsing/Ranges/RangeInfo.cs
+++ b/src/EPPlus/FormulaParsing/Ranges/RangeInfo.cs
@@ -462,17 +462,12 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
 
         public IRangeInfo GetRangeInfoByValue()
         {
-            if (ValueSubrange != null)
-            {
+            var fvc = ValueFinder.FirstValueCell(Worksheet, Address);
+            var lvc = ValueFinder.LastValueCell(Worksheet, Address);
+            ValueFinder.IterateColumns(fvc, lvc, Address, Worksheet._values);
+            var subrangeAddress = ValueFinder.IterateColumns(fvc, lvc, Address, Worksheet._values);
 
-                var fvc = ValueFinder.FirstValueCell(Worksheet, Address);
-                var lvc = ValueFinder.LastValueCell(Worksheet, Address);
-                ValueFinder.IterateColumns(fvc, lvc, Address, Worksheet._values);
-                var subrangeAddress = ValueFinder.IterateColumns(fvc, lvc, Address, Worksheet._values);
-
-                ValueSubrange = GetOffset(subrangeAddress.FromRow, subrangeAddress.FromCol, subrangeAddress.ToRow, subrangeAddress.ToCol);
-            }
-            return ValueSubrange;
+            return GetOffset(subrangeAddress.FromRow, subrangeAddress.FromCol, subrangeAddress.ToRow, subrangeAddress.ToCol);
         }
     }
 }

--- a/src/EPPlus/FormulaParsing/Ranges/RangeInfo.cs
+++ b/src/EPPlus/FormulaParsing/Ranges/RangeInfo.cs
@@ -11,12 +11,18 @@
   05/31/2022         EPPlus Software AB           EPPlus 6.1
  *************************************************************************************************/
 using OfficeOpenXml.Core.CellStore;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Finance;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Information;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
+using OfficeOpenXml.Utils;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Text;
+using static OfficeOpenXml.FormulaParsing.Excel.Functions.Engineering.Conversions;
 
 namespace OfficeOpenXml.FormulaParsing.Ranges
 {
@@ -450,6 +456,23 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
             {
                 return a;
             }
+        }
+
+        IRangeInfo ValueSubrange = null;
+
+        public IRangeInfo GetRangeInfoByValue()
+        {
+            if (ValueSubrange != null)
+            {
+
+                var fvc = ValueFinder.FirstValueCell(Worksheet, Address);
+                var lvc = ValueFinder.LastValueCell(Worksheet, Address);
+                ValueFinder.IterateColumns(fvc, lvc, Address, Worksheet._values);
+                var subrangeAddress = ValueFinder.IterateColumns(fvc, lvc, Address, Worksheet._values);
+
+                ValueSubrange = GetOffset(subrangeAddress.FromRow, subrangeAddress.FromCol, subrangeAddress.ToRow, subrangeAddress.ToCol);
+            }
+            return ValueSubrange;
         }
     }
 }

--- a/src/EPPlus/Utils/ValueFinder.cs
+++ b/src/EPPlus/Utils/ValueFinder.cs
@@ -1,9 +1,13 @@
-﻿using OfficeOpenXml.FormulaParsing.Excel.Functions.Information;
+﻿using OfficeOpenXml.Core.CellStore;
+using OfficeOpenXml.FormulaParsing;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Information;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
+using OfficeOpenXml.FormulaParsing.Ranges;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 
 
@@ -15,9 +19,9 @@ namespace OfficeOpenXml.Utils
         {
             var fromRow = address.FromRow;
             var fromCol = address.FromCol;
-            var someValue = sheet._values.GetValue(address.FromRow, address.FromCol);
-            var valueOfValue = sheet._values.GetValue(address.FromRow, address.FromCol)._value;
-            if (valueOfValue == null)
+
+            var firstValue = sheet._values.GetValue(address.FromRow, address.FromCol)._value;
+            if (firstValue == null)
             {
                 while (sheet._values.NextCell(ref fromRow, ref fromCol, address.FromRow, address.FromCol, address.ToRow, address.ToCol))
                 {
@@ -30,18 +34,36 @@ namespace OfficeOpenXml.Utils
             return new List<int> { fromRow, fromCol };
         }
 
-        internal static List<int> LastValueCell(ExcelWorksheet sheet, FormulaRangeAddress address)
+        internal static List<int> FirstValueCell(FormulaRangeAddress address, CellStore<object> values)
         {
-            //The range might refer to cells outside the worksheet dimension if no value has been set.
-            //Therefore take the lower value between toRow and toCol and the dimension version of them
-            var toRow = sheet.Dimension._toRow < address.ToRow ? sheet.Dimension._toRow : address.ToRow;
-            var toCol = sheet.Dimension._toCol < address.ToCol ? sheet.Dimension._toCol : address.ToCol;
+            var fromRow = address.FromRow;
+            var fromCol = address.FromCol;
 
-            if (sheet._values.GetValue(toRow, toCol)._value == null)
+            var valueStart = values.GetValue(fromRow, fromCol);
+            if (valueStart == null)
             {
-                while (sheet._values.PrevCell(ref toRow, ref toCol) && toRow > 0)
+                while (values.NextCell(ref fromRow, ref fromCol, address.FromRow, address.ToCol - address.FromCol, address.ToRow, address.ToCol))
                 {
-                    if (toCol > 0 && sheet._values.GetValue(toRow, toCol)._value != null)
+                    var cellValue = values.GetValue(fromRow, fromCol);
+                    if (cellValue != null)
+                    {
+                        return new List<int> { fromRow, fromCol - 1 };
+                    }
+                }
+            }
+            return new List<int> { fromRow, fromCol };
+        }
+
+        internal static List<int> LastValueCell(FormulaRangeAddress address, CellStore<object> values)
+        {
+            var toRow = address.ToRow;
+            var toCol = address.ToCol;
+            var firstVal = values.GetValue(toRow, toCol);
+            if (firstVal == null)
+            {
+                while (values.PrevCell(ref toRow, ref toCol) && toRow > 0)
+                {
+                    if (toCol > 0 && values.GetValue(toRow, toCol) != null)
                     {
                         return new List<int> { toRow, toCol };
                     }
@@ -51,78 +73,127 @@ namespace OfficeOpenXml.Utils
             return new List<int> { toRow, toCol };
         }
 
-        internal static SimpleAddress RangeByValue(ExcelWorksheet sheet, FormulaRangeAddress address)
+        internal static List<int> LastValueCell(ExcelWorksheet sheet, FormulaRangeAddress address)
         {
-            var fvc = FirstValueCell(sheet, address);
-            var lvc = LastValueCell(sheet, address);
+            //The range might refer to cells outside the worksheet dimension if no value has been set.
+            //Therefore take the lower value between toRow and toCol and the dimension version of them
+            var toRow = sheet.Dimension._toRow < address.ToRow ? sheet.Dimension._toRow : address.ToRow;
+            var toCol = sheet.Dimension._toCol < address.ToCol ? sheet.Dimension._toCol : address.ToCol;
 
-            var dimValStart = sheet.DimensionByValue.Start;
-            var dimValEnd = sheet.DimensionByValue.End;
-
-            var startRow = address.FromRow;
-            var endRow = address.ToRow;
-            if (dimValStart.Row > startRow)
+            if (sheet._values.GetValue(toRow, toCol)._value == null)
             {
-                startRow = dimValStart.Row;
+                while (sheet._values.PrevCell(ref toRow, ref toCol))
+                {
+                    if (sheet._values.GetValue(toRow, toCol)._value != null)
+                    {
+                        return new List<int> { toRow, toCol };
+                    }
+                }
+                return null;
             }
-            if (dimValEnd.Row < endRow)
+            return new List<int> { toRow, toCol };
+        }
+
+        internal static SimpleAddress IterateColumns<T>(List<int> fvc, List<int> lvc, FormulaRangeAddress address, CellStore<T> csValues)
+        {
+            var fromRow = fvc[0];
+            var toRow = lvc[0];
+            int fromCol, toCol;
+
+            if (fvc[1] == address.FromRow)
             {
-                endRow = dimValEnd.Row;
+                fromCol = fvc[1];
             }
-            var startCol = address.FromCol;
-            var endCol = address.ToCol;
-            if(dimValStart.Column > startCol)
+            else
             {
-                startCol = dimValStart.Column;
+                int r = fromRow, c = address.FromCol;
+                while (csValues.NextCellByColumn(ref r, ref c, fromRow, toRow, address.ToCol - address.FromCol))
+                {
+                    if (csValues.GetValue(r, c) != null)
+                    {
+                        break;
+                    }
+                    r++;
+                }
+                fromCol = c;
             }
-            if(dimValEnd.Column < endCol)
+
+            if (lvc[1] == address.ToCol)
             {
-                endCol = dimValEnd.Column;
+                toCol = lvc[1];
             }
-            return new SimpleAddress { FromRow = Math.Min(startRow, endRow), ToRow = Math.Max(startRow, endRow), FromCol = Math.Min(startCol, endCol), ToCol = Math.Max(startCol, endCol) };
+            else
+            {
+                int r = toRow, c = address.ToCol;
+                while (csValues.PrevCellByColumn(ref r, ref c, fromRow, toRow, address.ToCol - address.FromCol))
+                {
+                    if (csValues.GetValue(r, c) != null)
+                    {
+                        break;
+                    }
+                    r--;
+                }
+                toCol = c;
+            }
 
-            //var fromRow = fvc[0];
-            //var toRow = lvc[0];
-            //int fromCol, toCol;
+            var offsetFromRow = Math.Min(fromRow, toRow) - address.FromRow;
+            var offsetFromCol = Math.Min(fromCol, toCol) - address.FromCol;
+            var offsetToRow = Math.Max(fromRow, toRow) - address.FromRow;
+            var offsetToCol = Math.Max(fromCol, toCol) - address.FromCol;
 
-            //if (fvc[1] == address.FromRow)
-            //{
-            //    fromCol = fvc[1];
-            //}
-            //else
-            //{
-            //    int r = fromRow, c = address.FromCol;
-            //    while (sheet._values.NextCellByColumn(ref r, ref c, fromRow, toRow, address.ToCol - address.FromCol))
-            //    {
-            //        if (sheet._values.GetValue(r, c)._value != null)
-            //        {
-            //            break;
-            //        }
-            //        r++;
-            //    }
-            //    fromCol = c;
-            //}
+            return new SimpleAddress(offsetFromRow, offsetFromCol, offsetToRow, offsetToCol);
+        }
 
-            //if (lvc[1] == address.ToCol)
-            //{
-            //    toCol = lvc[1];
-            //}
-            //else
-            //{
-            //    int r = toRow, c = address.ToCol;
-            //    while (sheet._values.PrevCellByColumn(ref r, ref c, fromRow, toRow, address.ToCol - address.FromCol))
-            //    {
-            //        if (sheet._values.GetValue(r, c)._value != null)
-            //        {
-            //            break;
-            //        }
-            //        r--;
-            //    }
-            //    toCol = c;
-            //}
+        internal static IRangeInfo RangeByValue(IRangeInfo rInfo)
+        {
+            List<int> fvc;
+            List<int> lvc;
 
-            //SimpleAddress subRange = new SimpleAddress { FromRow = Math.Min(fromRow, toRow), FromCol = Math.Min(fromCol, toCol), ToRow = Math.Max(fromRow, toRow), ToCol = Math.Max(fromCol, toCol) };
-            //return subRange;
+            ExcelWorksheet sheet = null;
+            FormulaRangeAddress address = null;
+            ExcelAddressBase baseAddress = null;
+            SimpleAddress subrangeAddress;
+
+            baseAddress = rInfo.Address.ToExcelAddressBase();
+
+            if (rInfo.IsInMemoryRange)
+            {
+                var memRange = rInfo as InMemoryRange;
+                return rInfo;
+            }
+            else if (baseAddress.IsExternal)
+            {
+                var extRangeInfo = (EpplusExcelExternalRangeInfo)rInfo;
+
+                var cellValues = extRangeInfo?._externalWs.CellValues._values;
+
+                var rAddress = rInfo.Address;
+                address = rInfo.Address;
+
+                if (extRangeInfo._externalWs != null)
+                {
+                    var dimension = extRangeInfo._externalWs.GetDimension();
+                    rAddress.ToRow = dimension._toRow < address.ToRow ? dimension._toRow : address.ToRow;
+                    rAddress.ToCol = dimension._toCol < address.ToCol ? dimension._toCol : address.ToCol;
+                }
+
+                fvc = FirstValueCell(rAddress, cellValues);
+                lvc = LastValueCell(rAddress, cellValues);
+
+                subrangeAddress = IterateColumns(fvc, lvc, address, cellValues);
+            }
+            else
+            {
+                sheet = rInfo.Worksheet;
+                address = rInfo.Address;
+                fvc = FirstValueCell(sheet, rInfo.Address);
+                lvc = LastValueCell(sheet, rInfo.Address);
+
+                subrangeAddress = IterateColumns(fvc, lvc, address, sheet._values);
+            }
+
+            var subRange = rInfo.GetOffset(subrangeAddress.FromRow, subrangeAddress.FromCol, subrangeAddress.ToRow, subrangeAddress.ToCol);
+            return subRange;
         }
     }
 }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/VLookupTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/VLookupTests.cs
@@ -414,5 +414,45 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
                 #endregion
             }
         }
+        [TestMethod]
+        public void VlookupMemoryRange()
+        {
+            using (var p = OpenPackage("MemRange.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("Ws1");
+                //ws.Cells["A1:A10"].Formula = "ROW()+1";
+                //ws.Cells["B1:B10"].Formula = "ROW()";
+                ws.Cells["C1"].Formula = "VLOOKUP(\"b\",TRANSPOSE({\"a\",\"b\",\"c\";1,2,3}),2)";
+                ws.Calculate();
+
+                Assert.AreEqual(2, ws.Cells["C1"].Value);
+
+                SaveAndCleanup(p);
+            }
+        }
+        [TestMethod]
+        public void FullCols()
+        {
+            using (var package = OpenTemplatePackage("ExternalVLookupFullCols.xlsx"))
+            {
+                var ws = package.Workbook.Worksheets[0];
+                ws.Calculate();
+                Assert.AreEqual(6d, ws.Cells["A1"].Value);
+                Assert.AreEqual(7d, ws.Cells["A2"].Value);
+                Assert.AreEqual(8d, ws.Cells["A3"].Value);
+                Assert.AreEqual(10d, ws.Cells["A4"].Value);
+                Assert.AreEqual(13d, ws.Cells["A5"].Value);
+            }
+        }
+        //[TestMethod]
+        //public void LookupTest()
+        //{
+        //    using (var p = OpenTemplatePackage("LookupTest.xlsx"))
+        //    {
+        //        var ws = p.Workbook.Worksheets[0];
+        //        ws.Calculate();
+        //        Assert.AreEqual(19, ws.Cells["C1"].Value);
+        //    }
+        //}
     }
 }


### PR DESCRIPTION
Enhances performance of LookupBinarySearch SearchAsc by limiting a given range to a subrange that actually contains values.
Done via using the CellStore GetNextCell and GetPreviousCell classes.