### PR TITLE
#2124 - option to supply an instance of IConfiguration to ExcelPackage constructor and Configure method

### DIFF
--- a/src/EPPlus/Configuration/ExcelPackageConfiguration.cs
+++ b/src/EPPlus/Configuration/ExcelPackageConfiguration.cs
@@ -10,6 +10,9 @@
  *************************************************************************************************
   08/19/2022         EPPlus Software AB       Implementing handling of initialization errors in ExcelPackage class.
  *************************************************************************************************/
+#if(Core)
+using Microsoft.Extensions.Configuration;
+#endif
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -35,6 +38,13 @@ namespace OfficeOpenXml.Configuration
         {
             get; set;
         }
+
+#if(Core)
+        /// <summary>
+        /// A <see cref="IConfiguration" /> instance that will be used by EPPlus to read license information/key
+        /// </summary>
+        public IConfiguration Configuration { get; set; }
+#endif
 
         private string _jsonConfigBasePath = Directory.GetCurrentDirectory();
         /// <summary>
@@ -71,6 +81,9 @@ namespace OfficeOpenXml.Configuration
             _jsonConfigBasePath = other.JsonConfigBasePath;
             _jsonConfigFileName = other.JsonConfigFileName;
             SuppressInitializationExceptions = other.SuppressInitializationExceptions;
+#if(Core)
+            Configuration = other.Configuration;
+#endif
         }
 
         /// <summary>

--- a/src/EPPlus/ExcelConfigurationReader.cs
+++ b/src/EPPlus/ExcelConfigurationReader.cs
@@ -61,6 +61,28 @@ namespace OfficeOpenXml
         internal static string GetJsonConfigValue(string key, ExcelPackageConfiguration config, List<ExcelInitializationError> initErrors)
         {
             var supressInitExceptions = config.SuppressInitializationExceptions;
+            // try to read from the IConfiguration that can be supplied either via constructor of ExcelPackage or ExcelPackage.Configure
+            var cfg = ExcelPackage.Configuration;
+            if(cfg == null && config.Configuration != null)
+            {
+                cfg = config.Configuration;
+            }
+            if(cfg != null)
+            {
+                try
+                {
+                    var v = cfg[key];
+                    return v;
+                }
+                catch(Exception ex)
+                {
+                    var errorMessage = $"Could read value '{key}' from the supplied instance of IConfiguration.";
+                    var error = new ExcelInitializationError(errorMessage, ex);
+                    initErrors.Add(error);
+                    return null;
+                }
+            }
+            // use file paths of the configuration
             var basePath = config.JsonConfigBasePath;
             var configFileName = config.JsonConfigFileName;
             var configRoot = default(IConfigurationRoot);

--- a/src/EPPlus/ExcelPackage.cs
+++ b/src/EPPlus/ExcelPackage.cs
@@ -144,6 +144,9 @@ namespace OfficeOpenXml
         Stream _stream = null;
         private bool _isExternalStream = false;
         internal ExcelPackage _loadedPackage = null;
+#if(Core)
+        internal static IConfiguration Configuration { get; private set; }
+#endif
         #region Properties
         /// <summary>
         /// Extension Schema types
@@ -270,6 +273,8 @@ namespace OfficeOpenXml
             File = newFile;
             ConstructNewFile(null);
         }
+
+
         /// <summary>
 		/// Create a new instance of the ExcelPackage class based on a existing file or creates a new file. 
 		/// </summary>
@@ -277,6 +282,106 @@ namespace OfficeOpenXml
         public ExcelPackage(string path)
             : this(new FileInfo(path))
         { }
