### PR TITLE
Formula Calc improvements

### DIFF
--- a/src/EPPlus/FormulaParsing/DependencyChain/RpnFormulaExecution.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/RpnFormulaExecution.cs
@@ -744,7 +744,13 @@ namespace OfficeOpenXml.FormulaParsing
                             }
                             else
                             {
-                                f._ws.SetValueInner(f._row, f._column, cr.ResultValue ?? 0D);
+                                var dVal = cr.ResultValue;
+                                if (cr.DataType == DataType.Decimal && cr.ResultNumeric == 0d)
+                                {
+                                    // this is to avoid "-0" results from the ToString method.
+                                    dVal = 0d;
+                                }
+                                f._ws.SetValueInner(f._row, f._column, dVal ?? 0D);
                             }
                         }
                     }

--- a/src/EPPlus/FormulaParsing/DependencyChain/RpnFormulaExecution.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/RpnFormulaExecution.cs
@@ -745,7 +745,7 @@ namespace OfficeOpenXml.FormulaParsing
                             else
                             {
                                 var dVal = cr.ResultValue;
-                                if (cr.DataType == DataType.Decimal && cr.ResultNumeric == 0d)
+                                if (cr.DataType == DataType.Decimal && dVal != null && dVal is double && cr.ResultNumeric == 0d)
                                 {
                                     // this is to avoid "-0" results from the ToString method.
                                     dVal = 0d;

--- a/src/EPPlus/FormulaParsing/EpplusExcelDataProvider.cs
+++ b/src/EPPlus/FormulaParsing/EpplusExcelDataProvider.cs
@@ -615,7 +615,7 @@ namespace OfficeOpenXml.FormulaParsing
             SetCurrentWorksheet(worksheetName);
             return _currentWorksheet.GetValue(row, column);
         }
-        public override string GetFormat(object value, string format)
+        public override string GetFormat(object value, string format, out bool isValidFormat)
         {
             if (_workbook.NumberFormatToTextHandler == null)
             {
@@ -634,10 +634,12 @@ namespace OfficeOpenXml.FormulaParsing
                     ft = new ExcelFormatTranslator(format, -1);
                 }
 
-                return ValueToTextHandler.FormatValue(value, false, ft, null);
+                var frmt = ValueToTextHandler.FormatValue(value, false, ft, null, out isValidFormat);
+                return frmt;
             }
             else
             {
+                isValidFormat = true;
                 var arg = new NumberFormatToTextArgs(_currentWorksheet, _context.CurrentCell.Row, _context.CurrentCell.Column, value, _currentWorksheet.GetStyleInner(_context.CurrentCell.Row, _context.CurrentCell.Column));
                 return _workbook.NumberFormatToTextHandler(arg);
             }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Engineering/Bin2Hex.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Engineering/Bin2Hex.cs
@@ -42,7 +42,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Engineering
             if (number.Length < 10)
             {
                 var n = Convert.ToInt32(number, 2);
-                return CreateResult(n.ToString(formatString), DataType.Decimal);
+                return CreateResult(n.ToString(formatString), DataType.String);
             }
             else
             {

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Offset.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Offset.cs
@@ -56,6 +56,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             var toRow = (height != 0 ? adr.FromRow + height - 1 : adr.ToRow) + (int)rowOffset;
             var toCol = (width != 0 ? adr.FromCol + width - 1 : adr.ToCol) + (int)colOffset;
 
+            if(fromRow < 1 || fromCol < 1 || toRow > ExcelPackage.MaxRows || toCol > ExcelPackage.MaxColumns)
+            {
+                return CompileResult.GetErrorResult(eErrorType.Ref);
+            }
             var newRange = context.ExcelDataProvider.GetRange(adr.WorksheetName, fromRow, fromCol, toRow, toCol);
             
             return CreateAddressResult(newRange, DataType.ExcelRange);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Text.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Text.cs
@@ -50,7 +50,11 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
             var format = ArgToString(arguments, 1);
             var invariantFormat = GetInvariantFormat(format);
 
-            var result = context.ExcelDataProvider.GetFormat(value, invariantFormat);
+            var result = context.ExcelDataProvider.GetFormat(value, invariantFormat, out bool isValidFormat);
+            if(!isValidFormat)
+            {
+                return CreateResult(eErrorType.Value);
+            }
 
             return CreateResult(result, DataType.String);
         }

--- a/src/EPPlus/FormulaParsing/ExcelDataProvider.cs
+++ b/src/EPPlus/FormulaParsing/ExcelDataProvider.cs
@@ -138,7 +138,7 @@ namespace OfficeOpenXml.FormulaParsing
         public abstract int ExcelMaxRows { get; }
 
         public abstract object GetRangeValue(string worksheetName, int row, int column);
-        public abstract string GetFormat(object value, string format);
+        public abstract string GetFormat(object value, string format, out bool isValidFormat);
 
         public abstract void Reset();
         public abstract IRangeInfo GetRange(string worksheet, int fromRow, int fromCol, int toRow, int toCol);

--- a/src/EPPlus/Style/XmlAccess/BracketTextValidator.cs
+++ b/src/EPPlus/Style/XmlAccess/BracketTextValidator.cs
@@ -1,0 +1,78 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  06/27/2025         EPPlus Software AB       Improved format handling
+ *************************************************************************************************/
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OfficeOpenXml.Style.XmlAccess
+{
+    internal static class BracketTextValidator
+    {
+        private static HashSet<string> _colors = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { "Black", "Green", "White", "Blue", "Magenta", "Yellow", "Cyan", "Red" };
+
+        private static HashSet<char> _operators = new HashSet<char> { '>', '<', '=' };
+
+        public static bool IsValid(string text)
+        {
+            if(string.IsNullOrEmpty(text)) return false;
+            if (_colors.Contains(text)) return true;
+            if (text.StartsWith("$")) return true;
+            if(IsCondition(text)) return true;
+            // indexed colors
+            if (text.ToLowerInvariant().StartsWith("color") && int.TryParse(text.Substring(5), out int n) && n >= 1 && n <= 56) return true;
+            return false;
+        }
+
+        public static bool IsCondition(string text)
+        {
+
+            if (string.IsNullOrEmpty(text)) return false;
+
+            text = text.Replace(" ", "");
+
+            int i = 0;
+            if (text.StartsWith(">=")) i = 2;
+            else if (text.StartsWith("<=")) i = 2;
+            else if (text.StartsWith(">") || text.StartsWith("<") || text.StartsWith("=")) i = 1;
+            else return false;
+
+            if (i >= text.Length) return false;
+
+            bool isValidNumber = false;
+            bool hasDecimal = false;
+
+            if (text[i] == '-') i++; // tillåt negativt tal
+
+            for (; i < text.Length; i++)
+            {
+                char c = text[i];
+                if (char.IsDigit(c))
+                {
+                    isValidNumber = true;
+                }
+                else if (c == '.' && !hasDecimal)
+                {
+                    hasDecimal = true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            return isValidNumber;
+
+        }
+    }
+}

--- a/src/EPPlus/Style/XmlAccess/ExcelFormatTranslator.cs
+++ b/src/EPPlus/Style/XmlAccess/ExcelFormatTranslator.cs
@@ -255,6 +255,12 @@ namespace OfficeOpenXml.Style.XmlAccess
                                     bracketText.StartsWith("=")) //Conditional
                             {
                                 f.SpecialDateFormat = eSystemDateFormat.Conditional;
+                                var isValidFormat = BracketTextValidator.IsValid(bracketText);
+                                if(!isValidFormat)
+                                {
+                                    sb.Append($"[{bracketText}]");
+                                    f.IsValid = false;
+                                }
                             }
                             else if (bracketText.ContainsOnlyCharacter('h'))
                             {                                

--- a/src/EPPlus/Style/XmlAccess/ExcelFormatTranslator.cs
+++ b/src/EPPlus/Style/XmlAccess/ExcelFormatTranslator.cs
@@ -38,6 +38,9 @@ namespace OfficeOpenXml.Style.XmlAccess
             internal string NetFormat { get; set; }
             internal string NetFormatForWidth { get; set; }
             internal string FractionFormat { get; set; }
+
+            internal bool IsValid { get; set; } = true;
+
             internal eSystemDateFormat SpecialDateFormat { get; set; }
             internal bool ContainsTextPlaceholder { get; set; } = false;
             internal void SetFormat(string format, bool containsAmPm, bool forColWidth)
@@ -76,7 +79,11 @@ namespace OfficeOpenXml.Style.XmlAccess
             else
             {
                 ToNetFormat(format, false);
-                ToNetFormat(format, true);
+                if(f.IsValid)
+                {
+                    ToNetFormat(format, true);
+                }
+                
             }
         }
 
@@ -275,7 +282,16 @@ namespace OfficeOpenXml.Style.XmlAccess
                                 }
                                 else
                                 {
-                                    sb.Append(bracketText);
+                                    var isValidFormat = BracketTextValidator.IsValid(bracketText);
+                                    if(!isValidFormat)
+                                    {
+                                        sb.Append($"[{bracketText}]");
+                                        f.IsValid = false;
+                                    }
+                                    else
+                                    {
+                                        sb.Append(bracketText);
+                                    }
                                 }
                                 f.SpecialDateFormat = eSystemDateFormat.Conditional;
                             }

