### PR TITLE
Remove redundant hasContentTypeXml check from ZipPackage

### DIFF
--- a/src/EPPlus/Packaging/ZipPackage.cs
+++ b/src/EPPlus/Packaging/ZipPackage.cs
@@ -131,10 +131,6 @@ namespace OfficeOpenXml.Packaging
                 {
                     throw (new InvalidDataException("The file is not a valid Package file. If the file is encrypted, please supply the password in the constructor."));
                 }
-                if (!hasContentTypeXml)
-                {
-                    throw (new InvalidDataException("The file is not a valid Package file. If the file is encrypted, please supply the password in the constructor."));
-                }
             }
         }
 


### PR DESCRIPTION
Before submitting this pull request I have...
- [x] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [ ] ensured that the functionality I have added/changed is covered by new unit tests.
- [x] merged the target branch into the PR branch and resolved any merge conflicts
- [x] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).

This fixes #2089.

I've run all the unit tests and they are all green except for `XMatchTests.BinarySearchAsc` (which is also failing in the base branch).

I'm not sure if this change requires any new unit tests (so I leave the checkbox unchecked).
