### PR TITLE
Remove a call to Type.GetProperty to improve AOT support

### DIFF
--- a/src/EPPlus/Compatibility/TypeCompat.cs
+++ b/src/EPPlus/Compatibility/TypeCompat.cs
@@ -45,13 +45,5 @@ namespace OfficeOpenXml.Compatibility
 #endif
 
         }
-        public static object GetPropertyValue(object v, string name)
-        {
-#if (Core)
-            return v.GetType().GetTypeInfo().GetProperty(name).GetValue(v, null);
-#else
-            return v.GetType().GetProperty(name).GetValue(v, null);
-#endif
-        }
     }
 }

--- a/src/EPPlus/Vba/ExcelVBACollectionBase.cs
+++ b/src/EPPlus/Vba/ExcelVBACollectionBase.cs
@@ -20,7 +20,7 @@ namespace OfficeOpenXml.VBA
     /// Base class for VBA collections
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class ExcelVBACollectionBase<T> : IEnumerable<T>
+    public class ExcelVBACollectionBase<T> : IEnumerable<T> where T : IExcelVBACollectionElement
     {
         /// <summary>
         /// A list of vba objects
@@ -48,7 +48,7 @@ namespace OfficeOpenXml.VBA
         {
             get
             {
-                return _list.Find((f) => TypeCompat.GetPropertyValue(f,"Name").ToString().Equals(Name,StringComparison.OrdinalIgnoreCase));
+                return _list.Find((f) => f.Name.ToString().Equals(Name,StringComparison.OrdinalIgnoreCase));
             }
         }
         /// <summary>
@@ -77,7 +77,7 @@ namespace OfficeOpenXml.VBA
         /// <returns>True if the name exists</returns>
         public bool Exists(string Name)
         {
-            return _list.Exists((f) => TypeCompat.GetPropertyValue(f,"Name").ToString().Equals(Name,StringComparison.OrdinalIgnoreCase));
+            return _list.Exists((f) => f.Name.ToString().Equals(Name,StringComparison.OrdinalIgnoreCase));
         }
         /// <summary>
         /// Removes the item

--- a/src/EPPlus/Vba/ExcelVBAReference.cs
+++ b/src/EPPlus/Vba/ExcelVBAReference.cs
@@ -15,7 +15,7 @@ namespace OfficeOpenXml.VBA
     /// <summary>
     /// A VBA reference
     /// </summary>
-    public class ExcelVbaReference
+    public class ExcelVbaReference : IExcelVBACollectionElement
     {
         /// <summary>
         /// Constructor.

--- a/src/EPPlus/Vba/ExcelVbaModule.cs
+++ b/src/EPPlus/Vba/ExcelVbaModule.cs
@@ -21,7 +21,7 @@ namespace OfficeOpenXml.VBA
     /// <summary>
     /// A VBA code module. 
     /// </summary>
-    public class ExcelVBAModule
+    public class ExcelVBAModule : IExcelVBACollectionElement
     {
         string _name = "";
         ModuleNameChange _nameChangeCallback = null;

--- a/src/EPPlus/Vba/ExcelVbaModuleAttribute.cs
+++ b/src/EPPlus/Vba/ExcelVbaModuleAttribute.cs
@@ -15,7 +15,7 @@ namespace OfficeOpenXml.VBA
     /// <summary>
     /// A VBA modual attribute
     /// </summary>
-    public class ExcelVbaModuleAttribute
+    public class ExcelVbaModuleAttribute : IExcelVBACollectionElement
     {
         internal ExcelVbaModuleAttribute()
         {

--- a/src/EPPlus/Vba/IExcelVBACollectionElement.cs
+++ b/src/EPPlus/Vba/IExcelVBACollectionElement.cs
@@ -1,0 +1,9 @@
+namespace OfficeOpenXml.VBA {
+
+    /// <summary>
+    /// The interface that must be implemented by the elements stored by ExcelVBACollectionBase.
+    /// </summary>
+    public interface IExcelVBACollectionElement {
+        string Name{get;}
+    }
+}


### PR DESCRIPTION
EPPlus is mostly usable in a native AOT compilation context. One exception to this support is the use of the reflection method `Type.GetProperty` in `TypeCompat.GetPropertyValue`.

Fortunately, there is only one place where this method is used, in `ExcelVBACollectionBase`. By adding a type constraint on the generic type `T` of `ExcelVBACollectionBase`, we can get rid of the use of reflection.

In practice, an AOT compiled project that uses EPPlus to read an Excel file that contains VBA macro could throw a `NullReferenceException`.

## How to reproduce the issue

[epplus-vba-aot-exception.tar.gz](https://github.com/user-attachments/files/21057783/epplus-vba-aot-exception.tar.gz)

I attached a project that reproduces the problem. It runs on Linux with the dotnet CLI (I used net8.0), and it requires gcc. The script `run.sh` compiles a small C# source using AOT into a .so. This code exposes a function via the C ABI, that calls into EPPlus. It then compiles a C++ source that links against this .so and calls the exposed function.

During the AOT compilation, the trim analysis gives some warning about cryptography functions, and about `TypeCompat.GetPropertyValue`.

> ILC : Trim analysis warning IL2075: OfficeOpenXml.Compatibility.TypeCompat.GetPropertyValue(Object,String): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperty(String)'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to. [/path/to/bug-macro.csproj]

When the executable runs, I get this exception:

```
Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at OfficeOpenXml.Compatibility.TypeCompat.GetPropertyValue(Object, String) + 0x39
   at OfficeOpenXml.VBA.ExcelVBACollectionBase`1.<>c__DisplayClass9_0.<Exists>b__0(T f) + 0x1a
   at System.Collections.Generic.List`1.FindIndex(Int32, Int32, Predicate`1) + 0x4f
   at OfficeOpenXml.VBA.ExcelVBACollectionBase`1.Exists(String) + 0x5d
   at OfficeOpenXml.VBA.ExcelVbaProject.ReadProjectProperties() + 0x592
   at OfficeOpenXml.VBA.ExcelVbaProject.GetProject() + 0xeb
   at OfficeOpenXml.VBA.ExcelVbaProject..ctor(ExcelWorkbook) + 0x184
   at OfficeOpenXml.ExcelWorkbook.get_VbaProject() + 0x83
   at OfficeOpenXml.ExcelWorksheets.AddSheet(String, Boolean, Nullable`1, ExcelPivotTable, XmlElement) + 0x2c0
   at bug_macro.BugMacro.DoStuff() + 0xc7
```

With the fix in this commit, both the trim warning and the exception disappear.

Note that I could not reproduce the problem when I compile the C# code using AOT directly as an executable, but only as a shared library.

## PR checklist

Before submitting this pull request I have...
- [x] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [ ] ensured that the functionality I have added/changed is covered by new unit tests.
- [x] merged the target branch into the PR branch and resolved any merge conflicts
- [ ] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).

I did not add unit tests related to this issue, because adding a dependency on a C++ compiler seems overkill.

Also, I tried running the unit tests suite using `dotnet test`, and it hangs indefinitely (dotnet 8.0.104 running on Centos8). I am not familiar enough with the .NET tooling to investigate the reason.
