### PR TITLE
Fixes issue 2118

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/AverageIf.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/AverageIf.cs
@@ -48,7 +48,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                 {
                     var rv = new RangeOrValue { Range = rangeInfo };
                     var mi = GetMatchIndexes(rv, args[1].Result, null);
-                    addresses = EnqueueMatchingAddresses(valueRange, mi);
+                    EnqueueMatchingAddresses(valueRange, mi, ref addresses);
                 }
             }
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/AverageIfs.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/AverageIfs.cs
@@ -40,18 +40,27 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             {
                 return FunctionParameterInformation.AdjustParameterAddress;
             }
-            if (argumentIndex % 2 == 0)
+            else if (argumentIndex % 2 == 0)
             {
                 return FunctionParameterInformation.IgnoreErrorInPreExecute;
             }
-            return FunctionParameterInformation.Normal;
+            else if (argumentIndex == 1)
+            {
+                return FunctionParameterInformation.Normal;
+            }
+            return FunctionParameterInformation.AdjustParameterAddress;
         }));
         public override void GetNewParameterAddress(IList<CompileResult> args, int index, ref Queue<FormulaRangeAddress> addresses)
         {
             if (index == 0 && args[0].Result is IRangeInfo valueRange)
             {
                 IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args);
-                addresses = EnqueueMatchingAddresses(valueRange, matchIndexes);
+                EnqueueMatchingAddresses(valueRange, matchIndexes, ref addresses);
+            }
+            else if (args[index].Result is IRangeInfo criteriaRange)
+            {
+                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args, index);
+                EnqueueMatchingAddresses(criteriaRange, matchIndexes, ref addresses);
             }
         }
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/CountIfs.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/CountIfs.cs
@@ -12,6 +12,7 @@
  *************************************************************************************************/
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
+using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
 using OfficeOpenXml.FormulaParsing.Ranges;
 using System;
 using System.Collections.Generic;
@@ -27,16 +28,26 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
     internal class CountIfs : RangeCriteriaFunction
     {
         public override int ArgumentMinLength => 2;
-        //public override ExcelFunctionArrayBehaviour ArrayBehaviour => ExcelFunctionArrayBehaviour.Custom;
         public override ExcelFunctionParametersInfo ParametersInfo => new ExcelFunctionParametersInfo(new Func<int, FunctionParameterInformation>((argumentIndex) =>
         {
-            if (argumentIndex % 2 == 1)
+            if(argumentIndex == 0)
             {
-                return FunctionParameterInformation.IgnoreErrorInPreExecute;
+                return FunctionParameterInformation.Normal;
             }
-            return FunctionParameterInformation.Normal;
+            if (argumentIndex % 2 == 0)
+            {
+                return FunctionParameterInformation.AdjustParameterAddress;
+            }
+            return FunctionParameterInformation.IgnoreErrorInPreExecute;
         }));
-
+        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ref Queue<FormulaRangeAddress> addresses)
+        {
+            if (args[index].Result is IRangeInfo criteriaRange)
+            {
+                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(0, args, index);
+                EnqueueMatchingAddresses(criteriaRange, matchIndexes, ref addresses);
+            }
+        }
         public override void ConfigureArrayBehaviour(ArrayBehaviourConfig config)
         {
             config.IgnoreNumberOfArgsFromStart = 1;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/RangeCriteriaFunction.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/RangeCriteriaFunction.cs
@@ -196,9 +196,12 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             }
             return result;
         }
-        protected static Queue<FormulaRangeAddress> EnqueueMatchingAddresses(IRangeInfo valueRange, IEnumerable<int> matchIndexes)
+        protected static Queue<FormulaRangeAddress> EnqueueMatchingAddresses(IRangeInfo valueRange, IEnumerable<int> matchIndexes, ref Queue<FormulaRangeAddress> addresses)
         {
-            Queue<FormulaRangeAddress> addresses = new Queue<FormulaRangeAddress>();
+            if(addresses==null)
+            {
+                addresses=new Queue<FormulaRangeAddress>();
+            }
             var pIx = int.MinValue;
             var valueAddress = valueRange.GetAddressDimensionAdjusted(0);
             var extRef = valueAddress.ExternalReferenceIx;
@@ -243,12 +246,12 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
 
             return addresses;
         }
