### PR TITLE
Fixed column range issues (s915, branch name is wrong)

### DIFF
--- a/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingThreeColorScale.cs
+++ b/src/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingThreeColorScale.cs
@@ -18,7 +18,6 @@ using System.Globalization;
 using System.Linq;
 using System.Xml;
 using OfficeOpenXml.ConditionalFormatting.Contracts;
-using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing.Utilities;
 using OfficeOpenXml.Utils.TypeConversion;
 

--- a/src/EPPlus/Core/Worksheet/WorksheetRangeBaseHelper.cs
+++ b/src/EPPlus/Core/Worksheet/WorksheetRangeBaseHelper.cs
@@ -12,10 +12,7 @@
 *************************************************************************************************/
 using OfficeOpenXml.ConditionalFormatting;
 using OfficeOpenXml.DataValidation;
-using OfficeOpenXml.DataValidation.Contracts;
 using OfficeOpenXml.DataValidation.Formulas.Contracts;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace OfficeOpenXml.Core.Worksheet
 {
@@ -46,14 +43,7 @@ namespace OfficeOpenXml.Core.Worksheet
 
             foreach (ExcelConditionalFormattingRule cf in ws.ConditionalFormatting)
             {
-                if (!string.IsNullOrEmpty(cf.Formula))
-                {
-                    cf.Formula = ExcelCellBase.UpdateFormulaReferences(cf.Formula, rows, 0, rowFrom, 0, ws.Name, ws.Name);
-                }
-                if (!string.IsNullOrEmpty(cf.Formula2))
-                {
-                    cf.Formula2 = ExcelCellBase.UpdateFormulaReferences(cf.Formula2, rows, 0, rowFrom, 0, ws.Name, ws.Name);
-                }
+                UpdateCFformulaReferences(cf, rows, 0, rowFrom, 0, ws.Name);
             }
         }
 
@@ -73,16 +63,69 @@ namespace OfficeOpenXml.Core.Worksheet
 
             foreach (ExcelConditionalFormattingRule cf in ws.ConditionalFormatting)
             {
-                if (!string.IsNullOrEmpty(cf.Formula))
-                {
-                    cf.Formula = ExcelCellBase.UpdateFormulaReferences(cf.Formula, 0, columns, 0, columnFrom, ws.Name, ws.Name);
-                }
-                if (!string.IsNullOrEmpty(cf.Formula2))
-                {
-                    cf.Formula2 = ExcelCellBase.UpdateFormulaReferences(cf.Formula2, 0, columns, 0, columnFrom, ws.Name, ws.Name);
-                }
+                UpdateCFformulaReferences(cf, 0, columns, 0, columnFrom, ws.Name);
             }
         }
 
+        internal static void UpdateCFformulaReferences(ExcelConditionalFormattingRule cf, int rows, int columns, int rowFrom, int columnFrom, string currentSheet)
+        {
+            if (cf is ExcelConditionalFormattingTwoColorScale)
+            {
+                var colorScale = cf.As.TwoColorScale;
+                if (colorScale.LowValue.Formula != null)
+                {
+                    colorScale.LowValue.Formula = ExcelCellBase.UpdateFormulaReferences(colorScale.LowValue.Formula, rows, columns, rowFrom, columnFrom, currentSheet, currentSheet);
+                }
+                if (colorScale.HighValue.Formula != null)
+                {
+                    colorScale.HighValue.Formula = ExcelCellBase.UpdateFormulaReferences(colorScale.HighValue.Formula, rows, columns, rowFrom, columnFrom, currentSheet, currentSheet);
+                }
+                if (cf is ExcelConditionalFormattingThreeColorScale)
+                {
+                    var threeColorScale = cf.As.ThreeColorScale;
+                    if (threeColorScale.MiddleValue.Formula != null)
+                    {
+                        threeColorScale.MiddleValue.Formula = ExcelCellBase.UpdateFormulaReferences(threeColorScale.MiddleValue.Formula, rows, columns, rowFrom, columnFrom, currentSheet, currentSheet);
+                    }
+                }
+            }
+
+            if (cf.IsIconSet)
+            {
+                ExcelConditionalFormattingIconDataBarValue[] iconArray = null;
+                switch (cf.Type)
+                {
+                    case eExcelConditionalFormattingRuleType.ThreeIconSet:
+                        var iconSet3 = (ExcelConditionalFormattingIconSetBase<eExcelconditionalFormatting3IconsSetType>)cf;
+                        iconArray = iconSet3.GetIconArray();
+                        break;
+                    case eExcelConditionalFormattingRuleType.FourIconSet:
+                        var iconSet4 = (ExcelConditionalFormattingIconSetBase<eExcelconditionalFormatting3IconsSetType>)cf;
+                        iconArray = iconSet4.GetIconArray();
+                        break;
+                    case eExcelConditionalFormattingRuleType.FiveIconSet:
+                        var iconSet5 = (ExcelConditionalFormattingIconSetBase<eExcelconditionalFormatting3IconsSetType>)cf;
+                        iconArray = iconSet5.GetIconArray();
+                        break;
+                }
+
+                for (int i = 0; i < iconArray.Length; i++)
+                {
+                    if (iconArray[i].Formula != null)
+                    {
+                        iconArray[i].Formula = ExcelCellBase.UpdateFormulaReferences(cf.Formula, rows, columns, rowFrom, columnFrom, currentSheet, currentSheet);
+                    }
+                }
+            }
+
+            if (!string.IsNullOrEmpty(cf.Formula))
+            {
+                cf.Formula = ExcelCellBase.UpdateFormulaReferences(cf.Formula, rows, columns, rowFrom, columnFrom, currentSheet, currentSheet);
+            }
+            if (!string.IsNullOrEmpty(cf.Formula2))
+            {
+                cf.Formula2 = ExcelCellBase.UpdateFormulaReferences(cf.Formula2, rows, columns, rowFrom, columnFrom, currentSheet, currentSheet);
+            }
+        }
     }
 }

