### PR TITLE
Freezepanes now handles it appropriately if some rows are visible and

### DIFF
--- a/src/EPPlus/ExcelWorksheetView.cs
+++ b/src/EPPlus/ExcelWorksheetView.cs
@@ -646,6 +646,9 @@ namespace OfficeOpenXml
             int hiddenCols = 0;
             int hiddenRows = 0;
 
+            int? firstVisibleRow = null;
+            int? firstVisibleColumn = null;
+
             for (int i = 1; i < Column; i++)
             {
                 var col = _worksheet.Column(i);
@@ -653,15 +656,27 @@ namespace OfficeOpenXml
                 {
                     hiddenCols++;
                 }
+                else if(firstVisibleColumn == null)
+                {
+                    firstVisibleColumn = i;
+                }
             }
 
-            foreach (var row in _worksheet.Rows[0, Row])
+            for (int i = 1; i < Row; i++)
             {
-                if (row.Hidden == true)
+                if (_worksheet.Row(i).Hidden == true)
                 {
                     hiddenRows++;
                 }
+                else if(firstVisibleRow == null)
+                {
+                    firstVisibleRow = i;
+                }
             }
+
+            firstVisibleColumn = firstVisibleColumn ?? 1 + hiddenCols;
+            firstVisibleRow = firstVisibleRow ?? 1 + hiddenRows;
+
 
             var visibleRows = Row - hiddenRows;
             var visibleColumns = Column - hiddenCols;
@@ -689,11 +704,11 @@ namespace OfficeOpenXml
             //TopLeftCell must be topLeft Visible cell for the topnode
             if(TopLeftCell == "")
             {
-                TopLeftCell = ExcelCellBase.GetAddress(1 + hiddenRows, 1 + hiddenCols);
+                TopLeftCell = ExcelCellBase.GetAddress(firstVisibleRow.Value, firstVisibleColumn.Value);
             }
 
-            if (Column > 1) PaneSettings.XSplit = visibleColumns - 1;
-            if (Row > 1) PaneSettings.YSplit = visibleRows - 1;
+            if (Column > 1) PaneSettings.XSplit = Column - firstVisibleColumn.Value;
+            if (Row > 1) PaneSettings.YSplit = Row - firstVisibleRow.Value;
 
             PaneSettings.TopLeftCell = ExcelCellBase.GetAddress(Row, Column);
             PaneSettings.State = isSplit ? ePaneState.FrozenSplit : ePaneState.Frozen;

--- a/src/EPPlusTest/Issues/LegacyTests/Issues.cs
+++ b/src/EPPlusTest/Issues/LegacyTests/Issues.cs
@@ -2601,31 +2601,46 @@ namespace EPPlusTest
             var hiddenCols = 0;
             var hiddenRows = 0;
 
-            for (int i = 1; i < address.Start.Column; i++)
+            int? firstVisibleRow = null;
+            int? firstVisibleColumn = null;
+
+            for (int i = 1; i < col; i++)
             {
-                var coVar = ws.Column(i);
-                if (coVar != null && coVar.Hidden)
+                var currentCol = ws.Column(i);
+                if (currentCol != null && currentCol.Hidden)
                 {
                     hiddenCols++;
                 }
-            }
-
-            foreach (var rowVar in ws.Rows[0, address.Start.Row])
-            {
-                if (rowVar.Hidden == true)
+                else if (firstVisibleColumn == null)
                 {
-                    hiddenRows++;
+                    firstVisibleColumn = i;
                 }
             }
 
+            for (int i = 1; i < row; i++)
+            {
+                if (ws.Row(i).Hidden == true)
+                {
+                    hiddenRows++;
+                }
+                else if (firstVisibleRow == null)
+                {
+                    firstVisibleRow = i;
+                }
+            }
+
+            firstVisibleColumn = firstVisibleColumn ?? 1 + hiddenCols;
+            firstVisibleRow = firstVisibleRow ?? 1 + hiddenRows;
+
+
             var visibleRows = row - hiddenRows;
             var visibleColumns = col - hiddenCols;
