### PR TITLE
Moved save drawings to drawings collection and individual drawings

### DIFF
--- a/src/EPPlus/Drawing/Chart/ExcelChart.cs
+++ b/src/EPPlus/Drawing/Chart/ExcelChart.cs
@@ -10,20 +10,21 @@
  *************************************************************************************************
   01/27/2020         EPPlus Software AB       Initial release EPPlus 5
  *************************************************************************************************/
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Xml;
-using System.IO;
-using OfficeOpenXml.Table.PivotTable;
-using OfficeOpenXml.Packaging;
+using OfficeOpenXml.Drawing.Chart.ChartEx;
 using OfficeOpenXml.Drawing.Chart.Style;
 using OfficeOpenXml.Drawing.Interfaces;
 using OfficeOpenXml.Drawing.Style.Effect;
-using OfficeOpenXml.Style;
 using OfficeOpenXml.Drawing.Style.ThreeD;
-using OfficeOpenXml.Drawing.Chart.ChartEx;
+using OfficeOpenXml.Packaging;
+using OfficeOpenXml.Style;
+using OfficeOpenXml.Table.PivotTable;
 using OfficeOpenXml.Utils.FileUtils;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Xml;
 
 namespace OfficeOpenXml.Drawing.Chart
 {
@@ -1136,6 +1137,28 @@ namespace OfficeOpenXml.Drawing.Chart
             }
 
             throw new InvalidOperationException($"Cannot change ValueAxis to CatAxis. Original Axis type: {currentType.ToString()}  New Axis type: {type.ToString()}");
+        }
+
+        internal override void SaveDrawing(bool hasLoadedPivotTables)
+        {
+            base.SaveDrawing(hasLoadedPivotTables);
+
+            var chartStream = Part.GetStream(FileMode.Create, FileAccess.Write);
+            ChartXml.PreserveWhitespace = true;
+            ChartXml.Save(chartStream);
+
+            if (this is ExcelChartStandard cs && cs.Drawings.Part != null)
+            {
+                foreach (var cd in cs.Drawings)
+                {
+                    cd.UpdatePositionAndSizeXml();
+                    cd.SaveDrawing(hasLoadedPivotTables); //Handle group shapes.
+                }
+
+                var xrd = new XmlTextWriter(cs.Drawings.Part.GetStream(FileMode.Create, FileAccess.Write), Encoding.UTF8);
+                xrd.Formatting = Formatting.None;
+                cs.Drawings.DrawingXml.Save(xrd);
+            }
         }
     }
 }

--- a/src/EPPlus/Drawing/Controls/ExcelControl.cs
+++ b/src/EPPlus/Drawing/Controls/ExcelControl.cs
@@ -14,6 +14,7 @@ using OfficeOpenXml.Constants;
 using OfficeOpenXml.Drawing.Vml;
 using OfficeOpenXml.Packaging;
 using System;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
@@ -711,6 +712,15 @@ namespace OfficeOpenXml.Drawing.Controls
             _drawings._package.ZipPackage.DeletePart(ControlPropertiesUri);
             _control.DeleteMe();
             base.DeleteMe();
+        }
+
+        internal override void SaveDrawing(bool hasLoadedPivotTables)
+        {
+            base.SaveDrawing(hasLoadedPivotTables);
+
+            ControlPropertiesXml.Save(ControlPropertiesPart.GetStream(FileMode.Create, FileAccess.Write));
+            ControlPropertiesXml.PreserveWhitespace = true;
+            UpdateXml();
         }
     }
 }

--- a/src/EPPlus/Drawing/ExcelDrawing.cs
+++ b/src/EPPlus/Drawing/ExcelDrawing.cs
@@ -2382,5 +2382,10 @@ namespace OfficeOpenXml.Drawing
             GetToBounds(out int toRow, out _, out int toCol, out _);
             return new ExcelAddress(fromRow + 1, fromCol + 1, toRow + 1, toCol + 1);
         }
+
+        internal virtual void SaveDrawing(bool hasLoadedPivotTables)
+        {
+            //Individual drawings that require certain saving actions do so by overriding this
+        }
     }
 }

