### PR TITLE
Fix for FileLoadException due to System.Memory version conflicts v8

### DIFF
--- a/src/EPPlus/CellPictures/ExcelCellPicture.cs
+++ b/src/EPPlus/CellPictures/ExcelCellPicture.cs
@@ -80,7 +80,7 @@ namespace OfficeOpenXml.CellPictures
         {
             ePictureType? pt = null;
             var b = GetImageBytes();
-            using (var stream = RecyclableMemory.GetStream(b))
+            using (var stream = EPPlusMemoryManager.GetStream(b))
             {
                 pt = ImageReader.GetPictureType(stream, false);
             }

--- a/src/EPPlus/Core/Worksheet/Fonts/GenericFontMetrics/GenericFontMetricsLoader.cs
+++ b/src/EPPlus/Core/Worksheet/Fonts/GenericFontMetrics/GenericFontMetricsLoader.cs
@@ -43,7 +43,7 @@ namespace OfficeOpenXml.Core.Worksheet.Core.Worksheet.Fonts.GenericMeasurements
                     {
                         var bytes = new byte[entry.UncompressedSize];
                         var size = zipStream.Read(bytes, 0, (int)entry.UncompressedSize);
-                        using (var ms = RecyclableMemory.GetStream(bytes))
+                        using (var ms = EPPlusMemoryManager.GetStream(bytes))
                         {
                             var fnt = GenericFontMetricsSerializer.Deserialize(ms);
                             fonts.Add(fnt.GetKey(), fnt);

--- a/src/EPPlus/Drawing/ExcelImageBase.cs
+++ b/src/EPPlus/Drawing/ExcelImageBase.cs
@@ -117,7 +117,7 @@ namespace OfficeOpenXml.Drawing
 
             PictureStore.SavePicture(image, _container, pictureType);
 
-            using (var ms = RecyclableMemory.GetStream(image))
+            using (var ms = EPPlusMemoryManager.GetStream(image))
             {
                 if (_container.RelationDocument.Package.Settings.ImageSettings.GetImageBounds(ms, pictureType, out double width, out double height, out double horizontalResolution, out double verticalResolution))
                 {
@@ -182,7 +182,7 @@ namespace OfficeOpenXml.Drawing
             {
                 ImageBytes = image;
             }
-            using (var ms = RecyclableMemory.GetStream(image))
+            using (var ms = EPPlusMemoryManager.GetStream(image))
             {
                 var imageHandler = new GenericImageHandler();
                 if (imageHandler.GetImageBounds(ms, pictureType, out double width, out double height, out double horizontalResolution, out double verticalResolution))

--- a/src/EPPlus/Drawing/ExcelPicture.cs
+++ b/src/EPPlus/Drawing/ExcelPicture.cs
@@ -211,7 +211,7 @@ namespace OfficeOpenXml.Drawing
                 type = pt.Value;
             }
 
-            using (var ms = RecyclableMemory.GetStream(img))
+            using (var ms = EPPlusMemoryManager.GetStream(img))
             {
                 Image.Type = type;
                 Image.ImageBytes = img;
@@ -282,7 +282,7 @@ namespace OfficeOpenXml.Drawing
 
             container.ImageHash = ii.Hash;
 
-            using (var ms = RecyclableMemory.GetStream(img))
+            using (var ms = EPPlusMemoryManager.GetStream(img))
             {
                 Image.ImageBytes = img;
                 Image.Type = type;

--- a/src/EPPlus/Drawing/ImageHandling/ImageReader.cs
+++ b/src/EPPlus/Drawing/ImageHandling/ImageReader.cs
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.Drawing
             }
             else
             {
-                Stream newMs = RecyclableMemory.GetStream();
+                Stream newMs = EPPlusMemoryManager.GetStream();
                 StreamUtil.CopyStream(stream, ref newMs);
                 pt = GetPictureTypeFromMs((MemoryStream)newMs);
                 newMs.Dispose();
@@ -63,7 +63,7 @@ namespace OfficeOpenXml.Drawing
             }
             else
             {
-                using (Stream newMs = RecyclableMemory.GetStream())
+                using (Stream newMs = EPPlusMemoryManager.GetStream())
                 {
                     await StreamUtil.CopyStreamAsync(stream, newMs, new CancellationToken()).ConfigureAwait(false);
                     pt = GetPictureTypeFromMs((MemoryStream)newMs);
@@ -199,9 +199,9 @@ namespace OfficeOpenXml.Drawing
             {
                 try
                 {
-                    using(var ms = RecyclableMemory.GetStream(img))
+                    using(var ms = EPPlusMemoryManager.GetStream(img))
                     {
-                        using(var msOut = RecyclableMemory.GetStream())
+                        using(var msOut = EPPlusMemoryManager.GetStream())
                         {
                             const int bufferSize = 4096;
                             var buffer = new byte[bufferSize];

--- a/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
+++ b/src/EPPlus/Drawing/ImageHandling/PictureStore.cs
@@ -177,7 +177,7 @@ namespace OfficeOpenXml.Drawing
         {
             var ret = new ExcelImageInfo();
             var s = pck.Settings.ImageSettings;
-            using(var ms = RecyclableMemory.GetStream(image))
+            using(var ms = EPPlusMemoryManager.GetStream(image))
             {
                 if (s.GetImageBounds(ms, type, out double width, out double height, out double horizontalResolution, out double verticalResolution) == false)
                 {

--- a/src/EPPlus/Drawing/OleObject/Structures/CompObj.cs
+++ b/src/EPPlus/Drawing/OleObject/Structures/CompObj.cs
@@ -66,7 +66,7 @@ namespace OfficeOpenXml.Drawing.OleObject.Structures
         }
         internal static void ReadCompObjStream(OleObjectDataStructures _oleDataStructures, byte[] oleBytes)
         {
-            using (var ms = RecyclableMemory.GetStream(oleBytes))
+            using (var ms = EPPlusMemoryManager.GetStream(oleBytes))
             {
                 BinaryReader br = new BinaryReader(ms);
                 _oleDataStructures.CompObj.Header = ReadCompObjHeader(br);

--- a/src/EPPlus/Drawing/OleObject/Structures/Ole.cs
+++ b/src/EPPlus/Drawing/OleObject/Structures/Ole.cs
@@ -142,7 +142,7 @@ namespace OfficeOpenXml.Drawing.OleObject.Structures
 
         internal static void ReadOleStream(OleObjectDataStructures _oleDataStructures, byte[] oleBytes)
         {
-            using (var ms = RecyclableMemory.GetStream(oleBytes))
+            using (var ms = EPPlusMemoryManager.GetStream(oleBytes))
             {
                 BinaryReader br = new BinaryReader(ms);
                 _oleDataStructures.Ole.Version = br.ReadUInt32();

--- a/src/EPPlus/Drawing/OleObject/Structures/Ole10Native.cs
+++ b/src/EPPlus/Drawing/OleObject/Structures/Ole10Native.cs
@@ -87,7 +87,7 @@ namespace OfficeOpenXml.Drawing.OleObject.Structures
 
         internal static void ReadOle10Native(OleObjectDataStructures _oleDataStructures, byte[] oleBytes)
         {
-            using (var ms = RecyclableMemory.GetStream(oleBytes))
+            using (var ms = EPPlusMemoryManager.GetStream(oleBytes))
             {
                 BinaryReader br = new BinaryReader(ms);
                 _oleDataStructures.OleNative.Header = ReadOle10NativeHeader(br);

--- a/src/EPPlus/Drawing/OleObject/Structures/OleDataFile.cs
+++ b/src/EPPlus/Drawing/OleObject/Structures/OleDataFile.cs
@@ -33,7 +33,7 @@ namespace OfficeOpenXml.Drawing.OleObject.Structures
 
         internal static int ReadDataFileObject(OleObjectDataStructures _oleObjectDataStructures, byte[] fileData)
         {
-            using (var ms = RecyclableMemory.GetStream(fileData))
+            using (var ms = EPPlusMemoryManager.GetStream(fileData))
             {
                 BinaryReader br = new BinaryReader(ms);
                 _oleObjectDataStructures.DataFile = new byte[br.BaseStream.Length];

--- a/src/EPPlus/Drawing/Theme/ExcelThemeManager.cs
+++ b/src/EPPlus/Drawing/Theme/ExcelThemeManager.cs
@@ -112,7 +112,7 @@ namespace OfficeOpenXml.Drawing.Theme
                 throw (new FileNotFoundException($"{thmxFile.FullName} does not exist"));
             }
 
-            using (var ms = RecyclableMemory.GetStream(File.ReadAllBytes(thmxFile.FullName)))
+            using (var ms = EPPlusMemoryManager.GetStream(File.ReadAllBytes(thmxFile.FullName)))
             {
                 Load(ms);
             }

--- a/src/EPPlus/Encryption/EncryptionHandler.cs
+++ b/src/EPPlus/Encryption/EncryptionHandler.cs
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.Encryption
             if (CompoundDocument.IsCompoundDocument(fi))
             {
                 var b=File.ReadAllBytes(fi.FullName);
-                using (var ms = RecyclableMemory.GetStream(b))
+                using (var ms = EPPlusMemoryManager.GetStream(b))
                 {
                     return GetStreamFromPackage(ms, encryption);
                 }
@@ -165,17 +165,17 @@ namespace OfficeOpenXml.Encryption
             var VerifierHashKey = GetFinalHash(hashProvider, BlockKey_HashValue, baseHash);
             var KeyValueKey = GetFinalHash(hashProvider, BlockKey_KeyValue, baseHash);
 
-            var ms = RecyclableMemory.GetStream();
+            var ms = EPPlusMemoryManager.GetStream();
             EncryptAgileFromKey(encr, VerifierInputKey, encr.VerifierHashInput, 0, encr.VerifierHashInput.Length, encr.SaltValue, ms);
             encr.EncryptedVerifierHashInput = ms.ToArray();
             ms.Dispose();
 
-            ms = RecyclableMemory.GetStream();
+            ms = EPPlusMemoryManager.GetStream();
             EncryptAgileFromKey(encr, VerifierHashKey, encr.VerifierHash, 0, encr.VerifierHash.Length, encr.SaltValue, ms);
             encr.EncryptedVerifierHash = ms.ToArray();
             ms.Dispose();
 
-            ms = RecyclableMemory.GetStream();
+            ms = EPPlusMemoryManager.GetStream();
             EncryptAgileFromKey(encr, KeyValueKey, encr.KeyValue, 0, encr.KeyValue.Length, encr.SaltValue, ms);
             encr.EncryptedKeyValue = ms.ToArray();
             ms.Dispose();
@@ -184,7 +184,7 @@ namespace OfficeOpenXml.Encryption
 
             var byXml = Encoding.UTF8.GetBytes(xml);
 
-            ms = RecyclableMemory.GetStream();
+            ms = EPPlusMemoryManager.GetStream();
             ms.Write(BitConverter.GetBytes((ushort)4), 0, 2); //Major Version
             ms.Write(BitConverter.GetBytes((ushort)4), 0, 2); //Minor Version
             ms.Write(BitConverter.GetBytes((uint)0x40), 0, 4); //Reserved
@@ -200,7 +200,7 @@ namespace OfficeOpenXml.Encryption
 
             //...and the encrypted package
             doc.Storage.DataStreams.Add(ENCRYPTED_PACKAGE_STREAM_NAME, new CompoundDocumentItem(ENCRYPTED_PACKAGE_STREAM_NAME, encrData));
-            ms = RecyclableMemory.GetStream();
+            ms = EPPlusMemoryManager.GetStream();
             doc.Save(ms);
             //ms.Write(e,0,e.Length);
             return ms;
@@ -223,7 +223,7 @@ namespace OfficeOpenXml.Encryption
 
             //Encrypt the data
             using (
-            var ms = RecyclableMemory.GetStream())
+            var ms = EPPlusMemoryManager.GetStream())
             {
                 ms.Write(BitConverter.GetBytes((ulong)data.Length), 0, 8);
                 while (pos < data.Length)
@@ -247,7 +247,7 @@ namespace OfficeOpenXml.Encryption
         private void SetHMAC(EncryptionInfoAgile ei, HashAlgorithm hashProvider, byte[] salt, byte[] data)
         {
             var iv = GetFinalHash(hashProvider, BlockKey_HmacKey, ei.KeyData.SaltValue);
-            var ms = RecyclableMemory.GetStream();
+            var ms = EPPlusMemoryManager.GetStream();
             EncryptAgileFromKey(ei.KeyEncryptors[0], ei.KeyEncryptors[0].KeyValue, salt, 0L, salt.Length, iv, ms);
             ei.DataIntegrity.EncryptedHmacKey = ms.ToArray();
             ms.Dispose();
@@ -255,7 +255,7 @@ namespace OfficeOpenXml.Encryption
             var h = GetHmacProvider(ei.KeyEncryptors[0], salt);
             var hmacValue = h.ComputeHash(data);
 
-            ms = RecyclableMemory.GetStream();
+            ms = EPPlusMemoryManager.GetStream();
             iv = GetFinalHash(hashProvider, BlockKey_HmacValue, ei.KeyData.SaltValue);
             EncryptAgileFromKey(ei.KeyEncryptors[0], ei.KeyEncryptors[0].KeyValue, hmacValue, 0L, hmacValue.Length, iv, ms);
             ei.DataIntegrity.EncryptedHmacValue = ms.ToArray();
@@ -309,14 +309,14 @@ namespace OfficeOpenXml.Encryption
             
             //Encrypt the package
             byte[] encryptedPackage = EncryptData(encryptionKey, package, false);
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 ms.Write(BitConverter.GetBytes((ulong)package.Length), 0, 8);
                 ms.Write(encryptedPackage, 0, encryptedPackage.Length);
                 doc.Storage.DataStreams.Add(ENCRYPTED_PACKAGE_STREAM_NAME, new CompoundDocumentItem(ENCRYPTED_PACKAGE_STREAM_NAME, ms.ToArray()));
             }
 
-            var ret = RecyclableMemory.GetStream();
+            var ret = EPPlusMemoryManager.GetStream();
             doc.Save(ret);
 
             return ret;
@@ -344,7 +344,7 @@ namespace OfficeOpenXml.Encryption
         }
         private byte[] CreateStrongEncryptionDataSpaceStream()
         {
-            using (MemoryStream ms = RecyclableMemory.GetStream())
+            using (MemoryStream ms = EPPlusMemoryManager.GetStream())
             {
                 BinaryWriter bw = new BinaryWriter(ms);
 
@@ -361,7 +361,7 @@ namespace OfficeOpenXml.Encryption
         }
         private byte[] CreateVersionStream()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 BinaryWriter bw = new BinaryWriter(ms);
 
@@ -378,7 +378,7 @@ namespace OfficeOpenXml.Encryption
         }
         private byte[] CreateDataSpaceMap()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 BinaryWriter bw = new BinaryWriter(ms);
 
@@ -400,7 +400,7 @@ namespace OfficeOpenXml.Encryption
         }
         private byte[] CreateTransformInfoPrimary()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 BinaryWriter bw = new BinaryWriter(ms);
                 string TransformID = "{FF9A3F03-56EF-4613-BDD5-5A41C1D07246}";
@@ -496,7 +496,7 @@ namespace OfficeOpenXml.Encryption
 
             //Encrypt the data
             var crypt = aes.CreateEncryptor(key, null);
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 var cs = new CryptoStream(ms, crypt, CryptoStreamMode.Write);
                 cs.Write(data, 0, data.Length);
@@ -626,7 +626,7 @@ namespace OfficeOpenXml.Encryption
                     int pos = 0;
                     uint segment = 0;
 
-                    var doc = RecyclableMemory.GetStream();
+                    var doc = EPPlusMemoryManager.GetStream();
                     while (pos < size)
                     {
                         var segmentSize = (int)(size - pos > 4096 ? 4096 : size - pos);
@@ -698,7 +698,7 @@ namespace OfficeOpenXml.Encryption
 #endif
         private MemoryStream DecryptBinary(EncryptionInfoBinary encryptionInfo, string password, long size, byte[] encryptedData)
         {
-            var doc = RecyclableMemory.GetStream();
+            var doc = EPPlusMemoryManager.GetStream();
 
             if (encryptionInfo.Header.AlgID == AlgorithmID.AES128 || (encryptionInfo.Header.AlgID == AlgorithmID.Flags && ((encryptionInfo.Flags & (Flags.fAES | Flags.fExternal | Flags.fCryptoAPI)) == (Flags.fAES | Flags.fCryptoAPI)))
                 ||
@@ -723,7 +723,7 @@ namespace OfficeOpenXml.Encryption
                                                                 key,
                                                                 null);
 
-                    using (var dataStream = RecyclableMemory.GetStream(encryptedData))
+                    using (var dataStream = EPPlusMemoryManager.GetStream(encryptedData))
                     {
                         var cryptoStream = new CryptoStream(dataStream,
                                                                         decryptor,
@@ -768,7 +768,7 @@ namespace OfficeOpenXml.Encryption
             MemoryStream dataStream;
             var decryptedVerifier = new byte[16];
             var decryptedVerifierHash = new byte[16];
-            using (dataStream = RecyclableMemory.GetStream(encryptionInfo.Verifier.EncryptedVerifier))
+            using (dataStream = EPPlusMemoryManager.GetStream(encryptionInfo.Verifier.EncryptedVerifier))
             {
                 CryptoStream cryptoStream = new CryptoStream(dataStream,
                                                               decryptor,
@@ -776,7 +776,7 @@ namespace OfficeOpenXml.Encryption
                 var r = cryptoStream.Read(decryptedVerifier, 0, 16);
             }
 
-            using (dataStream = RecyclableMemory.GetStream(encryptionInfo.Verifier.EncryptedVerifierHash))
+            using (dataStream = EPPlusMemoryManager.GetStream(encryptionInfo.Verifier.EncryptedVerifierHash))
             {
                 var cryptoStream = new CryptoStream(dataStream,
                                                     decryptor,
@@ -841,7 +841,7 @@ namespace OfficeOpenXml.Encryption
                                                         FixHashSize(iv, encr.BlockSize, 0x36));
 
 
-            using (var dataStream = RecyclableMemory.GetStream(encryptedData))
+            using (var dataStream = EPPlusMemoryManager.GetStream(encryptedData))
             {
 
                 using (var cryptoStream = new CryptoStream(dataStream, decryptor, CryptoStreamMode.Read))

--- a/src/EPPlus/Encryption/EncryptionHeader.cs
+++ b/src/EPPlus/Encryption/EncryptionHeader.cs
@@ -65,7 +65,7 @@ namespace OfficeOpenXml.Encryption
         internal string CSPName;            //SHOULD<11> be set to either "Microsoft Enhanced RSA and AES Cryptographic Provider" or "Microsoft Enhanced RSA and AES Cryptographic Provider (Prototype)" as a null-terminated Unicode string.
         internal byte[] WriteBinary()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 BinaryWriter bw = new BinaryWriter(ms);
 

--- a/src/EPPlus/Encryption/EncryptionInfo.cs
+++ b/src/EPPlus/Encryption/EncryptionInfo.cs
@@ -549,7 +549,7 @@ namespace OfficeOpenXml.Encryption
         }
         internal byte[] WriteBinary()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 BinaryWriter bw = new BinaryWriter(ms);
 

--- a/src/EPPlus/Encryption/EncryptionVerifier.cs
+++ b/src/EPPlus/Encryption/EncryptionVerifier.cs
@@ -32,7 +32,7 @@ namespace OfficeOpenXml.Encryption
         internal byte[] EncryptedVerifierHash; //(variable): An array of bytes that contains the encrypted form of the hash of the randomly generated Verifier value. The length of the array MUST be the size of the encryption block size multiplied by the number of blocks needed to encrypt the hash of the Verifier. If the encryption algorithm is RC4, the length MUST be 20 bytes. If the encryption algorithm is AES, the length MUST be 32 bytes.
         internal byte[] WriteBinary()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 BinaryWriter bw = new BinaryWriter(ms);
 

--- a/src/EPPlus/ExcelEncryption.cs
+++ b/src/EPPlus/ExcelEncryption.cs
@@ -217,7 +217,7 @@ namespace OfficeOpenXml
                 stream.Read(b, 0, (int)stream.Length);
                 ms = new MemoryStream(b);
 #else
-                ms = RecyclableMemory.GetStream();
+                ms = EPPlusMemoryManager.GetStream();
                 stream.CopyTo(ms);                
 #endif
             }

--- a/src/EPPlus/ExcelPackage.cs
+++ b/src/EPPlus/ExcelPackage.cs
@@ -496,9 +496,9 @@ namespace OfficeOpenXml
                     throw new IOException($"{template.FullName} cannot be a zero-byte file.");
                 }
                 if (_stream == null)
-                    _stream = RecyclableMemory.GetStream();
+                    _stream = EPPlusMemoryManager.GetStream();
 
-                var ms = RecyclableMemory.GetStream();
+                var ms = EPPlusMemoryManager.GetStream();
                 if(CompoundDocument.IsCompoundDocument(template))
                 {
                     Encryption.IsEncrypted = true;
@@ -538,7 +538,7 @@ namespace OfficeOpenXml
         }
         private void ConstructNewFile(string password)
         {
-            if (_stream == null) _stream = RecyclableMemory.GetStream();
+            if (_stream == null) _stream = EPPlusMemoryManager.GetStream();
             if (File != null) File.Refresh();
             if (File != null && File.Exists && File.Length > 0)
             {
@@ -552,7 +552,7 @@ namespace OfficeOpenXml
                 }
                 else
                 {
-                    ms = RecyclableMemory.GetStream();
+                    ms = EPPlusMemoryManager.GetStream();
                     WriteFileToStream(File.FullName, ms);
                 }
                 try
@@ -880,7 +880,7 @@ namespace OfficeOpenXml
                     if (Encryption.IsEncrypted && (Encryption.Version == EncryptionVersion.Standard || Encryption.Version == EncryptionVersion.Agile))
                     {
                         byte[] file;
-                        using (var ms = RecyclableMemory.GetStream())
+                        using (var ms = EPPlusMemoryManager.GetStream())
                         {
                             _zipPackage.Save(ms);
                             file = ms.ToArray();
@@ -894,7 +894,7 @@ namespace OfficeOpenXml
 #if (!NET35)
                     else if (SensibilityLabels.Labels.Count > 0 && ExcelPackage.SensibilityLabelHandler != null)
                     {
-                        using (var ms = RecyclableMemory.GetStream())
+                        using (var ms = EPPlusMemoryManager.GetStream())
                         {
                             _zipPackage.Save(ms);
                             _stream = SensibilityLabels.ApplyLabel(ms.ToArray()).ConfigureAwait(false).GetAwaiter().GetResult(); 
@@ -1070,7 +1070,7 @@ namespace OfficeOpenXml
                 _stream.Dispose();
             }
 
-            _stream = RecyclableMemory.GetStream();
+            _stream = EPPlusMemoryManager.GetStream();
         }
         /// <summary>
         /// The output stream. This stream is the not the encrypted package.
@@ -1246,7 +1246,7 @@ namespace OfficeOpenXml
         /// <param name="input">The input.</param>
         public void Load(Stream input)
         {
-            Load(input, RecyclableMemory.GetStream(), null);            
+            Load(input, EPPlusMemoryManager.GetStream(), null);            
         }
         /// <summary>
         /// Loads the specified package data from a stream.
@@ -1255,7 +1255,7 @@ namespace OfficeOpenXml
         /// <param name="Password">The password to decrypt the document</param>
         public void Load(Stream input, string Password)
         {
-            Load(input, RecyclableMemory.GetStream(), Password);
+            Load(input, EPPlusMemoryManager.GetStream(), Password);
         }   
         /// <summary>
         /// 
@@ -1273,7 +1273,7 @@ namespace OfficeOpenXml
             }
             else
             {
-                Stream ms = RecyclableMemory.GetStream();
+                Stream ms = EPPlusMemoryManager.GetStream();
                 StreamUtil.CopyStream(input, ref ms);
                 if(CompoundDocument.IsCompoundDocument((MemoryStream)ms))
                 {

--- a/src/EPPlus/ExcelPackageAsync.cs
+++ b/src/EPPlus/ExcelPackageAsync.cs
@@ -36,7 +36,7 @@ namespace OfficeOpenXml
         {
             using (var stream = fileInfo.OpenRead())
             {
-                await LoadAsync(stream, RecyclableMemory.GetStream(), null, cancellationToken).ConfigureAwait(false);
+                await LoadAsync(stream, EPPlusMemoryManager.GetStream(), null, cancellationToken).ConfigureAwait(false);
             }
         }
         /// <summary>
@@ -59,7 +59,7 @@ namespace OfficeOpenXml
         {
             using (var stream = fileInfo.OpenRead())
             {
-                await LoadAsync(stream, RecyclableMemory.GetStream(), Password, cancellationToken).ConfigureAwait(false);
+                await LoadAsync(stream, EPPlusMemoryManager.GetStream(), Password, cancellationToken).ConfigureAwait(false);
                 stream.Close();
             }
         }
@@ -108,7 +108,7 @@ namespace OfficeOpenXml
         /// <param name="cancellationToken">The cancellation token</param>
         public async Task LoadAsync(Stream input, CancellationToken cancellationToken = default)
         {
-            await LoadAsync(input, RecyclableMemory.GetStream(), null, cancellationToken).ConfigureAwait(false);
+            await LoadAsync(input, EPPlusMemoryManager.GetStream(), null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace OfficeOpenXml
         /// <param name="cancellationToken">The cancellation token</param>
         public async Task LoadAsync(Stream input, string Password, CancellationToken cancellationToken = default)
         {
-            await LoadAsync(input, RecyclableMemory.GetStream(), Password, cancellationToken).ConfigureAwait(false);
+            await LoadAsync(input, EPPlusMemoryManager.GetStream(), Password, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace OfficeOpenXml
                 _stream = output;
                 if (Password != null)
                 {
-                    using (var encrStream = RecyclableMemory.GetStream())
+                    using (var encrStream = EPPlusMemoryManager.GetStream())
                     {
                         await StreamUtil.CopyStreamAsync(input, encrStream, cancellationToken).ConfigureAwait(false);
                         var eph = new EncryptedPackageHandler(null);
@@ -153,7 +153,7 @@ namespace OfficeOpenXml
                 }
                 else
                 {
-                    ms = RecyclableMemory.GetStream();
+                    ms = EPPlusMemoryManager.GetStream();
                     await StreamUtil.CopyStreamAsync(input, ms, cancellationToken).ConfigureAwait(false);
                 }
 
@@ -217,7 +217,7 @@ namespace OfficeOpenXml
                 {
                     if (Encryption.IsEncrypted)
                     {
-                        using (var ms = RecyclableMemory.GetStream())
+                        using (var ms = EPPlusMemoryManager.GetStream())
                         {
                             _zipPackage.Save(ms);
                             var file = ms.ToArray();
@@ -230,7 +230,7 @@ namespace OfficeOpenXml
                     }
                     else if (SensibilityLabels.Labels.Count > 0 && ExcelPackage.SensibilityLabelHandler != null)
                     {
-                        using (var ms = RecyclableMemory.GetStream())
+                        using (var ms = EPPlusMemoryManager.GetStream())
                         {
                             _zipPackage.Save(ms);
                             _stream = await SensibilityLabels.ApplyLabel(ms.ToArray()).ConfigureAwait(false);
@@ -279,7 +279,7 @@ namespace OfficeOpenXml
                             }
                             else if (SensibilityLabels.Labels.Count > 0 && ExcelPackage.SensibilityLabelHandler != null)
                             {
-                                using (var ms = RecyclableMemory.GetStream())
+                                using (var ms = EPPlusMemoryManager.GetStream())
                                 {
                                     _zipPackage.Save(ms);
                                     stream = await SensibilityLabels.ApplyLabel(ms.ToArray()).ConfigureAwait(false);
@@ -466,7 +466,7 @@ namespace OfficeOpenXml
 #else
                     _stream.Dispose();
 #endif
-                    _stream = RecyclableMemory.GetStream();
+                    _stream = EPPlusMemoryManager.GetStream();
                 }
                 _zipPackage.Save(_stream);
             }
@@ -542,8 +542,8 @@ namespace OfficeOpenXml
 
         private async Task ConstructNewFileAsync(string password, CancellationToken cancellationToken)
         {
-            var ms = RecyclableMemory.GetStream();
-            if (_stream == null) _stream = RecyclableMemory.GetStream();
+            var ms = EPPlusMemoryManager.GetStream();
+            if (_stream == null) _stream = EPPlusMemoryManager.GetStream();
             File?.Refresh();
             if (File != null && File.Exists)
             {

--- a/src/EPPlus/ExcelRangeBase_Save.cs
+++ b/src/EPPlus/ExcelRangeBase_Save.cs
@@ -116,7 +116,7 @@ namespace OfficeOpenXml
         /// <returns>A string containing the text</returns>
         public string ToText(ExcelOutputTextFormat Format)
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 SaveToText(ms, Format);
                 ms.Position = 0;
@@ -219,7 +219,7 @@ namespace OfficeOpenXml
         /// <returns>A string containing the text</returns>
         public string ToText(ExcelOutputTextFormatFixedWidth Format)
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 SaveToText(ms, Format);
                 ms.Position = 0;
@@ -410,7 +410,7 @@ namespace OfficeOpenXml
         /// <returns>A string containing the text</returns>
         public async Task<string> ToTextAsync(ExcelOutputTextFormat Format)
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 await SaveToTextAsync(ms, Format).ConfigureAwait(false);
                 ms.Position = 0;
@@ -511,7 +511,7 @@ namespace OfficeOpenXml
         /// <returns>A string containing the text</returns>
         public async Task<string> ToTextAsync(ExcelOutputTextFormatFixedWidth Format)
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 await SaveToTextAsync(ms, Format);
                 ms.Position = 0;
@@ -691,7 +691,7 @@ namespace OfficeOpenXml
         public string ToJson()
         {
             var re = new JsonRangeExport(this, new JsonRangeExportSettings());
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 re.Export(ms);
                 return Encoding.UTF8.GetString(ms.ToArray());
@@ -707,7 +707,7 @@ namespace OfficeOpenXml
             var s = new JsonRangeExportSettings();
             settings.Invoke(s);
             var re = new JsonRangeExport(this, s);
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 re.Export(ms);
                 return s.Encoding.GetString(ms.ToArray());

--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -1239,7 +1239,7 @@ namespace OfficeOpenXml
 
             // now release stream buffer (already converted whole Xml into XmlDocument Object and String)
             stream.Dispose();
-            packPart.Stream = RecyclableMemory.GetStream();
+            packPart.Stream = EPPlusMemoryManager.GetStream();
 
             //first char is invalid sometimes?? 
             Encoding encoding = Encoding.UTF8;

--- a/src/EPPlus/Export/HtmlExport/Exporters/Internal/CssRangeExporterAsync.cs
+++ b/src/EPPlus/Export/HtmlExport/Exporters/Internal/CssRangeExporterAsync.cs
@@ -39,7 +39,7 @@ namespace OfficeOpenXml.Export.HtmlExport.Exporters
         /// <returns>A html table</returns>
         public async Task<string> GetCssStringAsync()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 await RenderCssAsync(ms);
                 ms.Position = 0;

--- a/src/EPPlus/Export/HtmlExport/Exporters/Internal/CssRangeExporterSync.cs
+++ b/src/EPPlus/Export/HtmlExport/Exporters/Internal/CssRangeExporterSync.cs
@@ -40,7 +40,7 @@ namespace OfficeOpenXml.Export.HtmlExport.Exporters.Internal
         /// <returns>A html table</returns>
         public string GetCssString()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 RenderCss(ms);
                 ms.Position = 0;

--- a/src/EPPlus/Export/HtmlExport/Exporters/Internal/CssTableExporterAsync.cs
+++ b/src/EPPlus/Export/HtmlExport/Exporters/Internal/CssTableExporterAsync.cs
@@ -37,7 +37,7 @@ namespace OfficeOpenXml.Export.HtmlExport.Exporters
         /// <returns>A html table</returns>
         public async Task<string> GetCssStringAsync()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 await RenderCssAsync(ms);
                 ms.Position = 0;

--- a/src/EPPlus/Export/HtmlExport/Exporters/Internal/CssTableExporterSync.cs
+++ b/src/EPPlus/Export/HtmlExport/Exporters/Internal/CssTableExporterSync.cs
@@ -34,7 +34,7 @@ namespace OfficeOpenXml.Export.HtmlExport.Exporters.Internal
         /// <returns>A html table</returns>
         public string GetCssString()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 RenderCss(ms);
                 ms.Position = 0;

--- a/src/EPPlus/Export/HtmlExport/Exporters/Internal/HtmlRangeExporterAsync.cs
+++ b/src/EPPlus/Export/HtmlExport/Exporters/Internal/HtmlRangeExporterAsync.cs
@@ -36,7 +36,7 @@ namespace OfficeOpenXml.Export.HtmlExport.Exporters
         /// <returns>A html table</returns>
         public async Task<string> GetHtmlStringAsync()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 await RenderHtmlAsync(ms, 0);
                 ms.Position = 0;
@@ -54,7 +54,7 @@ namespace OfficeOpenXml.Export.HtmlExport.Exporters
         /// <returns>A html table</returns>
         public async Task<string> GetHtmlStringAsync(int rangeIndex, ExcelHtmlOverrideExportSettings settings = null)
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 await RenderHtmlAsync(ms, rangeIndex, settings);
                 ms.Position = 0;

--- a/src/EPPlus/Export/HtmlExport/Exporters/Internal/HtmlRangeExporterSync.cs
+++ b/src/EPPlus/Export/HtmlExport/Exporters/Internal/HtmlRangeExporterSync.cs
@@ -35,7 +35,7 @@ namespace OfficeOpenXml.Export.HtmlExport.Exporters.Internal
         /// <returns>A html table</returns>
         public string GetHtmlString()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 RenderHtml(ms, 0);
                 ms.Position = 0;
@@ -52,7 +52,7 @@ namespace OfficeOpenXml.Export.HtmlExport.Exporters.Internal
         public string GetHtmlString(int rangeIndex)
         {
             ValidateRangeIndex(rangeIndex);
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 RenderHtml(ms, rangeIndex);
                 ms.Position = 0;
@@ -72,7 +72,7 @@ namespace OfficeOpenXml.Export.HtmlExport.Exporters.Internal
         public string GetHtmlString(int rangeIndex, ExcelHtmlOverrideExportSettings settings)
         {
             ValidateRangeIndex(rangeIndex);
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 RenderHtml(ms, rangeIndex, settings);
                 ms.Position = 0;

--- a/src/EPPlus/Export/HtmlExport/Exporters/Internal/HtmlTableExporterAsync.cs
+++ b/src/EPPlus/Export/HtmlExport/Exporters/Internal/HtmlTableExporterAsync.cs
@@ -31,7 +31,7 @@ namespace OfficeOpenXml.Export.HtmlExport.Exporters
         /// <returns>A html table</returns>
         public async Task<string> GetHtmlStringAsync()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 await RenderHtmlAsync(ms);
                 ms.Position = 0;

--- a/src/EPPlus/Export/HtmlExport/Exporters/Internal/HtmlTableExporterSync.cs
+++ b/src/EPPlus/Export/HtmlExport/Exporters/Internal/HtmlTableExporterSync.cs
@@ -29,7 +29,7 @@ namespace OfficeOpenXml.Export.HtmlExport.Exporters.Internal
         /// <returns>A html table</returns>
         public string GetHtmlString()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 RenderHtml(ms);
                 ms.Position = 0;

--- a/src/EPPlus/FontSize.cs
+++ b/src/EPPlus/FontSize.cs
@@ -220,7 +220,7 @@ namespace OfficeOpenXml
                                 var br = new BinaryReader(zipStream);
                                 if (string.IsNullOrEmpty(fontName))
                                 {
-                                    using (var ms = RecyclableMemory.GetStream(br.ReadBytes((int)entry.UncompressedSize)))
+                                    using (var ms = EPPlusMemoryManager.GetStream(br.ReadBytes((int)entry.UncompressedSize)))
                                     {
                                         ReadFontSize(ms, fontName);
                                     }
@@ -228,7 +228,7 @@ namespace OfficeOpenXml
                                 }
                                 else
                                 {
-                                    _fontStream = RecyclableMemory.GetStream(br.ReadBytes((int)entry.UncompressedSize));
+                                    _fontStream = EPPlusMemoryManager.GetStream(br.ReadBytes((int)entry.UncompressedSize));
                                     ReadFontSize(_fontStream, fontName);
                                 }
                             }

--- a/src/EPPlus/LicenseHandler.cs
+++ b/src/EPPlus/LicenseHandler.cs
@@ -200,7 +200,7 @@ namespace OfficeOpenXml
 
         static byte[] GetLicenseData(byte version, string licenseNo, DateTime fromDate, DateTime toDate, byte licenseType, short numberOfLicenses)
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 var br = new BinaryWriter(ms);
                 br.Write(version);
@@ -223,7 +223,7 @@ namespace OfficeOpenXml
         internal static void GetLicenseDataFromKey(string lk, out byte version, out string licenseNo, out DateTime fromDate, out DateTime toDate, out EPPlusCommercialLicenseType licenseType, out short noOfLicenses, out byte[] signature, int size)
         {        
             var by = Convert.FromBase64String(lk);
-            using (var ms = RecyclableMemory.GetStream(by))
+            using (var ms = EPPlusMemoryManager.GetStream(by))
             {
                 var br = new BinaryReader(ms);
                 signature = br.ReadBytes(size);

--- a/src/EPPlus/Packaging/DotNetZip/ZipFile.AddUpdate.cs
+++ b/src/EPPlus/Packaging/DotNetZip/ZipFile.AddUpdate.cs
@@ -1200,7 +1200,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zip
         {
             // cannot employ a using clause here.  We need the stream to
             // persist after exit from this method.
-            var ms = RecyclableMemory.GetStream();
+            var ms = EPPlusMemoryManager.GetStream();
 
             // cannot use a using clause here; StreamWriter takes
             // ownership of the stream and Disposes it before we are ready.
@@ -1859,7 +1859,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zip
         public ZipEntry AddEntry(string entryName, byte[] byteContent)
         {
             if (byteContent == null) throw new ArgumentException("bad argument", "byteContent");
-            using (var ms = RecyclableMemory.GetStream(byteContent))
+            using (var ms = EPPlusMemoryManager.GetStream(byteContent))
             {
                 var e = AddEntry(entryName, ms);
                 return e;

--- a/src/EPPlus/Packaging/DotNetZip/ZipFile.Save.cs
+++ b/src/EPPlus/Packaging/DotNetZip/ZipFile.Save.cs
@@ -606,7 +606,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zip
             // write to a memory stream in order to keep the
             // CDR contiguous
             Int64 aLength = 0;
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 foreach (ZipEntry e in entries)
                 {

--- a/src/EPPlus/Packaging/DotNetZip/Zlib/DeflateStream.cs
+++ b/src/EPPlus/Packaging/DotNetZip/Zlib/DeflateStream.cs
@@ -644,7 +644,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zlib
         /// <returns>The string in compressed form</returns>
         public static byte[] CompressString(String s)
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 System.IO.Stream compressor =
                     new DeflateStream(ms, CompressionMode.Compress, CompressionLevel.BestCompression);
@@ -674,7 +674,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zlib
         /// <returns>The data in compressed form</returns>
         public static byte[] CompressBuffer(byte[] b)
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 System.IO.Stream compressor =
                     new DeflateStream( ms, CompressionMode.Compress, CompressionLevel.BestCompression );
@@ -701,7 +701,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zlib
         /// <returns>The uncompressed string</returns>
         public static String UncompressString(byte[] compressed)
         {
-            using (var input = RecyclableMemory.GetStream(compressed))
+            using (var input = EPPlusMemoryManager.GetStream(compressed))
             {
                 System.IO.Stream decompressor =
                     new DeflateStream(input, CompressionMode.Decompress);
@@ -727,7 +727,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zlib
         /// <returns>The data in uncompressed form</returns>
         public static byte[] UncompressBuffer(byte[] compressed)
         {
-            using (var input = RecyclableMemory.GetStream(compressed))
+            using (var input = EPPlusMemoryManager.GetStream(compressed))
             {
                 System.IO.Stream decompressor =
                     new DeflateStream( input, CompressionMode.Decompress );

--- a/src/EPPlus/Packaging/DotNetZip/Zlib/GZipStream.cs
+++ b/src/EPPlus/Packaging/DotNetZip/Zlib/GZipStream.cs
@@ -946,7 +946,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zlib
         /// <returns>The string in compressed form</returns>
         public static byte[] CompressString(String s)
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 System.IO.Stream compressor =
                     new GZipStream(ms, CompressionMode.Compress, CompressionLevel.BestCompression);
@@ -974,7 +974,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zlib
         /// <returns>The data in compressed form</returns>
         public static byte[] CompressBuffer(byte[] b)
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 System.IO.Stream compressor =
                     new GZipStream( ms, CompressionMode.Compress, CompressionLevel.BestCompression );
@@ -999,7 +999,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zlib
         /// <returns>The uncompressed string</returns>
         public static String UncompressString(byte[] compressed)
         {
-            using (var input = RecyclableMemory.GetStream(compressed))
+            using (var input = EPPlusMemoryManager.GetStream(compressed))
             {
                 Stream decompressor = new GZipStream(input, CompressionMode.Decompress);
                 return ZlibBaseStream.UncompressString(compressed, decompressor);
@@ -1021,7 +1021,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zlib
         /// <returns>The data in uncompressed form</returns>
         public static byte[] UncompressBuffer(byte[] compressed)
         {
-            using (var input = RecyclableMemory.GetStream(compressed))
+            using (var input = EPPlusMemoryManager.GetStream(compressed))
             {
                 System.IO.Stream decompressor =
                     new GZipStream( input, CompressionMode.Decompress );

--- a/src/EPPlus/Packaging/DotNetZip/Zlib/ZlibBaseStream.cs
+++ b/src/EPPlus/Packaging/DotNetZip/Zlib/ZlibBaseStream.cs
@@ -593,7 +593,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zlib
             // workitem 8460
             byte[] working = new byte[1024];
             var encoding = System.Text.Encoding.UTF8;
-            using (var output = RecyclableMemory.GetStream())
+            using (var output = EPPlusMemoryManager.GetStream())
             {
                 using (decompressor)
                 {
@@ -615,7 +615,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zlib
         {
             // workitem 8460
             byte[] working = new byte[1024];
-            using (var output = RecyclableMemory.GetStream())
+            using (var output = EPPlusMemoryManager.GetStream())
             {
                 using (decompressor)
                 {

--- a/src/EPPlus/Packaging/DotNetZip/Zlib/ZlibStream.cs
+++ b/src/EPPlus/Packaging/DotNetZip/Zlib/ZlibStream.cs
@@ -635,7 +635,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zlib
         /// <returns>The string in compressed form</returns>
         public static byte[] CompressString(String s)
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 Stream compressor =
                     new ZlibStream(ms, CompressionMode.Compress, CompressionLevel.BestCompression);
@@ -663,7 +663,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zlib
         /// <returns>The data in compressed form</returns>
         public static byte[] CompressBuffer(byte[] b)
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 Stream compressor =
                     new ZlibStream( ms, CompressionMode.Compress, CompressionLevel.BestCompression );
@@ -688,7 +688,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zlib
         /// <returns>The uncompressed string</returns>
         public static String UncompressString(byte[] compressed)
         {
-            using (var input = RecyclableMemory.GetStream(compressed))
+            using (var input = EPPlusMemoryManager.GetStream(compressed))
             {
                 Stream decompressor =
                     new ZlibStream(input, CompressionMode.Decompress);
@@ -712,7 +712,7 @@ namespace OfficeOpenXml.Packaging.Ionic.Zlib
         /// <returns>The data in uncompressed form</returns>
         public static byte[] UncompressBuffer(byte[] compressed)
         {
-            using (var input = RecyclableMemory.GetStream(compressed))
+            using (var input = EPPlusMemoryManager.GetStream(compressed))
             {
                 Stream decompressor =
                     new ZlibStream( input, CompressionMode.Decompress );

--- a/src/EPPlus/Packaging/ZipPackage.cs
+++ b/src/EPPlus/Packaging/ZipPackage.cs
@@ -163,7 +163,7 @@ namespace OfficeOpenXml.Packaging
             else
             {
                 const int BATCH_SIZE = 0x100000;
-                part.Stream = RecyclableMemory.GetStream();
+                part.Stream = EPPlusMemoryManager.GetStream();
                 while (rest > 0)
                 {
                     var bufferSize = rest > BATCH_SIZE ? BATCH_SIZE : (int)rest;

--- a/src/EPPlus/Packaging/ZipPackagePart.cs
+++ b/src/EPPlus/Packaging/ZipPackagePart.cs
@@ -76,7 +76,7 @@ namespace OfficeOpenXml.Packaging
         {
             if (_stream == null || fileMode == FileMode.CreateNew || fileMode == FileMode.Create)
             {
-                _stream = RecyclableMemory.GetStream();
+                _stream = EPPlusMemoryManager.GetStream();
             }
             else
             {
@@ -108,7 +108,7 @@ namespace OfficeOpenXml.Packaging
         public Uri Uri { get; private set; }
         public Stream GetZipStream()
         {
-            using (MemoryStream ms = RecyclableMemory.GetStream())
+            using (MemoryStream ms = EPPlusMemoryManager.GetStream())
             {
                 ZipOutputStream os = new ZipOutputStream(ms);
                 return os;

--- a/src/EPPlus/Table/ExcelTable.cs
+++ b/src/EPPlus/Table/ExcelTable.cs
@@ -481,7 +481,7 @@ namespace OfficeOpenXml.Table
         private string ToJsonString(JsonTableExportSettings s)
         {
             var exporter = new JsonTableExport(this, s);
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 exporter.Export(ms);
                 return s.Encoding.GetString(ms.ToArray());

--- a/src/EPPlus/Utils/CompundDocument/CompoundDocument.cs
+++ b/src/EPPlus/Utils/CompundDocument/CompoundDocument.cs
@@ -72,7 +72,7 @@ namespace OfficeOpenXml.Utils.CompundDocument
         }
         internal void Read(byte[] doc) 
         {
-            using (var ms = RecyclableMemory.GetStream(doc))
+            using (var ms = EPPlusMemoryManager.GetStream(doc))
             {
                 Read(ms, true);
             }

--- a/src/EPPlus/Utils/CompundDocument/CompoundDocumentFile.cs
+++ b/src/EPPlus/Utils/CompundDocument/CompoundDocumentFile.cs
@@ -39,7 +39,7 @@ namespace OfficeOpenXml.Utils.CompundDocument
         }
         internal CompoundDocumentFile(byte[] file)
         {
-            using (var ms = RecyclableMemory.GetStream(file))
+            using (var ms = EPPlusMemoryManager.GetStream(file))
             {
                 LoadFromMemoryStream(ms);
             }
@@ -210,7 +210,7 @@ namespace OfficeOpenXml.Utils.CompundDocument
             var nextSector = _firstDIFATSectorLocation;
             while (nextSector > 0)
             {
-                using (var ms = RecyclableMemory.GetStream(_sectors[nextSector]))
+                using (var ms = EPPlusMemoryManager.GetStream(_sectors[nextSector]))
                 {
                     var brDI = new BinaryReader(ms);
                     var sect = -1;
@@ -242,7 +242,7 @@ namespace OfficeOpenXml.Utils.CompundDocument
         }
         private void GetMiniSectors(byte[] miniFATStream)
         {
-            using (var ms = RecyclableMemory.GetStream(miniFATStream))
+            using (var ms = EPPlusMemoryManager.GetStream(miniFATStream))
             {
                 var br = new BinaryReader(ms);
                 _miniSectors = new List<byte[]>();
@@ -254,7 +254,7 @@ namespace OfficeOpenXml.Utils.CompundDocument
         }
         private byte[] GetStream(int startingSectorLocation, long streamSize, List<int> FAT, List<byte[]> sectors)
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 var bw = new BinaryWriter(ms);
 
@@ -286,7 +286,7 @@ namespace OfficeOpenXml.Utils.CompundDocument
             var nextSector = _firstMiniFATSectorLocation;
             while(nextSector!=END_OF_CHAIN)
             {
-                using (var ms = RecyclableMemory.GetStream(sectors[nextSector]))
+                using (var ms = EPPlusMemoryManager.GetStream(sectors[nextSector]))
                 {
                     var br = new BinaryReader(ms);
                     while (ms.Position < _sectorSize)
@@ -315,7 +315,7 @@ namespace OfficeOpenXml.Utils.CompundDocument
             var l = new List<int>();
             foreach (var i in dwi.DIFAT)
             {
-                using (var ms = RecyclableMemory.GetStream(sectors[i]))
+                using (var ms = EPPlusMemoryManager.GetStream(sectors[i]))
                 {
                     var br = new BinaryReader(ms);
                     while (ms.Position < _sectorSize)
@@ -329,7 +329,7 @@ namespace OfficeOpenXml.Utils.CompundDocument
         }
         private void ReadDirectory(List<byte[]> sectors, int index, List<CompoundDocumentItem> l)
         {
-            using (var ms = RecyclableMemory.GetStream(sectors[index]))
+            using (var ms = EPPlusMemoryManager.GetStream(sectors[index]))
             {
                 var br = new BinaryReader(ms);
 
@@ -868,10 +868,10 @@ namespace OfficeOpenXml.Utils.CompundDocument
         private byte[] SetMiniStream(List<CompoundDocumentItem> dirs)
         {
             //Create the miniStream
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 var bwMiniFATStream = new BinaryWriter(ms);
-                using (var msforBw = RecyclableMemory.GetStream())
+                using (var msforBw = EPPlusMemoryManager.GetStream())
                 {
                     var bwMiniFAT = new BinaryWriter(msforBw);
                     int pos = 0;

--- a/src/EPPlus/Utils/EPPlusMemoryManager.cs
+++ b/src/EPPlus/Utils/EPPlusMemoryManager.cs
@@ -24,20 +24,33 @@ namespace OfficeOpenXml.Utils
     /// </summary>
     internal static class EPPlusMemoryManager
     {
-
+        // this variable indicates if an error has occured while calling
+        // RecyclableMemory
         private static bool _isBroken = false;
+
+        // indicates if RecyclableMemory should be used
+        public static bool UseRecyclableMemory
+        {
+            get; set;
+        } = false;
+
+        private static void Log(Exception e, string message)
+        {
+            // implement logging here
+        }
 
         public static MemoryStream GetStream()
         {
-            if (_isBroken)
+            if (_isBroken || !UseRecyclableMemory)
                 return new MemoryStream();
 
             try
             {
                 return RecyclableMemory.GetStreamInternal();
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                Log(e, "Failed to get stream from RecyclableMemory");
                 _isBroken = true;
                 return new MemoryStream();
             }
@@ -45,15 +58,16 @@ namespace OfficeOpenXml.Utils
 
         public static MemoryStream GetStream(byte[] buffer)
         {
-            if (_isBroken)
+            if (_isBroken || !UseRecyclableMemory)
                 return new MemoryStream(buffer);
 
             try
             {
                 return RecyclableMemory.GetStreamInternal(buffer);
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                Log(e, "Failed to get stream from RecyclableMemory");
                 _isBroken = true;
                 return new MemoryStream(buffer);
             }
@@ -61,15 +75,16 @@ namespace OfficeOpenXml.Utils
 
         public static MemoryStream GetStream(int capacity)
         {
-            if (_isBroken)
+            if (_isBroken || !UseRecyclableMemory)
                 return new MemoryStream(capacity);
 
             try
             {
                 return RecyclableMemory.GetStreamInternal(capacity);
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                Log(e, "Failed to get stream from RecyclableMemory");
                 _isBroken = true;
                 return new MemoryStream(capacity);
             }

--- a/src/EPPlus/Utils/EPPlusMemoryManager.cs
+++ b/src/EPPlus/Utils/EPPlusMemoryManager.cs
@@ -1,0 +1,79 @@
+﻿using System;
+/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  01/27/2020         EPPlus Software AB       Initial release EPPlus 5
+ *************************************************************************************************/
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace OfficeOpenXml.Utils
+{
+    /// <summary>
+    /// The purpose of this class is to encapsulate the calls the <see cref="RecyclableMemory"/>'s GetStream methods.
+    /// By wrapping these methods we can catch errors like <see cref="FileNotFoundException"/> and <see cref="FileLoadException"/>.
+    /// </summary>
+    internal static class EPPlusMemoryManager
+    {
+
+        private static bool _isBroken = false;
+
+        public static MemoryStream GetStream()
+        {
+            if (_isBroken)
+                return new MemoryStream();
+
+            try
+            {
+                return RecyclableMemory.GetStreamInternal();
+            }
+            catch (Exception)
+            {
+                _isBroken = true;
+                return new MemoryStream();
+            }
+        }
+
+        public static MemoryStream GetStream(byte[] buffer)
+        {
+            if (_isBroken)
+                return new MemoryStream(buffer);
+
+            try
+            {
+                return RecyclableMemory.GetStreamInternal(buffer);
+            }
+            catch (Exception)
+            {
+                _isBroken = true;
+                return new MemoryStream(buffer);
+            }
+        }
+
+        public static MemoryStream GetStream(int capacity)
+        {
+            if (_isBroken)
+                return new MemoryStream(capacity);
+
+            try
+            {
+                return RecyclableMemory.GetStreamInternal(capacity);
+            }
+            catch (Exception)
+            {
+                _isBroken = true;
+                return new MemoryStream(capacity);
+            }
+        }
+
+    }
+}

--- a/src/EPPlus/Utils/RecyclableMemory.cs
+++ b/src/EPPlus/Utils/RecyclableMemory.cs
@@ -102,7 +102,7 @@ namespace OfficeOpenXml.Utils
         /// Get a new memory stream.
         /// </summary>
         /// <returns>A MemoryStream</returns>
-        internal static MemoryStream GetStream()
+        internal static MemoryStream GetStreamInternal()
         {
 #if NET35
 			return new MemoryStream();
@@ -122,7 +122,7 @@ namespace OfficeOpenXml.Utils
         /// Get a new memory stream initiated with a byte-array
         /// </summary>
         /// <returns>A MemoryStream</returns>
-        internal static MemoryStream GetStream(byte[] array)
+        internal static MemoryStream GetStreamInternal(byte[] array)
         {
 #if NET35
 			return new MemoryStream(array);
@@ -142,7 +142,7 @@ namespace OfficeOpenXml.Utils
         /// </summary>
         /// <param name="capacity">The initial size of the internal array</param>
         /// <returns>A MemoryStream</returns>
-        internal static MemoryStream GetStream(int capacity)
+        internal static MemoryStream GetStreamInternal(int capacity)
         {
 #if NET35
 			return new MemoryStream(capacity);

--- a/src/EPPlus/Utils/RecyclableMemory.cs
+++ b/src/EPPlus/Utils/RecyclableMemory.cs
@@ -44,11 +44,11 @@ namespace OfficeOpenXml.Utils
         {
             get
             {
-                return RecyclableMemory.UseRecyclableMemory;
+                return EPPlusMemoryManager.UseRecyclableMemory;
             }
             set
             {
-                RecyclableMemory.UseRecyclableMemory = value;
+                EPPlusMemoryManager.UseRecyclableMemory = value;
             }
         }
     }
@@ -61,7 +61,6 @@ namespace OfficeOpenXml.Utils
 #if !NET35
         private static RecyclableMemoryStreamManager _memoryManager;
         private static object _dataLock = new object();
-        public static bool UseRecyclableMemory { get; set; } = true;
         internal static bool HasMemoryManager
         {
             get
@@ -75,7 +74,7 @@ namespace OfficeOpenXml.Utils
             {
                 lock (_dataLock)
                 {
-                    if (_memoryManager == null && UseRecyclableMemory)
+                    if (_memoryManager == null && EPPlusMemoryManager.UseRecyclableMemory)
                     {
                         var defaultOptions = new RecyclableMemoryStreamManager.Options
                         {
@@ -107,7 +106,7 @@ namespace OfficeOpenXml.Utils
 #if NET35
 			return new MemoryStream();
 #else
-            if (UseRecyclableMemory == true)
+            if (EPPlusMemoryManager.UseRecyclableMemory == true)
             {
                 return MemoryManager.GetStream();
             }
@@ -127,7 +126,7 @@ namespace OfficeOpenXml.Utils
 #if NET35
 			return new MemoryStream(array);
 #else
-            if (UseRecyclableMemory == true)
+            if (EPPlusMemoryManager.UseRecyclableMemory == true)
             {
                 return MemoryManager.GetStream(array);
             }
@@ -147,7 +146,7 @@ namespace OfficeOpenXml.Utils
 #if NET35
 			return new MemoryStream(capacity);
 #else
-            if (UseRecyclableMemory == true)
+            if (EPPlusMemoryManager.UseRecyclableMemory == true)
             {
                 return MemoryManager.GetStream(null, capacity);
             }

--- a/src/EPPlus/Utils/VBACompression.cs
+++ b/src/EPPlus/Utils/VBACompression.cs
@@ -29,7 +29,7 @@ namespace OfficeOpenXml.Utils
         /// <returns></returns>
         internal static byte[] CompressPart(byte[] part)
         {
-            using (var ms = RecyclableMemory.GetStream(4096))
+            using (var ms = EPPlusMemoryManager.GetStream(4096))
             {
                 BinaryWriter br = new BinaryWriter(ms);
                 br.Write((byte)1);
@@ -154,7 +154,7 @@ namespace OfficeOpenXml.Utils
             {
                 return null;
             }
-            using (var ms = RecyclableMemory.GetStream(4096))
+            using (var ms = EPPlusMemoryManager.GetStream(4096))
             {
                 int compressPos = startPos + 1;
                 while (compressPos < part.Length - 1)

--- a/src/EPPlus/Vba/ContentHash/ContentHashInputProvider.cs
+++ b/src/EPPlus/Vba/ContentHash/ContentHashInputProvider.cs
@@ -38,7 +38,7 @@ namespace OfficeOpenXml.Vba.ContentHash
         {
             if(ms == null)
             {
-                ms = RecyclableMemory.GetStream();
+                ms = EPPlusMemoryManager.GetStream();
             }
             CreateHashInputInternal(ms);
         }

--- a/src/EPPlus/Vba/ContentHash/VbaSignHashAlgorithmUtil.cs
+++ b/src/EPPlus/Vba/ContentHash/VbaSignHashAlgorithmUtil.cs
@@ -28,7 +28,7 @@ namespace OfficeOpenXml.VBA.ContentHash
         {
             if (ctx.SignatureType == ExcelVbaSignatureType.Legacy)
             {
-                using (var ms = RecyclableMemory.GetStream())
+                using (var ms = EPPlusMemoryManager.GetStream())
                 {
                     ContentHashInputProvider.GetContentNormalizedDataHashInput(proj, ms);
                     var buffer = ms.ToArray();
@@ -39,7 +39,7 @@ namespace OfficeOpenXml.VBA.ContentHash
             }
             else if (ctx.SignatureType == ExcelVbaSignatureType.Agile)
             {
-                using (var ms = RecyclableMemory.GetStream())
+                using (var ms = EPPlusMemoryManager.GetStream())
                 {
                     ContentHashInputProvider.GetContentNormalizedDataHashInput(proj, ms);
                     ContentHashInputProvider.GetFormsNormalizedDataHashInput(proj, ms);
@@ -51,7 +51,7 @@ namespace OfficeOpenXml.VBA.ContentHash
             }
             else if(ctx.SignatureType == ExcelVbaSignatureType.V3)
             {
-                using (var ms = RecyclableMemory.GetStream())
+                using (var ms = EPPlusMemoryManager.GetStream())
                 {
                     ContentHashInputProvider.GetV3ContentNormalizedDataHashInput(proj, ms);
                     var buffer = ms.ToArray();

--- a/src/EPPlus/Vba/ExcelVBAProject.cs
+++ b/src/EPPlus/Vba/ExcelVBAProject.cs
@@ -381,7 +381,7 @@ namespace OfficeOpenXml.VBA
             byte[] array;
             byte pb;
             byte[] enc = new byte[value.Length + 10];
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 BinaryWriter br = new BinaryWriter(ms);
                 enc[0] = seed[0];
@@ -443,7 +443,7 @@ namespace OfficeOpenXml.VBA
         private void ReadDirStream()
         {
             byte[] dir = VBACompression.DecompressPart(Document.Storage.SubStorage["VBA"].DataStreams["dir"].Stream);
-            using (var ms = RecyclableMemory.GetStream(dir))
+            using (var ms = EPPlusMemoryManager.GetStream(dir))
             {
                 BinaryReader br = new BinaryReader(ms);
                 ExcelVbaReference currentRef = null;
@@ -685,7 +685,7 @@ namespace OfficeOpenXml.VBA
         /// <returns></returns>
         private byte[] CreateVBAProjectStream()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 BinaryWriter bw = new BinaryWriter(ms);
                 bw.Write((ushort)0x61CC); //Reserved1
@@ -701,7 +701,7 @@ namespace OfficeOpenXml.VBA
         /// <returns></returns>
         private byte[] CreateDirStream()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 BinaryWriter bw = new BinaryWriter(ms);
 
@@ -962,7 +962,7 @@ namespace OfficeOpenXml.VBA
 
         private byte[] CreateProjectwmStream()
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 BinaryWriter bw = new BinaryWriter(ms);
 
@@ -1094,7 +1094,7 @@ namespace OfficeOpenXml.VBA
                     }
                 }
                 //Write the Password Hash Data Structure (2.4.4.1)
-                using (var ms = RecyclableMemory.GetStream())
+                using (var ms = EPPlusMemoryManager.GetStream())
                 {
                     BinaryWriter bw = new BinaryWriter(ms);
                     bw.Write((byte)0xFF);

--- a/src/EPPlus/Vba/Signatures/CertUtil.cs
+++ b/src/EPPlus/Vba/Signatures/CertUtil.cs
@@ -55,7 +55,7 @@ namespace OfficeOpenXml.VBA.Signatures
         internal static byte[] GetSerializedCertStore(byte[] certRawData)
         {
             //MS-OSHARED 2.3.2.5.5 VBASigSerializedCertStore
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 var bw = new BinaryWriter(ms);
 

--- a/src/EPPlus/Vba/Signatures/EPPlusVbaSignature.cs
+++ b/src/EPPlus/Vba/Signatures/EPPlusVbaSignature.cs
@@ -121,7 +121,7 @@ namespace OfficeOpenXml.VBA.Signatures
                     return;
                 }
             }
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 var bw = new BinaryWriter(ms);
                 Verifier = CertUtil.SignProject(project, this, Context);

--- a/src/EPPlus/Vba/Signatures/ProjectSignUtil.cs
+++ b/src/EPPlus/Vba/Signatures/ProjectSignUtil.cs
@@ -37,7 +37,7 @@ namespace OfficeOpenXml.VBA.Signatures
             var hash = VbaSignHashAlgorithmUtil.GetContentHash(proj, ctx);
 
             ContentInfo contentInfo;
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 contentInfo = CreateContentInfo(hash, ms, ctx);
             }
@@ -130,7 +130,7 @@ namespace OfficeOpenXml.VBA.Signatures
 
         private static byte[] GetHashContent(EPPlusSignatureContext ctx, byte[] hash)
         {
-            using (var ms = RecyclableMemory.GetStream())
+            using (var ms = EPPlusMemoryManager.GetStream())
             {
                 var bw = new BinaryWriter(ms);
                 if (ctx.SignatureType == ExcelVbaSignatureType.Legacy)

--- a/src/EPPlus/Vba/Signatures/SignatureReader.cs
+++ b/src/EPPlus/Vba/Signatures/SignatureReader.cs
@@ -82,7 +82,7 @@ namespace OfficeOpenXml.VBA.Signatures
 
         internal static void ReadSignedData(byte[] data, EPPlusSignatureContext ctx)
         {
-            using(var ms = RecyclableMemory.GetStream(data))
+            using(var ms = EPPlusMemoryManager.GetStream(data))
             {
                 var br = new BinaryReader(ms);
                 var totallength = ReadSequence(br);

--- a/src/EPPlus/WorksheetZipStream.cs
+++ b/src/EPPlus/WorksheetZipStream.cs
@@ -101,14 +101,14 @@ namespace OfficeOpenXml
         {
             _stream.Write(buffer, offset, count);
         }
-        public BinaryWriter Buffer = new BinaryWriter(RecyclableMemory.GetStream());
+        public BinaryWriter Buffer = new BinaryWriter(EPPlusMemoryManager.GetStream());
         public void SetWriteToBuffer()
         {
             Buffer.BaseStream.Dispose();
 #if(!NET35)
             Buffer.Dispose();
 #endif
-            Buffer = new BinaryWriter(RecyclableMemory.GetStream());
+            Buffer = new BinaryWriter(EPPlusMemoryManager.GetStream());
             Buffer.Write(_rollingBuffer.GetBuffer());
             WriteToBuffer = true;
         }

--- a/src/EPPlus/XmlHelper.cs
+++ b/src/EPPlus/XmlHelper.cs
@@ -1355,7 +1355,7 @@ namespace OfficeOpenXml
         }
         internal static void LoadXmlSafe(XmlDocument xmlDoc, string xml, Encoding encoding)
         {
-            using (var stream = RecyclableMemory.GetStream(encoding.GetBytes(xml)))
+            using (var stream = EPPlusMemoryManager.GetStream(encoding.GetBytes(xml)))
             {
                 LoadXmlSafe(xmlDoc, stream);
             }


### PR DESCRIPTION
A new class - EPPlusMemoryManager - encapsulates calls to the RecyclableMemory class and handles exceptions like FileLoadException and FileNotFoundException. If an Exception is thrown when calling RecyclableMemory.GetStream the EPPlusMemoryManager will switch to returning MemoryStreams instead.

Previous calls to RecyclableMemory.GetStream methods are now changed to EPPlusMemoryManager.GetStream.