--- a/src/EPPlus/Core/Worksheet/WorksheetRangeDeleteHelper.cs
+++ b/src/EPPlus/Core/Worksheet/WorksheetRangeDeleteHelper.cs
@@ -569,6 +569,7 @@ namespace OfficeOpenXml.Core.Worksheet
                 else
                 {
                     ((ExcelConditionalFormattingRule)cf).Address = new ExcelAddress(newAddress.Address);
+
                 }
             }
             deletedCF.ForEach(cf => ws.ConditionalFormatting.Remove(cf));

--- a/src/EPPlus/ExcelRangeColumn.cs
+++ b/src/EPPlus/ExcelRangeColumn.cs
@@ -692,7 +692,7 @@ namespace OfficeOpenXml
             List<int> toDelete = new();
             for(int i = EndColumn; i >= StartColumn; i--)
             {
-                var col = _worksheet.GetValueInner(0, i) as ExcelColumn;
+                var col = _worksheet.GetColumn(i);
                 if (col != null)
                 {
                     if (match(col))

--- a/src/EPPlusTest/Core/Worksheet/WorksheetRowIterationTests.cs
+++ b/src/EPPlusTest/Core/Worksheet/WorksheetRowIterationTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -810,6 +811,34 @@ namespace EPPlusTest.Core.Worksheet
                 var found = cs.NextCell(ref row, ref col, row, 0, 6, col);
 
                 Assert.IsFalse(found);
+            }
+        }
+        [TestMethod]
+        public void s915()
+        {
+            using (var pck = OpenTemplatePackage("s915.xlsx"))
+            {
+                using ExcelPackage excelPackage = pck;
+                ExcelWorksheets worksheets = excelPackage.Workbook.Worksheets;
+
+                IEnumerable<ExcelWorksheet> sheetsToClear = worksheets.Where(s => !s.Name.StartsWith("data ", StringComparison.OrdinalIgnoreCase));
+                foreach (ExcelWorksheet ws in sheetsToClear)
+                {
+                    ws.ClearFormulas();
+
+                    ws.Rows.DeleteAll(r => r.Hidden);
+                    ws.Columns.DeleteAll(c => c.Hidden);
+
+                    ws.View.TopLeftCell = "A1";
+                    ws.View.SelectedRange = "A1";
+
+                    foreach(var condFormatting in ws.ConditionalFormatting)
+                    {
+                        var someAddress = condFormatting.Address;
+                    }
+                }
+
+                SaveAndCleanup(pck);
             }
         }
     }


### PR DESCRIPTION
We were using get innervalue instead of Column(index). This caused us to miss columns that were part of column ranges if it's row was empty.

This caused the second/last column in a columnrange not to be deleted when it should