--- a/src/EPPlus/Drawing/ExcelDrawings.cs
+++ b/src/EPPlus/Drawing/ExcelDrawings.cs
@@ -2165,5 +2165,39 @@ namespace OfficeOpenXml.Drawing
                 d.GetPositionSize();
             }
         }
+
+
+        internal void SaveDrawings(bool hasLoadedPivotTables)
+        {
+            if (UriDrawing != null)
+            {
+                if (Count == 0)
+                {
+                    if (Worksheet != null)
+                    {
+                        Worksheet.Part.DeleteRelationship(_drawingRelation.Id);
+                        Worksheet._package.ZipPackage.DeletePart(UriDrawing);
+                    }
+                }
+                else
+                {
+                    if (Worksheet != null)
+                    {
+                        Worksheet.RowHeightCache = new Dictionary<int, double>();
+
+                        foreach (ExcelDrawing d in this)
+                        {
+                            d.AdjustPositionAndSize();
+                            d.UpdatePositionAndSizeXml();
+                            d.SaveDrawing(hasLoadedPivotTables);
+                        }
+
+                        ZipPackagePart partPack = Part;
+                        var partStream = partPack.GetStream(FileMode.Create, FileAccess.Write);
+                        DrawingXml.Save(partStream);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/EPPlus/Drawing/ExcelGroupShape.cs
+++ b/src/EPPlus/Drawing/ExcelGroupShape.cs
@@ -635,6 +635,16 @@ namespace OfficeOpenXml.Drawing
                 return eDrawingType.GroupShape;
             }
         }
+
+        internal override void SaveDrawing(bool hasLoadedPivotTables)
+        {
+            base.SaveDrawing(hasLoadedPivotTables);
+
+            foreach (var d in Drawings)
+            {
+                d.SaveDrawing(hasLoadedPivotTables);
+            }
+        }
     }
 
 }

--- a/src/EPPlus/Drawing/OleObject/ExcelOleObject.cs
+++ b/src/EPPlus/Drawing/OleObject/ExcelOleObject.cs
@@ -911,5 +911,19 @@ namespace OfficeOpenXml.Drawing.OleObject
             p.Save();
         }
         #endregion
+
+        internal override void SaveDrawing(bool hasLoadedPivotTables)
+        {
+            base.SaveDrawing(hasLoadedPivotTables);
+
+            if (IsExternalLink)
+            {
+                if (_oleObjectPart != null && _linkedOleObjectXml != null)
+                {
+                    _linkedOleObjectXml.Save(_oleObjectPart.GetStream(FileMode.Create, FileAccess.Write));
+                }
+            }
+            UpdateXml();
+        }
     }
 }

--- a/src/EPPlus/Drawing/Slicer/ExcelSlicer.cs
+++ b/src/EPPlus/Drawing/Slicer/ExcelSlicer.cs
@@ -13,6 +13,7 @@
 using OfficeOpenXml.Table.PivotTable;
 using OfficeOpenXml.Utils.EnumUtils;
 using System;
+using System.IO;
 using System.Xml;
 
 namespace OfficeOpenXml.Drawing.Slicer
@@ -26,7 +27,7 @@ namespace OfficeOpenXml.Drawing.Slicer
         internal ExcelSlicerXmlSource _xmlSource;
         internal ExcelWorksheet _ws;
         internal XmlHelper _slicerXmlHelper;
-        internal ExcelSlicer(ExcelDrawings drawings, XmlNode node, ExcelGroupShape parent=null) :
+        internal ExcelSlicer(ExcelDrawings drawings, XmlNode node, ExcelGroupShape parent = null) :
             base(drawings, node, "mc:AlternateContent/mc:Choice/xdr:graphicFrame", "xdr:nvGraphicFramePr/xdr:cNvPr", parent)
         {
             _ws = drawings.Worksheet;
@@ -49,7 +50,7 @@ namespace OfficeOpenXml.Drawing.Slicer
         /// <summary>
         /// The caption text of the slicer.
         /// </summary>
-        public string Caption 
+        public string Caption
         {
             get
             {
@@ -73,7 +74,7 @@ namespace OfficeOpenXml.Drawing.Slicer
             {
                 _slicerXmlHelper.SetXmlNodeBool("@showCaption", value, true);
             }
-        }        
+        }
         /// <summary>
         /// The the name of the slicer.
         /// </summary>
@@ -85,14 +86,14 @@ namespace OfficeOpenXml.Drawing.Slicer
             }
             set
             {
-                if(!CheckSlicerNameIsUnique(value))
+                if (!CheckSlicerNameIsUnique(value))
                 {
                     if (Name != value)
                     {
                         throw new InvalidOperationException("Slicer Name is not unique");
                     }
                 }
-                if (Name != value) Name=value;
+                if (Name != value) Name = value;
                 _slicerXmlHelper.SetXmlNodeString("@name", value);
             }
         }