+
+#if (Core)
+        /// <summary>
+        /// Create a new instance of the ExcelPackage. 
+        /// Output is accessed through the Stream property, using the <see cref="SaveAs(FileInfo)"/> method or later set the <see cref="File" /> property.
+        /// <param name="configuration">An instance of <see cref="IConfiguration"/> provided by the hosting application.</param>
+        /// </summary>
+        public ExcelPackage(IConfiguration configuration)
+        {
+            Configuration = configuration;
+            Init();
+            ConstructNewFile(null);
+        }
+        /// <summary>
+        ///  Create a new instance of the ExcelPackage class based on a existing file or creates a new file. 
+        /// </summary>
+        /// <param name="newFile">If newFile exists, it is opened.  Otherwise it is created from scratch.</param>
+        /// <param name="configuration">An instance of <see cref="IConfiguration"/> provided by the hosting application.</param>
+        public ExcelPackage(FileInfo newFile, IConfiguration configuration)
+        {
+            Configuration = configuration;
+            Init();
+            File = newFile;
+            ConstructNewFile(null);
+        }
+        /// <summary>
+        ///  Create a new instance of the ExcelPackage class based on a existing file or creates a new file. 
+        /// </summary>
+        /// <param name="path">If newFile exists, it is opened.  Otherwise it is created from scratch.</param>
+        /// <param name="configuration">An instance of <see cref="IConfiguration"/> provided by the hosting application.</param>
+        public ExcelPackage(string path, IConfiguration configuration)
+            : this(new FileInfo(path), configuration)
+        { }
+
+        /// <summary>
+        /// Create a new instance of the ExcelPackage class based on a existing file or creates a new file. 
+        /// </summary>
+        /// <param name="newFile">If newFile exists, it is opened.  Otherwise it is created from scratch.</param>
+        /// <param name="password">Password for an encrypted package</param>
+        /// <param name="configuration">An instance of <see cref="IConfiguration"/> provided by the hosting application.</param>
+        public ExcelPackage(FileInfo newFile, string password, IConfiguration configuration)
+        {
+            Configuration = configuration;
+            Init();
+            File = newFile;
+            ConstructNewFile(password);
+        }
+
+        /// <summary>
+        /// Create a new instance of the ExcelPackage class based on a existing template.
+        /// If newFile exists, it will be overwritten when the Save method is called
+        /// </summary>
+        /// <param name="newFile">The name of the Excel file to be created</param>
+        /// <param name="template">The name of the Excel template to use as the basis of the new Excel file</param>
+        /// <param name="configuration">An instance of <see cref="IConfiguration"/> provided by the hosting application.</param>
+        public ExcelPackage(FileInfo newFile, FileInfo template, IConfiguration configuration)
+        {
+            Configuration = configuration;
+            Init();
+            File = newFile;
+            CreateFromTemplate(template, null);
+        }
+
+        /// <summary>
+        /// Create a new instance of the ExcelPackage class based on a existing template.
+        /// If newFile exists, it will be overwritten when the Save method is called
+        /// </summary>
+        /// <param name="newFile">The name of the Excel file to be created</param>
+        /// <param name="template">The name of the Excel template to use as the basis of the new Excel file</param>
+        /// <param name="password">Password to decrypted the template</param>
+        /// <param name="configuration">An instance of <see cref="IConfiguration"/> provided by the hosting application.</param>
+        public ExcelPackage(FileInfo newFile, FileInfo template, string password, IConfiguration configuration)
+        {
+            Configuration = configuration;
+            Init();
+            File = newFile;
+            CreateFromTemplate(template, password);
+        }
+
+        /// <summary>
+        /// Create a new instance of the ExcelPackage class based on a stream
+        /// </summary>
+        /// <param name="newStream">The stream object can be empty or contain a package. The stream must be Read/Write</param>
+        /// /// <param name="configuration">An instance of <see cref="IConfiguration"/> provided by the hosting application.</param>
+        public ExcelPackage(Stream newStream, IConfiguration configuration)
+        {
+            Configuration = configuration;
+            Init();
+            if (newStream.CanSeek && newStream.Length == 0)
+            {
+                _stream = newStream;
+                _isExternalStream = true;
+                ConstructNewFile(null);
+            }
+            else
+            {
+                Load(newStream);
+            }
+        }
+#endif
         /// <summary>
         /// Create a new instance of the ExcelPackage class based on a existing file or creates a new file. 
         /// </summary>


### PR DESCRIPTION
See #2124

Available when #if(Core) is true only.

### Test file:
``` json
{
  "EPPlus": {
    "ExcelPackage": {
      "License": "NonCommercialOrganization:The noncommercial organization"
    }
  }
}
```
### Demo/Test 1:
Set configuration via ExcelPackage.Configure method
``` cs
using Microsoft.Extensions.Configuration;
using OfficeOpenXml;

var config = new ConfigurationBuilder()
       .SetBasePath(Directory.GetCurrentDirectory()) // Viktigt för att hitta filen
       .AddJsonFile("appConfig1.json", optional: false, reloadOnChange: true)
       .Build();

// this passes the configuration of the hosting applications to EPPlus and
// license key/info will be read from this instance.
ExcelPackage.Configure(x => x.Configuration = config);
using var package = new ExcelPackage();
var ws = package.Workbook.Worksheets.Add("Test");
Console.WriteLine(ExcelPackage.License.LegalName);
```

### Demo/Test2:
Set configuration via the ExcelPackage Constructor.
``` cs
using Microsoft.Extensions.Configuration;
using OfficeOpenXml;

var config = new ConfigurationBuilder()
       .SetBasePath(Directory.GetCurrentDirectory()) // Viktigt för att hitta filen
       .AddJsonFile("appConfig1.json", optional: false, reloadOnChange: true)
       .Build();

using var package = new ExcelPackage(config);
var ws = package.Workbook.Worksheets.Add("Test");
Console.WriteLine(ExcelPackage.License.LegalName);
``` 