-        protected IEnumerable<int> GetMatchingIndicesFromArguments(int argStartIx, IList<CompileResult> args)
+        protected IEnumerable<int> GetMatchingIndicesFromArguments(int argStartIx, IList<CompileResult> args, int maxIndex=31)
         {
             //Return the addresses matching the criteria in the queue
             var argRanges = new List<RangeOrValue>();
             var criteria = new List<object>();
-            for (var ix = argStartIx; ix < 31; ix += 2)
+            for (var ix = argStartIx; ix < maxIndex; ix += 2)
             {
                 if (args.Count <= ix) break;
                 var arg = args[ix];

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/SumIf.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/SumIf.cs
@@ -49,7 +49,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                 {
                     var rv = new RangeOrValue { Range = criteriaRange };                    
                     var  mi=GetMatchIndexes(rv, args[1].Result, null);
-                    addresses = EnqueueMatchingAddresses(valueRange, mi);
+                    addresses = EnqueueMatchingAddresses(valueRange, mi, ref addresses);
                 }
             }
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/SumIfs.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/SumIfs.cs
@@ -45,18 +45,27 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             {
                 return FunctionParameterInformation.AdjustParameterAddress;
             }
-            if (argumentIndex % 2 == 0)
+            else if (argumentIndex % 2 == 0)
             {
                 return FunctionParameterInformation.IgnoreErrorInPreExecute;
             }
-            return FunctionParameterInformation.Normal;
+            else if(argumentIndex==1)
+            {
+                return FunctionParameterInformation.Normal;
+            }
+            return FunctionParameterInformation.AdjustParameterAddress;
         }));
         public override void GetNewParameterAddress(IList<CompileResult> args, int index, ref Queue<FormulaRangeAddress> addresses)
         {
             if (index == 0 && args[0].Result is IRangeInfo valueRange)
             {
                 IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args);
-                addresses = EnqueueMatchingAddresses(valueRange, matchIndexes);
+                addresses = EnqueueMatchingAddresses(valueRange, matchIndexes, ref addresses);
+            }
+            else if(args[index].Result is IRangeInfo criteriaRange)
+            {
+                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args, index);
+                addresses = EnqueueMatchingAddresses(criteriaRange, matchIndexes, ref addresses);
             }
         }
 

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/AverageIfsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/AverageIfsTests.cs
@@ -208,5 +208,38 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
                 SaveWorkbook("AverageIfsMultiArray.xlsx", package);
             }
         }
+        [TestMethod]
+        public void AverageIfsOutsideCriteriaShouldNotThrowCircularReferences()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                sheet1.Cells["A1"].Value = "AvgResult";
+                // This shouldn't be a circular reference, because the 1:1="AVG" condition should filter out A2 before the 2:2 filter is applied
+                sheet1.Cells["A2"].Formula = "AverageIfs(3:3, 1:1,\"AVG\",2:2,\"<>\")";
+
+                sheet1.Cells["B2"].Value = 1;
+                sheet1.Cells["C2"].Value = 2;
+                sheet1.Cells["E2"].Value = 4;
+                sheet1.Cells["F2"].Value = 5;
+                sheet1.Cells["G2"].Value = 6;
+
+                sheet1.Cells["C1"].Value = "AVG";
+                sheet1.Cells["D1"].Value = "AVG";
+                sheet1.Cells["E1"].Value = "AVG";
+                sheet1.Cells["G1"].Value = "AVG";
+
+                sheet1.Cells["B3"].Value = 1;
+                sheet1.Cells["C3"].Value = 2;
+                sheet1.Cells["E3"].Value = 4;
+                sheet1.Cells["F3"].Value = 5;
+                sheet1.Cells["G3"].Value = 6;
+
+                pck.Workbook.Calculate();
+
+                Assert.AreEqual(4D, sheet1.Cells["A2"].GetValue<double>(), 0.00);
+            }
+        }
+
     }
 }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/CountIfsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/CountIfsTests.cs