@@ -102,8 +103,8 @@ namespace OfficeOpenXml.Drawing.Slicer
         /// <summary>
         /// Row height in points
         /// </summary>
-        public double RowHeight 
-        { 
+        public double RowHeight
+        {
             get
             {
                 return _slicerXmlHelper.GetXmlNodeEmuToPt("@rowHeight");
@@ -119,7 +120,7 @@ namespace OfficeOpenXml.Drawing.Slicer
         public int StartItem
         {
             get
-            { 
+            {
                 return _slicerXmlHelper.GetXmlNodeInt("@startItem", 0);
             }
             set
@@ -167,11 +168,11 @@ namespace OfficeOpenXml.Drawing.Slicer
             }
             set
             {
-                if(value==eSlicerStyle.None)
+                if (value == eSlicerStyle.None)
                 {
                     StyleName = "";
                 }
-                else if(value != eSlicerStyle.Custom)
+                else if (value != eSlicerStyle.Custom)
                 {
                     StyleName = "SlicerStyle" + value.ToString();
                 }
@@ -189,15 +190,15 @@ namespace OfficeOpenXml.Drawing.Slicer
             }
             set
             {
-                if(string.IsNullOrEmpty(value))
+                if (string.IsNullOrEmpty(value))
                 {
                     _slicerXmlHelper.DeleteNode("@style");
                     return;
                 }
-                if(value.StartsWith("SlicerStyle", StringComparison.OrdinalIgnoreCase))
+                if (value.StartsWith("SlicerStyle", StringComparison.OrdinalIgnoreCase))
                 {
                     var style = value.Substring(11).ToEnum(eSlicerStyle.Custom);
-                    if(style!=eSlicerStyle.Custom || style!=eSlicerStyle.None)
+                    if (style != eSlicerStyle.Custom || style != eSlicerStyle.None)
                     {
                         _slicerXmlHelper.SetXmlNodeString("@style", "SlicerStyle" + style);
                         return;
@@ -226,7 +227,7 @@ namespace OfficeOpenXml.Drawing.Slicer
         {
             get
             {
-                if(_cache==null)
+                if (_cache == null)
                 {
                     _cache = _drawings.Worksheet.Workbook.GetSlicerCaches(CacheName);
                 }
@@ -252,5 +253,23 @@ namespace OfficeOpenXml.Drawing.Slicer
             base.DeleteMe();
         }
 
+        internal override void SaveDrawing(bool hasLoadedPivotTables)
+        {
+            base.SaveDrawing(hasLoadedPivotTables);
+            if (Cache is ExcelTableSlicerCache)
+            {
+                Cache.SlicerCacheXml.PreserveWhitespace = true;
+                Cache.SlicerCacheXml.Save(Cache.Part.GetStream(FileMode.Create, FileAccess.Write));
+            }
+            else if (Cache is ExcelPivotTableSlicerCache p)
+            {
+                if (Cache == null) return;
+                if (hasLoadedPivotTables)
+                {
+                    p.UpdateItemsXml();
+                }
+                Cache.SlicerCacheXml.Save(Cache.Part.GetStream(FileMode.Create, FileAccess.Write));
+            }
+        }
     }
 }

--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -2529,89 +2529,9 @@ namespace OfficeOpenXml
 
         private void SaveDrawings(bool hasLoadedPivotTables)
         {
-            if (Drawings.UriDrawing != null)
-            {
-                if (Drawings.Count == 0)
-                {
-                    Part.DeleteRelationship(Drawings._drawingRelation.Id);
-                    _package.ZipPackage.DeletePart(Drawings.UriDrawing);
-                }
-                else
-                {
-                    RowHeightCache = new Dictionary<int, double>();
-                    foreach (ExcelDrawing d in Drawings)
-                    {
-                        d.AdjustPositionAndSize();
-                        d.UpdatePositionAndSizeXml();
-                        HandleSaveForIndividualDrawings(d, hasLoadedPivotTables);
-                    }
-                    Packaging.ZipPackagePart partPack = Drawings.Part;
-                    var partStream = partPack.GetStream(FileMode.Create, FileAccess.Write);
-                    Drawings.DrawingXml.Save(partStream);
-                }
-            }
+            Drawings.SaveDrawings(hasLoadedPivotTables);
         }
 
-        private static void HandleSaveForIndividualDrawings(ExcelDrawing d, bool hasLoadedPivotTables)
-        {
-            if (d is ExcelChart c)
-            {
-                var chartStream = c.Part.GetStream(FileMode.Create, FileAccess.Write);
-                c.ChartXml.PreserveWhitespace = true;
-                c.ChartXml.Save(chartStream);
-
-                if (c is ExcelChartStandard cs && cs.Drawings.Part != null)
-                {
-                    foreach (var cd in cs.Drawings)
-                    {
-                        cd.UpdatePositionAndSizeXml();
-                        HandleSaveForIndividualDrawings(cd, hasLoadedPivotTables); //Handle group shapes.
-                    }
-
-                    var xrd = new XmlTextWriter(cs.Drawings.Part.GetStream(FileMode.Create, FileAccess.Write), Encoding.UTF8);
-                    xrd.Formatting = Formatting.None;
-                    cs.Drawings.DrawingXml.Save(xrd);
-                }
-            }
-            else if (d is ExcelSlicer<ExcelTableSlicerCache> s)
-            {
-                s.Cache.SlicerCacheXml.PreserveWhitespace = true;
-                s.Cache.SlicerCacheXml.Save(s.Cache.Part.GetStream(FileMode.Create, FileAccess.Write));
-            }
-            else if (d is ExcelSlicer<ExcelPivotTableSlicerCache> p)
-            {
-                if (p.Cache == null) return;
-                if (hasLoadedPivotTables)
-                {
-                    p.Cache.UpdateItemsXml();
-                }
-                p.Cache.SlicerCacheXml.Save(p.Cache.Part.GetStream(FileMode.Create, FileAccess.Write));
-            }
-            else if (d is ExcelControl ctrl)
-            {
-                ctrl.ControlPropertiesXml.Save(ctrl.ControlPropertiesPart.GetStream(FileMode.Create, FileAccess.Write));
-                ctrl.ControlPropertiesXml.PreserveWhitespace = true;
-                ctrl.UpdateXml();
-            }
-            else if (d is ExcelOleObject o)
-            {
-                if (o.IsExternalLink)
-                {
-                    if (o._oleObjectPart != null && o._linkedOleObjectXml != null)
-                    {
-                        o._linkedOleObjectXml.Save(o._oleObjectPart.GetStream(FileMode.Create, FileAccess.Write));
-                    }
-                }
-                o.UpdateXml();
-            }
-            else if (d is ExcelGroupShape grp)
-            {
-                foreach (var sd in grp.Drawings)
-                {
-                    HandleSaveForIndividualDrawings(sd, hasLoadedPivotTables);
-                }
-            }
-        }
 
         private void SaveSlicers()
         {

--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -2485,7 +2485,7 @@ namespace OfficeOpenXml
 
             if (_worksheetXml != null)
             {
-                SaveDrawings(hasLoadedPivotTables);
+                Drawings.SaveDrawings(hasLoadedPivotTables);
                 if (!(this is ExcelChartsheet))
                 {
                     // save the header & footer (if defined)
@@ -2526,12 +2526,6 @@ namespace OfficeOpenXml
                 }
             }
         }
-
-        private void SaveDrawings(bool hasLoadedPivotTables)
-        {
-            Drawings.SaveDrawings(hasLoadedPivotTables);
-        }
-
 
         private void SaveSlicers()
         {


### PR DESCRIPTION
Previously we saved drawings within ExcelWorksheet and had an ever-growing If()Else() for specific drawing types.

This fix creates a virtual in ExcelDrawing (SaveDrawing) that each individual shape type can then override. This way each shape holds the responsibility for how it is saved if it needs to be saved differently from other shapes