--- a/src/EPPlus/Utils/ValueToTextHandler.cs
+++ b/src/EPPlus/Utils/ValueToTextHandler.cs
@@ -31,7 +31,7 @@ namespace OfficeOpenXml.Utils
             var styles = wb.Styles;
             ExcelFormatTranslator nf = GetNumberFormat(styleId, styles).FormatTranslator;
 
-            return FormatValue(v, forWidthCalc, nf, cultureInfo);
+            return FormatValue(v, forWidthCalc, nf, cultureInfo, out bool isValid);
         }
 
         internal static ExcelNumberFormatXml GetNumberFormat(int styleId, ExcelStyles styles)
@@ -72,10 +72,15 @@ namespace OfficeOpenXml.Utils
             return null;
         }
 
-        internal static string FormatValue(object v, bool forWidthCalc, ExcelFormatTranslator nf, CultureInfo overrideCultureInfo)
+        internal static string FormatValue(object v, bool forWidthCalc, ExcelFormatTranslator nf, CultureInfo overrideCultureInfo, out bool isValidFormat)
         {
             if (v == null) v = 0;
             var f = nf.GetFormatPart(v);
+            isValidFormat = f.IsValid;
+            if(isValidFormat == false)
+            {
+                return null;
+            }
             string format;
             if (forWidthCalc)
             {

--- a/src/EPPlusTest/EPPlus.Test.csproj
+++ b/src/EPPlusTest/EPPlus.Test.csproj
@@ -274,6 +274,9 @@
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>
+	<ItemGroup>
+	  <Folder Include="Style\XmlAccess\" />
+	</ItemGroup>
 	<PropertyGroup>
 		<SsdtUnitTestVersion>3.1</SsdtUnitTestVersion>
 	</PropertyGroup>

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -1258,6 +1258,9 @@ namespace EPPlusTest.Issues
                 Assert.AreEqual(dataSheet.Cells["D31"].Text, "0280");
                 Assert.AreEqual(dataSheet.Cells["AG31"].Text, "0110_vs_0280_Loans_Current_Received_EUR");
                 Assert.AreEqual(dataSheet.Cells["AH31"].Text, "0110_vs_0280_Ref_");
+            }
+        }
+
         [TestMethod]
         public void s868()
         {

--- a/src/EPPlusTest/Style/XmlAccess/ExcelFormatTranslatorTests.cs
+++ b/src/EPPlusTest/Style/XmlAccess/ExcelFormatTranslatorTests.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml.Style.XmlAccess;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace EPPlusTest.Style.XmlAccess
+{
+    [TestClass]
+    public class ExcelFormatTranslatorTests
+    {
+        [TestMethod]
+        public void ShouldHandleInvalidStringWithinBrackets()
+        {
+            var translator = new ExcelFormatTranslator("[YYYY-MM]", -1);
+            var r = translator.GetFormatPart(45677);
+            Assert.IsFalse(r.IsValid);
+        }
+
+
+        [TestMethod]
+        public void ShouldAcceptValidConditionWithDecimal()
+        {
+            var translator = new ExcelFormatTranslator("[<=-123.45]", -1);
+            var r = translator.GetFormatPart(123);
+            Assert.IsTrue(r.IsValid);
+        }
+
+
+        [TestMethod]
+        public void ShouldHandleValidStringWithinBrackets_1()
+        {
+            var translator = new ExcelFormatTranslator("[Red]", -1);
+            var r = translator.GetFormatPart(45677);
+            Assert.IsTrue(r.IsValid);
+            Assert.AreEqual("", r.NetFormat);
+        }
+
+        [TestMethod]
+        public void ShouldHandleValidStringWithinBrackets_2()
+        {
+            var translator = new ExcelFormatTranslator("[mm]:ss", -1);
+            var r = translator.GetFormatPart(45677);
+            Assert.IsTrue(r.IsValid);
+            Assert.AreEqual("[m]:ss", r.NetFormat);
+        }
+
+        [TestMethod]
+        public void ShouldHandleValidStringWithinBrackets_3()
+        {
+            var translator = new ExcelFormatTranslator("[$USD-409]", -1);
+            var r = translator.GetFormatPart(45677);
+            Assert.IsTrue(r.IsValid);
+            Assert.AreEqual("\"USD\"", r.NetFormat);
+        }
+
+        [TestMethod]
+        public void ShouldHandleIndexedColor()
+        {
+            var translator = new ExcelFormatTranslator("[Color12]", -1);
+            var r = translator.GetFormatPart(123);
+            Assert.IsTrue(r.IsValid);
+        }
+
+
+        [TestMethod]
+        public void ShouldRejectConditionWithDoubleDecimal()
+        {
+            var translator = new ExcelFormatTranslator("[>12.3.4]", -1);
+            var r = translator.GetFormatPart(123);
+            Assert.IsFalse(r.IsValid);
+        }
+
+        [TestMethod]
+        public void ShouldRejectConditionWithInvalidCharacters()
+        {
+            var translator = new ExcelFormatTranslator("[>12a3]", -1);
+            var r = translator.GetFormatPart(123);
+            Assert.IsFalse(r.IsValid);
+        }
+
+        [TestMethod]
+        public void ShouldRejectConditionWithOnlyOperator()
+        {
+            var translator = new ExcelFormatTranslator("[>]", -1);
+            var r = translator.GetFormatPart(123);
+            Assert.IsFalse(r.IsValid);
+        }
+
+
+
+    }
+}


### PR DESCRIPTION
This PR contains several fixes for improved formula calc:

1. Validation of number formats in the TEXT function. Invalid formats will cause a VALUE error.
2. Fix for a 0 value of a double causing "-0" to be returned by ToString()
3. Improved handling of REF errors in the OFFSET function.