-            
+
             if(visibleColumns != 1 && visibleRows != 1)
             {
                 Assert.AreEqual(ws.Cells[1 + hiddenRows, 1 + hiddenCols].Address, ws.View.TopLeftCell);
-                Assert.AreEqual(visibleColumns - 1d, ws.View.PaneSettings.XSplit);
-                Assert.AreEqual(visibleRows - 1d, ws.View.PaneSettings.YSplit);
+                Assert.AreEqual(col - firstVisibleColumn.Value, ws.View.PaneSettings.XSplit);
+                Assert.AreEqual(row - firstVisibleRow.Value, ws.View.PaneSettings.YSplit);
                 Assert.AreEqual(ePanePosition.BottomRight, ws.View.PaneSettings.ActivePanePosition);
             }
             else

--- a/src/EPPlusTest/Issues/WorksheetIssues.cs
+++ b/src/EPPlusTest/Issues/WorksheetIssues.cs
@@ -934,5 +934,66 @@ namespace EPPlusTest.Issues
             excelPackage.Workbook.Calculate();
             Assert.AreEqual("64.066,27€", excelPackage.Workbook.Worksheets[0].Cells[1, 3].Text);
         }
+
+		[TestMethod]
+		public void s931()
+		{
+			using (ExcelPackage xlPackage = OpenPackage("s931.xlsx", true))
+            {
+                ExcelWorksheet sheet = xlPackage.Workbook.Worksheets.Add("test");
+
+                sheet.Cells[1, 1].Value = "a";
+                sheet.Cells[2, 1].Value = "b";
+                sheet.Cells[3, 1].Value = "c";
+                sheet.Cells[4, 1].Value = "d";
+                sheet.Cells[5, 1].Value = "e";
+                sheet.Cells[6, 1].Value = "f";
+                sheet.Cells[7, 1].Value = "g";
+                sheet.Cells[8, 1].Value = "h";
+                sheet.Cells[9, 1].Value = "i";
+                sheet.Cells[10, 1].Value = "j";
+                sheet.Cells[11, 1].Value = "k";
+                sheet.Cells[12, 1].Value = "l";
+
+                sheet.Row(1).Hidden = false;
+                sheet.Row(2).Hidden = false;
+
+                sheet.Row(3).Hidden = true;
+                sheet.Row(4).Hidden = true;
+                sheet.Row(5).Hidden = true;
+                sheet.Row(6).Hidden = true;
+                sheet.Row(7).Hidden = true;
+                sheet.Row(8).Hidden = true;
+                sheet.Row(9).Hidden = true;
+                sheet.Row(10).Hidden = true;
+
+                sheet.View.FreezePanes(11, 1);
+
+				sheet.Row(6).Hidden = false;
+				sheet.Row(7).Hidden = false;
+
+                //sheet.View.PaneSettings.YSplit = 10;
+
+                Assert.AreEqual(10, sheet.View.PaneSettings.YSplit);
+
+                ExcelWorksheet sheet2 = xlPackage.Workbook.Worksheets.Add("test2");
+
+                sheet2.Column(1).Hidden = true;
+                sheet2.Row(1).Hidden = true;
+                var address = sheet2.Cells["C3"];
+
+                var row = address.Start.Row;
+                var col = address.Start.Column;
+
+                address.Value = "Freeze here";
+                sheet2.View.FreezePanes(address.Start.Row, address.Start.Column);
+
+                var someval = sheet2.View.PaneSettings.YSplit;
+
+                //Assert.AreEqual(2, sheet2.View.PaneSettings.YSplit);
+
+                xlPackage.Save();
+            }
+        }
     }
 }


### PR DESCRIPTION
some hidden before the frozen node.

X and Y split and TopLeft cell were based on hidden cells rather than visible ones.

It is required to base them on the first visible cell within a certain range and only if there is NONE should `1 + hidden` be used