### PR TITLE
Ensured pivot table with duplicate name not infinite loop

### DIFF
--- a/src/EPPlus/Table/PivotTable/PivotTableCacheInternal.cs
+++ b/src/EPPlus/Table/PivotTable/PivotTableCacheInternal.cs
@@ -286,12 +286,18 @@ namespace OfficeOpenXml.Table.PivotTable
                             while(movedFields.Contains(fi))
                             {
                                 var dupName = name + x.ToString();
-                                fi = _fields.FindIndex(x => x.Name.Equals(dupName, StringComparison.OrdinalIgnoreCase));
+                                fi = _fields.FindIndex(cField => cField.Name.Equals(dupName, StringComparison.OrdinalIgnoreCase));
+                                if(fi<0 && movedFields.Contains(fi))
+                                {
+                                    //there are somehow multiple duplicate col headers. Add number of already existing dupes.
+                                    x = movedFields.Where(anInt => anInt.Equals(-1)).Count()+x;
+                                    break;
+                                }
                                 x++;
                             }
                             if(fi<0)
                             {
-                                field = CreateField(name, -1, true, true, ix == 0 ? null : fields[ix - 1].TopNode);
+                                field = CreateField(name + (x-1).ToString(), -1, true, true, ix == 0 ? null : fields[ix - 1].TopNode);
                                 field.TopNode.InnerXml = "<sharedItems/>";
                                 movedFields.Add(-1);
                             }

--- a/src/EPPlusTest/Table/PivotTable/PivotTableTests.cs
+++ b/src/EPPlusTest/Table/PivotTable/PivotTableTests.cs
@@ -346,7 +346,7 @@ namespace EPPlusTest.Table.PivotTable
             pt.DataFields.Add(pt.Fields[3]);
             pt.DataFields.Add(pt.Fields[2]);
 
-            pt.DataOnRows = true;            
+            pt.DataOnRows = true;
         }
         [TestMethod]
         public void Pivot_GroupNumber()
@@ -1328,11 +1328,11 @@ namespace EPPlusTest.Table.PivotTable
         public void RefreshTemplateWithChangedColumns()
         {
             using var p = OpenTemplatePackage("PivotTableRefreshFields.xlsx");
-            foreach(var ws in p.Workbook.Worksheets)
+            foreach (var ws in p.Workbook.Worksheets)
             {
-                foreach(var pt in ws.PivotTables)
+                foreach (var pt in ws.PivotTables)
                 {
-                    
+
                 }
             }
             SaveAndCleanup(p);
@@ -1350,6 +1350,32 @@ namespace EPPlusTest.Table.PivotTable
             }
             p.Workbook.Worksheets[0].Cells["A2:P20"].Clear();
             SaveWorkbook("PivotTableRefreshFields-ClearData.xlsx", p);
+        }
+        [TestMethod]
+        public void s913()
+        {
+            using (var package = OpenTemplatePackage("s913.xlsx"))
+            {
+                var firstDataRow = 2;
+                var lastDataRow = 10;
+                var ws = package.Workbook.Worksheets["Sheet1"];
+
+
+                ws.DeleteRow(firstDataRow + 1, ExcelPackage.MaxRows - firstDataRow);
+
+
+                for (int row = firstDataRow; row <= lastDataRow; row++)
+                {
+                    for (int col = 1; col <= 3; col++)
+                    {
+                        ws.Cells[row, col].Value = "Lorem ipsum";
+                    }
+                }
+
+
+                package.GetAsByteArray();
+                SaveAndCleanup(package);
+            }
         }
     }
 }


### PR DESCRIPTION
If multiple columns a pivot table referred to had the same name it could end up in an infinite loop when asked to refresh the pivot table. This should resolve that.