@@ -14,7 +14,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
         [TestMethod]
         public void CountIfsShouldNotCountNumericStringsAsNumbers()
         {
-            using(var package = new ExcelPackage())
+            using (var package = new ExcelPackage())
             {
                 var sheet = package.Workbook.Worksheets.Add("test");
                 sheet.Cells[1, 1].Value = "123";
@@ -264,6 +264,32 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
                 Assert.IsNull(sheet.Cells["D6"].Value);
 
                 SaveWorkbook("CountIfsMultiArray.xlsx", package);
+            }
+        }
+        [TestMethod]
+        public void CountIfs_CountThisRowWithoutCircularReferences()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                sheet1.Cells["A1"].Value = "SumResult";
+                // This shouldn't be a circular reference, because the 1:1="COUNTABLE" condition should filter out A2 before the 2:2 filter is applied
+                sheet1.Cells["A2"].Formula = "COUNTIFS(1:1,\"COUNTABLE\",2:2,\"<>\")";
+                
+                sheet1.Cells["B2"].Value = 1;
+                sheet1.Cells["C2"].Value = 2;
+                sheet1.Cells["E2"].Value = 4;
+                sheet1.Cells["F2"].Value = 5;
+                sheet1.Cells["G2"].Value = 6;
+
+                sheet1.Cells["C1"].Value = "COUNTABLE";
+                sheet1.Cells["D1"].Value = "COUNTABLE";
+                sheet1.Cells["E1"].Value = "COUNTABLE";
+                sheet1.Cells["G1"].Value = "COUNTABLE";
+
+                pck.Workbook.Calculate();
+
+                Assert.AreEqual(3D, sheet1.Cells["A2"].GetValue<double>(), 0.00);
             }
         }
     }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/SumIfsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/SumIfsTests.cs
@@ -99,5 +99,37 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
                 Assert.AreEqual(0d, val);
             }
         }
+        [TestMethod]
+        public void SumIfs_SumOutsideCriteriaShouldNotThrowCircularReferences()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet1 = pck.Workbook.Worksheets.Add("Sheet1");
+                sheet1.Cells["A1"].Value = "SumResult";
+                // This shouldn't be a circular reference, because the 1:1="SUMABLE" condition should filter out A2 before the 2:2 filter is applied
+                sheet1.Cells["A2"].Formula = "SumIfs(3:3, 1:1,\"SUMABLE\",2:2,\"<>\")";
+
+                sheet1.Cells["B2"].Value = 1;
+                sheet1.Cells["C2"].Value = 2;
+                sheet1.Cells["E2"].Value = 4;
+                sheet1.Cells["F2"].Value = 5;
+                sheet1.Cells["G2"].Value = 6;
+
+                sheet1.Cells["C1"].Value = "SUMABLE";
+                sheet1.Cells["D1"].Value = "SUMABLE";
+                sheet1.Cells["E1"].Value = "SUMABLE";
+                sheet1.Cells["G1"].Value = "SUMABLE";
+
+                sheet1.Cells["B3"].Value = 1;
+                sheet1.Cells["C3"].Value = 2;
+                sheet1.Cells["E3"].Value = 4;
+                sheet1.Cells["F3"].Value = 5;
+                sheet1.Cells["G3"].Value = 6;
+
+                pck.Workbook.Calculate();
+
+                Assert.AreEqual(12D, sheet1.Cells["A2"].GetValue<double>(), 0.00);
+            }
+        }
     }
 }


### PR DESCRIPTION
#2118 - COUNTIFS, SUMIFS and AVERAGEIFS does not handle circular references correctly when having multiple criteria ranges
