### PR TITLE
#2142 - implemented shifting of multi-addresses in defined names on insert/delete

### DIFF
--- a/src/EPPlus/ExcelAddressBase.cs
+++ b/src/EPPlus/ExcelAddressBase.cs
@@ -18,6 +18,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using OfficeOpenXml.FormulaParsing;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
 using OfficeOpenXml.Style;
@@ -30,7 +31,7 @@ namespace OfficeOpenXml
     /// <remarks>Examples of addresses are "A1" "B1:C2" "A:A" "1:1" "A1:E2,G3:G5" </remarks>
     public class ExcelAddressBase : ExcelCellBase
     {
-        internal int _fromRow=-1, _toRow, _fromCol, _toCol;
+        internal int _fromRow = -1, _toRow, _fromCol, _toCol;
         internal bool _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed;
         internal string _wb;
         internal string _ws;
@@ -47,7 +48,7 @@ namespace OfficeOpenXml
         internal ExcelAddressBase()
         {
         }
-        internal ExcelAddressBase(FormulaRangeAddress adr) : this(adr.WorksheetName,adr.FromRow, adr.FromCol, adr.ToRow, adr.ToCol)
+        internal ExcelAddressBase(FormulaRangeAddress adr) : this(adr.WorksheetName, adr.FromRow, adr.FromCol, adr.ToRow, adr.ToCol)
         {
             _fromRowFixed = (adr.FixedFlag & FixedFlag.FromRowFixed) > 0;
             _fromColFixed = (adr.FixedFlag & FixedFlag.FromColFixed) > 0;
@@ -113,16 +114,55 @@ namespace OfficeOpenXml
             _address = GetFullAddress(_wb, worksheetName, GetAddress(_fromRow, _fromCol, _toRow, _toCol));
         }
 
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="addresses"></param>
+        /// <param name="workbook"></param>
+        /// <param name="wsName"></param>
+        public ExcelAddressBase(List<ExcelAddressBase> addresses)
+        {
+            //if(addresses == null || !addresses.Any())
+            //{
+            //    return;
+            //}
+            //var fa = addresses.First();
+            //_ws = fa.WorkSheetName;
+            //_fromRow = fa._fromRow;
+            //_fromRowFixed = fa._fromRowFixed;
+            //_fromCol = fa._fromCol;
+            //_fromColFixed = fa._fromColFixed;
+            //_toRow = fa._toRow;
+            //_toRowFixed = fa._toRowFixed;
+            //_toCol = fa._toCol;
+            //_toColFixed = fa._toColFixed;
+            //_address = fa._address;
+            //_addresses = addresses;
+
+            var sb = new StringBuilder();
+            foreach (var adr in addresses)
+            {
+                if (sb.Length > 0)
+                {
+                    sb.Append(',');
+                }
+                sb.Append(adr.Address);
+            }
+            var adrs = sb.ToString();
+            SetAddress(adrs, null, null);
+        }
+
         internal static bool IsTableAddress(string address)
         {
             SplitAddress(address, out string wb, out string ws, out string intAddress);
             var lPos = intAddress.IndexOf('[');
-            if(lPos >= 0) 
+            if (lPos >= 0)
             {
-                var rPos= intAddress.IndexOf(']',lPos);
-                if(rPos>lPos)
+                var rPos = intAddress.IndexOf(']', lPos);
+                if (rPos > lPos)
                 {
-                    var c=intAddress[lPos+1];
+                    var c = intAddress[lPos + 1];
                     return !((c >= '0' && c <= '9') || c == '-');
                 }
             }
@@ -185,7 +225,7 @@ namespace OfficeOpenXml
         /// <param name="wb">The workbook to verify any defined names from</param>
         /// <param name="wsName">The name of the worksheet the address referes to</param>
         /// <ws></ws>
-        public ExcelAddressBase(string address, ExcelWorkbook wb=null, string wsName=null)
+        public ExcelAddressBase(string address, ExcelWorkbook wb = null, string wsName = null)
         {
             SetAddress(address, wb, wsName);
             if (string.IsNullOrEmpty(_ws) && string.IsNullOrEmpty(_wb)) _ws = wsName;
@@ -301,13 +341,13 @@ namespace OfficeOpenXml
         }
         internal string ChangeTableName(string prevName, string name)
         {
-            if (LocalAddress.StartsWith(prevName +"[", StringComparison.CurrentCultureIgnoreCase))
+            if (LocalAddress.StartsWith(prevName + "[", StringComparison.CurrentCultureIgnoreCase))
             {
                 var wsPart = "";
                 var ix = _address.TrimEnd().LastIndexOf('!', _address.Length - 2);  //Last index can be ! if address is #REF!, so check from                 
                 if (ix >= 0)
                 {
-                    wsPart=_address.Substring(0, ix);
+                    wsPart = _address.Substring(0, ix);
                 }
 
                 return wsPart + name + LocalAddress.Substring(prevName.Length);
@@ -319,15 +359,15 @@ namespace OfficeOpenXml
         }
         internal ExcelAddressBase Intersect(ExcelAddressBase address)
         {
-            if(address._fromRow > _toRow || _toRow < address._fromRow ||
+            if (address._fromRow > _toRow || _toRow < address._fromRow ||
                address._fromCol > _toCol || _toCol < address._fromCol ||
                _fromRow > address._toRow || address._toRow < _fromRow ||
                _fromCol > address._toCol || address._toCol < _fromCol ||
-               (string.IsNullOrEmpty(address._ws)==false && string.IsNullOrEmpty(_ws) == false && address._ws != _ws))
+               (string.IsNullOrEmpty(address._ws) == false && string.IsNullOrEmpty(_ws) == false && address._ws != _ws))
             {
                 return null;
             }
-            
+
             var fromRow = Math.Max(address._fromRow, _fromRow);
             var toRow = Math.Min(address._toRow, _toRow);
             var fromCol = Math.Max(address._fromCol, _fromCol);
@@ -355,23 +395,23 @@ namespace OfficeOpenXml
 
             if (_fromCol < address._fromCol)
             {
-                retAddress = GetAddress(fromRow, fromCol, _toRow, address._fromCol-1) + ",";
+                retAddress = GetAddress(fromRow, fromCol, _toRow, address._fromCol - 1) + ",";
                 fromCol = address._fromCol;
             }
 
-            if(_fromRow < address._fromRow)
+            if (_fromRow < address._fromRow)
             {
                 retAddress += GetAddress(fromRow, fromCol, address._fromRow - 1, toCol) + ",";
-                fromRow= address._fromRow;
+                fromRow = address._fromRow;
             }
 
-            if(_toCol > address._toCol)
+            if (_toCol > address._toCol)
             {
                 retAddress += GetAddress(fromRow, address._toCol + 1, _toRow, toCol) + ",";
                 toCol = address._toCol;
             }
 
-            if(_toRow > address._toRow)
+            if (_toRow > address._toRow)
             {
                 retAddress += GetAddress(address._toRow + 1, fromCol, _toRow, toCol) + ",";
             }
@@ -425,7 +465,7 @@ namespace OfficeOpenXml
                 _address = address;
             }
             _addresses = null;
-            if (_address.IndexOfAny(new char[] {',','!', '['}) > -1)
+            if (_address.IndexOfAny(new char[] { ',', '!', '[' }) > -1)
             {
                 _firstAddress = null;
                 //Advanced address. Including Sheet or multi or table.
@@ -434,7 +474,7 @@ namespace OfficeOpenXml
             else
             {
                 //Simple address
-                GetRowColFromAddress(_address, out _fromRow, out _fromCol, out _toRow, out  _toCol, out _fromRowFixed, out _fromColFixed,  out _toRowFixed, out _toColFixed, wb, wsName);
+                GetRowColFromAddress(_address, out _fromRow, out _fromCol, out _toRow, out _toCol, out _fromRowFixed, out _fromColFixed, out _toRowFixed, out _toColFixed, wb, wsName);
                 _start = null;
                 _end = null;
             }
@@ -444,17 +484,17 @@ namespace OfficeOpenXml
 
         internal ExcelAddressBase ToInternalAddress()
         {
-            if(_address.StartsWith("["))
+            if (_address.StartsWith("["))
             {
                 var ix = _address.IndexOf("]", 1);
                 if (ix > 0)
                 {
-                    if(_address[ix+1]=='!')
+                    if (_address[ix + 1] == '!')
                     {
                         ix++;
                     }
-                    var a = _address.Substring(ix+1);
-                    
+                    var a = _address.Substring(ix + 1);
+
                     return new ExcelAddressBase(a);
                 }
                 return this;
@@ -482,29 +522,29 @@ namespace OfficeOpenXml
             if (address[0] == '[')
             {
                 pos = address.IndexOf(']');
-                _wb = address.Substring(1, pos - 1);                
-                _ws = address.Substring(pos + 1);                
+                _wb = address.Substring(1, pos - 1);
+                _ws = address.Substring(pos + 1);
             }
             else
             {
                 _wb = "";
                 _ws = address;
             }
-            if(_ws.StartsWith("'", StringComparison.OrdinalIgnoreCase))
+            if (_ws.StartsWith("'", StringComparison.OrdinalIgnoreCase))
             {
-                pos = _ws.IndexOf("'",1, StringComparison.OrdinalIgnoreCase);
-                while(pos>0 && pos+1<_ws.Length && _ws[pos+1]=='\'')
+                pos = _ws.IndexOf("'", 1, StringComparison.OrdinalIgnoreCase);
+                while (pos > 0 && pos + 1 < _ws.Length && _ws[pos + 1] == '\'')
                 {
-                    _ws = _ws.Substring(0, pos) + _ws.Substring(pos+1);
-                    pos = _ws.IndexOf("'", pos+1, StringComparison.OrdinalIgnoreCase);
+                    _ws = _ws.Substring(0, pos) + _ws.Substring(pos + 1);
+                    pos = _ws.IndexOf("'", pos + 1, StringComparison.OrdinalIgnoreCase);
                 }
-                if (pos>0)
+                if (pos > 0)
                 {
-                    if(_ws.Length-1==pos)
+                    if (_ws.Length - 1 == pos)
                     {
                         _address = "A:XFD";
                     }
-                    else if (_ws[pos+1]!='!')
+                    else if (_ws[pos + 1] != '!')
                     {
                         throw new InvalidOperationException($"Address is not valid {address}. Missing ! after sheet name.");
                     }
@@ -512,25 +552,25 @@ namespace OfficeOpenXml
                     {
                         _address = _ws.Substring(pos + 2);
                     }
-                    _ws = _ws.Substring(1, pos-1);
-                    if(_ws.StartsWith("["))
+                    _ws = _ws.Substring(1, pos - 1);
+                    if (_ws.StartsWith("["))
                     {
                         var ix = _ws.IndexOf("]", 1);
-                        if(ix>0)
+                        if (ix > 0)
                         {
                             _wb = _ws.Substring(1, ix - 1);
-                            _ws = _ws.Substring(ix+1);
+                            _ws = _ws.Substring(ix + 1);
                         }
                     }
                     pos = _address.IndexOf(":'", StringComparison.OrdinalIgnoreCase);
-                    if(pos>0)
+                    if (pos > 0)
                     {
-                        var a1 = _address.Substring(0,pos);
+                        var a1 = _address.Substring(0, pos);
                         pos = _address.LastIndexOf("\'!", StringComparison.OrdinalIgnoreCase);
                         if (pos > 0)
                         {
-                            var a2 = _address.Substring(pos+2);
-                            _address=a1 + ":" + a2; //Remove any worksheet on second reference of the address. 
+                            var a2 = _address.Substring(pos + 2);
+                            _address = a1 + ":" + a2; //Remove any worksheet on second reference of the address. 
                         }
                     }
                     return;
@@ -538,7 +578,7 @@ namespace OfficeOpenXml
             }
             pos = _ws.IndexOf('!');
 
-            if (pos==0)
+            if (pos == 0)
             {
                 _address = _ws.Substring(1);
                 _ws = "";
@@ -553,7 +593,7 @@ namespace OfficeOpenXml
             {
                 _address = address;
             }
-            if(string.IsNullOrEmpty(_address))
+            if (string.IsNullOrEmpty(_address))
             {
                 _address = "A:XFD";
             }
@@ -562,7 +602,7 @@ namespace OfficeOpenXml
         {
             if (_ws == wsName) _ws = newWs;
             var fullAddress = GetAddress();
-            
+
             if (Addresses != null)
             {
                 foreach (var a in Addresses)
@@ -601,9 +641,9 @@ namespace OfficeOpenXml
                     address = "[" + _wb + "]";
                 }
 
-                if (_address.IndexOf("'!", StringComparison.OrdinalIgnoreCase) >=0 || ExcelWorksheet.NameNeedsApostrophes(_ws))
+                if (_address.IndexOf("'!", StringComparison.OrdinalIgnoreCase) >= 0 || ExcelWorksheet.NameNeedsApostrophes(_ws))
                 {
-                    address += string.Format("'{0}'!", _ws.Replace("'","''"));
+                    address += string.Format("'{0}'!", _ws.Replace("'", "''"));
                 }
                 else
                 {
@@ -653,16 +693,16 @@ namespace OfficeOpenXml
         {
             get
             {
-                if(Address.StartsWith("["))
+                if (Address.StartsWith("["))
                 {
-                   if(_wb.Any(x=>char.IsDigit(x)))
-                   {
-                      return int.Parse(_wb);
-                   }
-                   else
-                   {
-                      return -1;
-                   }
+                    if (_wb.Any(x => char.IsDigit(x)))
+                    {
+                        return int.Parse(_wb);
+                    }
+                    else
+                    {
+                        return -1;
+                    }
                 }
                 else
                 {
@@ -717,12 +757,12 @@ namespace OfficeOpenXml
                 {
                     return _address;
                 }
-                string a="";
-                if(_addresses != null)
+                string a = "";
+                if (_addresses != null)
                 {
-                    foreach(var sa in _addresses)
+                    foreach (var sa in _addresses)
                     {
-                        a += ","+sa.GetAddress();
+                        a += "," + sa.GetAddress();
                     }
                     a = a.TrimStart(',');
                 }
@@ -804,7 +844,7 @@ namespace OfficeOpenXml
         /// </summary>
         protected void Validate()
         {
-            if ((_fromRow > _toRow || _fromCol > _toCol) && (_toRow!=0)) //_toRow==0 is #REF!
+            if ((_fromRow > _toRow || _fromCol > _toCol) && (_toRow != 0)) //_toRow==0 is #REF!
             {
                 throw new ArgumentOutOfRangeException("Start cell Address must be less or equal to End cell address");
             }
@@ -835,12 +875,12 @@ namespace OfficeOpenXml
 
         private bool ExtractAddress(string fullAddress)
         {
-            var brackPos=new Stack<int>();
-            var bracketParts=new List<string>();
-            string first="", second="";
-            bool isText=false, hasSheet=false, hasColon=false;
-            string ws="";
-            _addresses = null;            
+            var brackPos = new Stack<int>();
+            var bracketParts = new List<string>();
+            string first = "", second = "";
+            bool isText = false, hasSheet = false, hasColon = false;
+            string ws = "";
+            _addresses = null;
             try
             {
                 if (fullAddress == "#REF!")
@@ -916,7 +956,7 @@ namespace OfficeOpenXml
                                 second = Regex.Replace(second, $"{first}$", string.Empty);
                             }
                             if (string.IsNullOrEmpty(ws))
-                            {                                
+                            {
                                 if (second == "")
                                 {
                                     ws = first;
@@ -928,9 +968,9 @@ namespace OfficeOpenXml
                                     second = "";
                                 }
                             }
-                            else if(string.IsNullOrEmpty(second)==false)
+                            else if (string.IsNullOrEmpty(second) == false)
                             {
-                                if(!ws.Equals(second,StringComparison.OrdinalIgnoreCase))
+                                if (!ws.Equals(second, StringComparison.OrdinalIgnoreCase))
                                 {
                                     _fromRow = _toRow = _fromCol = _toCol = -1;
                                     return true;
@@ -941,8 +981,8 @@ namespace OfficeOpenXml
                         }
                         else if (c == ',' && !isText)
                         {
-                            if(_addresses==null) _addresses = new List<ExcelAddressBase>();
-                            if(string.IsNullOrEmpty(ws))
+                            if (_addresses == null) _addresses = new List<ExcelAddressBase>();
+                            if (string.IsNullOrEmpty(ws))
                             {
                                 first = string.IsNullOrEmpty(second) ? first : first + ":" + second;
                                 second = "";
@@ -995,21 +1035,21 @@ namespace OfficeOpenXml
 
         private void HandleBrackets(string first, string second, List<string> bracketParts)
         {
-            if(!string.IsNullOrEmpty(first))
+            if (!string.IsNullOrEmpty(first))
             {
                 _table = new ExcelTableAddress();
                 Table.Name = first;
                 foreach (var s in bracketParts)
                 {
-                    if(s.IndexOf('[')<0)
+                    if (s.IndexOf('[') < 0)
                     {
-                        switch(s.ToLower(CultureInfo.InvariantCulture))                
+                        switch (s.ToLower(CultureInfo.InvariantCulture))
                         {
                             case "#all":
                                 _table.IsAll = true;
                                 break;
                             case "#headers":
-                               _table.IsHeader = true;
+                                _table.IsHeader = true;
                                 break;
                             case "#data":
                                 _table.IsData = true;
@@ -1021,25 +1061,25 @@ namespace OfficeOpenXml
                                 _table.IsThisRow = true;
                                 break;
                             default:
-                                if(string.IsNullOrEmpty(_table.ColumnSpan))
+                                if (string.IsNullOrEmpty(_table.ColumnSpan))
                                 {
-                                    _table.ColumnSpan=s;
+                                    _table.ColumnSpan = s;
                                 }
                                 else
                                 {
                                     _table.ColumnSpan += ":" + s;
                                 }
                                 break;
-                        }                
+                        }
                     }
                 }
             }
         }
         #region Address manipulation methods
-        internal eAddressCollition Collide(ExcelAddressBase address, bool ignoreWs=false)
+        internal eAddressCollition Collide(ExcelAddressBase address, bool ignoreWs = false)
         {
-            if (ignoreWs == false && address.WorkSheetName != WorkSheetName && 
-                string.IsNullOrEmpty(address.WorkSheetName) == false && 
+            if (ignoreWs == false && address.WorkSheetName != WorkSheetName &&
+                string.IsNullOrEmpty(address.WorkSheetName) == false &&
                 string.IsNullOrEmpty(WorkSheetName) == false)
             {
                 return eAddressCollition.No;
@@ -1084,12 +1124,12 @@ namespace OfficeOpenXml
         }
         internal bool CollideFullRowOrColumn(int fromRow, int fromCol, int toRow, int toCol)
         {
-            return (CollideFullRow(fromRow, toRow) && CollideColumn(fromCol, toCol)) || 
+            return (CollideFullRow(fromRow, toRow) && CollideColumn(fromCol, toCol)) ||
                    (CollideFullColumn(fromCol, toCol) && CollideRow(fromRow, toRow));
         }
         private bool CollideColumn(int fromCol, int toCol)
         {
-            return fromCol  <= _toCol && toCol >= _fromCol;
+            return fromCol <= _toCol && toCol >= _fromCol;
         }
 
         internal bool CollideRow(int fromRow, int toRow)
@@ -1104,9 +1144,9 @@ namespace OfficeOpenXml
         {
             return fromCol <= _fromCol && toCol >= _toCol;
         }
-        internal ExcelAddressBase AddRow(int row, int rows, bool setFixed=false, bool setRefOnMinMax=true, bool extendIfLastRow=false)
+        internal ExcelAddressBase AddRowFirstAddress(int row, int rows, bool setFixed = false, bool setRefOnMinMax = true, bool extendIfLastRow = false)
         {
-            if (row > _toRow && (row!=_toRow+1 || extendIfLastRow==false))
+            if (row > _toRow && (row != _toRow + 1 || extendIfLastRow == false))
             {
                 return this;
             }
@@ -1124,9 +1164,28 @@ namespace OfficeOpenXml
             }
         }
 
+        internal ExcelAddressBase AddRow(int row, int rows, bool setFixed = false, bool setRefOnMinMax = true, bool extendIfLastRow = false)
+        {
+            if (Addresses == null || Addresses.Count < 2)
+            {
+                return AddRowFirstAddress(row, rows, setFixed, setRefOnMinMax, extendIfLastRow);
+            }
+            else
+            {
+                var addresses = new List<ExcelAddressBase>();
+                foreach (var address in Addresses)
+                {
+                    var shiftedAddress = address.AddRowFirstAddress(row, rows, setFixed, setRefOnMinMax, extendIfLastRow);
+                    addresses.Add(shiftedAddress);
+                }
+                return new ExcelAddressBase(addresses);
+            }
+        }
+
+
         private int GetRow(int row, bool setRefOnMinMax)
         {
-            if (setRefOnMinMax==false)
+            if (setRefOnMinMax == false)
             {
                 if (row < 1) return 1;
                 if (row > ExcelPackage.MaxRows) return ExcelPackage.MaxRows;
@@ -1145,7 +1204,7 @@ namespace OfficeOpenXml
             return column;
         }
 
-        internal ExcelAddressBase DeleteRow(int row, int rows, bool setFixed = false, bool adjustMaxRow=true)
+        internal ExcelAddressBase DeleteRowFirstAddress(int row, int rows, bool setFixed = false, bool adjustMaxRow = true)
         {
             if (row > _toRow) //After
             {
@@ -1155,9 +1214,9 @@ namespace OfficeOpenXml
             {
                 return null;
             }
-            else if (row+rows < _fromRow || (_fromRowFixed && row < _fromRow)) //Before
+            else if (row + rows < _fromRow || (_fromRowFixed && row < _fromRow)) //Before
             {
-                var toRow = ((setFixed && _toRowFixed) || (adjustMaxRow==false && _toRow==ExcelPackage.MaxRows)) ? _toRow : _toRow - rows;
+                var toRow = ((setFixed && _toRowFixed) || (adjustMaxRow == false && _toRow == ExcelPackage.MaxRows)) ? _toRow : _toRow - rows;
                 return new ExcelAddressBase((setFixed && _fromRowFixed ? _fromRow : Math.Max(row, _fromRow - rows)), _fromCol, toRow, _toCol, _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed, WorkSheetName, _address);
             }
             else  //Partly
@@ -1175,17 +1234,36 @@ namespace OfficeOpenXml
                 }
             }
         }
+
+        internal ExcelAddressBase DeleteRow(int row, int rows, bool setFixed = false, bool adjustMaxRow = true)
+        {
+            if (Addresses == null || Addresses.Count < 2)
+            {
+                return DeleteRowFirstAddress(row, rows, setFixed, adjustMaxRow);
+            }
+            else
+            {
+                var addresses = new List<ExcelAddressBase>();
+                foreach (var address in Addresses)
+                {
+                    var shiftedAddress = address.DeleteRowFirstAddress(row, rows, setFixed, adjustMaxRow);
+                    addresses.Add(shiftedAddress);
+                }
+                return new ExcelAddressBase(addresses);
+            }
+        }
+
         internal ExcelAddressBase DeleteRowKeepFixed(int row, int rows)
         {
             if (row > _toRow) //After
             {
                 return this;
             }
-            else if (row != 0 && row <= _fromRow && _fromRowFixed==false && row + rows > _toRow && _toRowFixed==false) //Inside
+            else if (row != 0 && row <= _fromRow && _fromRowFixed == false && row + rows > _toRow && _toRowFixed == false) //Inside
             {
                 return null;
             }
-            else if (row + rows < _fromRow || (_fromRowFixed==false && row < _fromRow)) //Before
+            else if (row + rows < _fromRow || (_fromRowFixed == false && row < _fromRow)) //Before
             {
                 var toRow = _toRowFixed ? _toRow : _toRow - rows;
                 return new ExcelAddressBase((_fromRowFixed ? _fromRow : Math.Max(row, _fromRow - rows)), _fromCol, toRow, _toCol, _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed, WorkSheetName, _address);
@@ -1234,7 +1312,7 @@ namespace OfficeOpenXml
             }
         }
 
-        internal ExcelAddressBase AddColumn(int col, int cols, bool setFixed = false, bool setRefOnMinMax=true, bool extendIfLastCol = false)
+        internal ExcelAddressBase AddColumnFirstAddress(int col, int cols, bool setFixed = false, bool setRefOnMinMax = true, bool extendIfLastCol = false)
         {
             if (col > _toCol && (col != _toCol + 1 || extendIfLastCol == false))
             {
@@ -1251,19 +1329,37 @@ namespace OfficeOpenXml
                 return new ExcelAddressBase(_fromRow, _fromCol, _toRow, toCol, _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed, WorkSheetName, _address);
             }
         }
-        internal ExcelAddressBase DeleteColumn(int col, int cols, bool setFixed = false, bool adjustMaxCol = true)
+
+        internal ExcelAddressBase AddColumn(int col, int cols, bool setFixed = false, bool setRefOnMinMax = true, bool extendIfLastCol = false)
+        {
+            if (Addresses == null || Addresses.Count < 2)
+            {
+                return AddColumnFirstAddress(col, cols, setFixed, setRefOnMinMax, extendIfLastCol);
+            }
+            else
+            {
+                var addresses = new List<ExcelAddressBase>();
+                foreach (var address in Addresses)
+                {
+                    var shiftedAddress = address.AddColumnFirstAddress(col, cols, setFixed, setRefOnMinMax, extendIfLastCol);
+                    addresses.Add(shiftedAddress);
+                }
+                return new ExcelAddressBase(addresses);
+            }
+        }
+        internal ExcelAddressBase DeleteColumnFirstAddress(int col, int cols, bool setFixed = false, bool adjustMaxCol = true)
         {
             if (col > _toCol) //After
             {
                 return this;
             }
-            if (col!=0 && col <= _fromCol && col + cols > _toCol) //Inside
+            if (col != 0 && col <= _fromCol && col + cols > _toCol) //Inside
             {
                 return null;
             }
             else if (col + cols < _fromCol || _fromColFixed && col < _fromCol) //Before
             {
-                var toCol = ((setFixed && _toColFixed) ||(adjustMaxCol==false && _toCol==ExcelPackage.MaxColumns)) ? _toCol : _toCol - cols;
+                var toCol = ((setFixed && _toColFixed) || (adjustMaxCol == false && _toCol == ExcelPackage.MaxColumns)) ? _toCol : _toCol - cols;
                 return new ExcelAddressBase(_fromRow, (setFixed && _fromColFixed ? _fromCol : Math.Max(_fromCol - cols, col)), _toRow, toCol, _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed, WorkSheetName, _address);
             }
             else  //Partly
@@ -1280,10 +1376,29 @@ namespace OfficeOpenXml
                 }
             }
         }
+
+        internal ExcelAddressBase DeleteColumn(int col, int cols, bool setFixed = false, bool adjustMaxCol = true)
+        {
+            if (Addresses == null || Addresses.Count < 2)
+            {
+                return DeleteColumnFirstAddress(col, cols, setFixed, adjustMaxCol);
+            }
+            else
+            {
+                var addresses = new List<ExcelAddressBase>();
+                foreach (var address in Addresses)
+                {
+                    var shiftedAddress = address.DeleteColumnFirstAddress(col, cols, setFixed, adjustMaxCol);
+                    addresses.Add(shiftedAddress);
+                }
+                return new ExcelAddressBase(addresses);
+            }
+        }
+
         internal ExcelAddressBase Insert(ExcelAddressBase address, eShiftTypeInsert Shift)
         {
             //Before or after, no change
-            if(_toRow < address._fromRow || _toCol < address._fromCol || (_fromRow > address._toRow && _fromCol > address._toCol))
+            if (_toRow < address._fromRow || _toCol < address._fromCol || (_fromRow > address._toRow && _fromCol > address._toCol))
             {
                 return this;
             }
@@ -1291,13 +1406,13 @@ namespace OfficeOpenXml
             int rows = address.Rows;
             int cols = address.Columns;
             string retAddress = "";
-            if (Shift==eShiftTypeInsert.Right)
+            if (Shift == eShiftTypeInsert.Right)
             {
                 if (address._fromRow > _fromRow)
                 {
                     retAddress = GetAddress(_fromRow, _fromCol, address._fromRow, _toCol, _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed);
                 }
-                if(address._fromCol > _fromCol)
+                if (address._fromCol > _fromCol)
                 {
                     retAddress = GetAddress(_fromRow < address._fromRow ? _fromRow : address._fromRow, _fromCol, address._fromRow, _toCol, _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed);
                 }
@@ -1336,10 +1451,10 @@ namespace OfficeOpenXml
             {
                 if (string.IsNullOrEmpty(_ws) || !string.IsNullOrEmpty(ws))
                 {
-                    _ws = ws;                    
+                    _ws = ws;
                 }
                 _firstAddress = address;
-                GetRowColFromAddress(address, out _fromRow, out _fromCol, out _toRow, out  _toCol, out _fromRowFixed, out _fromColFixed, out _toRowFixed, out _toColFixed);
+                GetRowColFromAddress(address, out _fromRow, out _fromCol, out _toRow, out _toCol, out _fromRowFixed, out _fromColFixed, out _toRowFixed, out _toColFixed);
                 _start = null;
                 _end = null;
             }
@@ -1359,14 +1474,14 @@ namespace OfficeOpenXml
             R1C1
         }
 
-        internal static AddressType IsValid(string Address, bool r1c1=false)
+        internal static AddressType IsValid(string Address, bool r1c1 = false)
         {
             double d;
             if (Address == "#REF!")
             {
                 return AddressType.Invalid;
             }
-            else if(double.TryParse(Address, NumberStyles.Any, CultureInfo.InvariantCulture, out d)) //A double, no valid address
+            else if (double.TryParse(Address, NumberStyles.Any, CultureInfo.InvariantCulture, out d)) //A double, no valid address
             {
                 return AddressType.Invalid;
             }
@@ -1388,7 +1503,7 @@ namespace OfficeOpenXml
 
                         if (intAddress.Contains("[")) //Table reference
                         {
-                            return string.IsNullOrEmpty(wb) || wb=="0" ? AddressType.InternalAddress : AddressType.ExternalAddress;
+                            return string.IsNullOrEmpty(wb) || wb == "0" ? AddressType.InternalAddress : AddressType.ExternalAddress;
                         }
                         if (intAddress.Contains(","))
                         {
@@ -1412,21 +1527,21 @@ namespace OfficeOpenXml
         }
         internal static bool IsR1C1(string address)
         {
-            var start = address.LastIndexOf("!", address.Length-1, StringComparison.OrdinalIgnoreCase);
-            if (start>=0)
+            var start = address.LastIndexOf("!", address.Length - 1, StringComparison.OrdinalIgnoreCase);
+            if (start >= 0)
             {
                 address = address.Substring(start + 1);
             }
             address = address.ToUpper();
-            if (string.IsNullOrEmpty(address) || (address[0]!='R' && address[0]!='C'))
+            if (string.IsNullOrEmpty(address) || (address[0] != 'R' && address[0] != 'C'))
             {
                 return false;
             }
             bool isC = false, isROrC = false;
             bool startBracket = false;
-            foreach(var c in address)
+            foreach (var c in address)
             {
-                switch(c)
+                switch (c)
                 {
                     case 'C':
                         isC = true;
@@ -1450,9 +1565,9 @@ namespace OfficeOpenXml
                         isROrC = false;
                         break;
                     default:
-                        if((c>='0' && c<='9') ||c=='-')
+                        if ((c >= '0' && c <= '9') || c == '-')
                         {
-                            if(isROrC==false)
+                            if (isROrC == false)
                             {
                                 return false;
                             }
@@ -1469,11 +1584,11 @@ namespace OfficeOpenXml
 
         private static bool IsAddress(string intAddress, bool allowRef = false)
         {
-            if(string.IsNullOrEmpty(intAddress)) return false;            
+            if (string.IsNullOrEmpty(intAddress)) return false;
             var cells = intAddress.Split(':');
             int fromRow, toRow, fromCol, toCol;
 
-            if(!GetRowCol(cells[0], out fromRow, out fromCol, false))
+            if (!GetRowCol(cells[0], out fromRow, out fromCol, false))
             {
                 return false;
             }
@@ -1499,7 +1614,7 @@ namespace OfficeOpenXml
             }
             else
             {
-                return 
+                return
                     fromRow <= toRow &&
                     fromCol <= toCol &&
                     fromCol > -1 &&
@@ -1516,45 +1631,45 @@ namespace OfficeOpenXml
             intAddress = "";
             var text = "";
             bool isText = false;
-            var brackPos=-1;
+            var brackPos = -1;
             for (int i = 0; i < Address.Length; i++)
             {
                 if (Address[i] == '\'')
                 {
                     isText = !isText;
-                    if(i>0 && Address[i-1]=='\'')
+                    if (i > 0 && Address[i - 1] == '\'')
                     {
                         text += "'";
                     }
                 }
                 else
                 {
-                    if(Address[i]=='!' && !isText)
+                    if (Address[i] == '!' && !isText)
                     {
-                        if (text.Length>0 && text[0] == '[')
+                        if (text.Length > 0 && text[0] == '[')
                         {
                             wb = text.Substring(1, text.IndexOf(']') - 1);
                             ws = text.Substring(text.IndexOf(']') + 1);
                         }
                         else
                         {
-                            ws=text;
+                            ws = text;
                         }
-                        intAddress=Address.Substring(i+1);
+                        intAddress = Address.Substring(i + 1);
                         return true;
                     }
                     else
                     {
-                        if(Address[i]=='[' && !isText)
+                        if (Address[i] == '[' && !isText)
                         {
                             if (i > 0) //Table reference return full address;
                             {
-                                intAddress=Address;
+                                intAddress = Address;
                                 return true;
                             }
-                            brackPos=i;
+                            brackPos = i;
                         }
-                        else if(Address[i]==']' && !isText)
+                        else if (Address[i] == ']' && !isText)
                         {
                             if (brackPos > -1)
                             {
@@ -1568,7 +1683,7 @@ namespace OfficeOpenXml
                         }
                         else
                         {
-                            text+=Address[i];
+                            text += Address[i];
                         }
                     }
                 }
@@ -1587,7 +1702,7 @@ namespace OfficeOpenXml
                 var addressChar = address[i];
                 if (addressChar == '\'')
                 {
-                    if(i>0 && isText==false && address.Length>i+1 && address[i - 1] == ' ' && address[i+1] != '\'')
+                    if (i > 0 && isText == false && address.Length > i + 1 && address[i - 1] == ' ' && address[i + 1] != '\'')
                     {
                         return true;
                     }
@@ -1597,7 +1712,7 @@ namespace OfficeOpenXml
                     tableNameCount++;
                 else if (isText == false && addressChar == ']')
                     tableNameCount--;
-                else if(tableNameCount==0)
+                else if (tableNameCount == 0)
                 {
                     if (isText == false && _tokens.Contains(addressChar))
                     {
@@ -1622,11 +1737,11 @@ namespace OfficeOpenXml
         /// <summary>
         /// Number of rows int the address
         /// </summary>
-        public int Rows 
+        public int Rows
         {
             get
             {
-                return _toRow - _fromRow+1;
+                return _toRow - _fromRow + 1;
             }
         }
         /// <summary>
@@ -1673,10 +1788,10 @@ namespace OfficeOpenXml
         /// <summary>
         /// The address without the workbook or worksheet reference
         /// </summary>
-        public string LocalAddress 
-        { 
+        public string LocalAddress
+        {
             get
-            {                
+            {
                 if (Addresses == null)
                 {
                     if (_table == null)
@@ -1727,7 +1842,7 @@ namespace OfficeOpenXml
             get
             {
                 if (!_address.StartsWith("[")) return _address;
-                var ix = _address.IndexOf("]",1);
+                var ix = _address.IndexOf("]", 1);
                 if (ix >= 0)
                 {
                     return _address.Substring(ix + 1);
@@ -1739,7 +1854,7 @@ namespace OfficeOpenXml
         internal static string GetWorkbookPart(string address)
         {
             var ix = 0;
-            if(address[ix]=='\'')
+            if (address[ix] == '\'')
             {
                 ix++;
             }
@@ -1748,44 +1863,44 @@ namespace OfficeOpenXml
                 var endIx = address.LastIndexOf(']');
                 if (endIx > 0)
                 {
-                    return address.Substring(ix+1, endIx - ix - 1);
-                }   
+                    return address.Substring(ix + 1, endIx - ix - 1);
+                }
             }
             return "";
         }
         internal static string GetWorksheetPart(string address, string defaultWorkSheet)
         {
-            int ix=0;
+            int ix = 0;
             return GetWorksheetPart(address, defaultWorkSheet, ref ix);
         }
         internal static string GetWorksheetPart(string address, string defaultWorkSheet, ref int endIx)
         {
-            if(address=="") return defaultWorkSheet;
+            if (address == "") return defaultWorkSheet;
             var ix = 0;
             if (address[0] == '[' || address.StartsWith("'["))
             {
-                ix = address.IndexOf(']')+1;
+                ix = address.IndexOf(']') + 1;
             }
             if (ix >= 0 && ix < address.Length)
             {
                 if (address[ix] == '\'')
                 {
-                    var ret=GetString(address, ix+1, out endIx);
+                    var ret = GetString(address, ix + 1, out endIx);
                     endIx++;
-                    return ret; 
+                    return ret;
                 }
                 else
                 {
-                    endIx = address.IndexOf('!',ix)+1;
+                    endIx = address.IndexOf('!', ix) + 1;
                     var subtrLen = 1;
-                    if(endIx>0 && address[endIx-2]=='\'')
+                    if (endIx > 0 && address[endIx - 2] == '\'')
                     {
                         subtrLen++;
                     }
-                    if(endIx > ix)
+                    if (endIx > ix)
                     {
                         return address.Substring(ix, endIx - ix - subtrLen);
-                    }   
+                    }
                     else
                     {
                         return defaultWorkSheet;
@@ -1799,9 +1914,9 @@ namespace OfficeOpenXml
         }
         internal static string GetAddressPart(string address)
         {
-            var ix=0;
+            var ix = 0;
             GetWorksheetPart(address, "", ref ix);
-            if(ix<address.Length)
+            if (ix < address.Length)
             {
                 if (address[ix] == '!')
                 {
@@ -1818,10 +1933,10 @@ namespace OfficeOpenXml
             }
 
         }
-        internal static void SplitAddress(string fullAddress, out string wb, out string ws, out string address, string defaultWorksheet="")
+        internal static void SplitAddress(string fullAddress, out string wb, out string ws, out string address, string defaultWorksheet = "")
         {
             wb = GetWorkbookPart(fullAddress);
-            int ix=0;
+            int ix = 0;
             ws = GetWorksheetPart(fullAddress, defaultWorksheet, ref ix);
             if (ix < fullAddress.Length)
             {
@@ -1836,7 +1951,7 @@ namespace OfficeOpenXml
             }
             else
             {
-                address="";
+                address = "";
             }
         }
         internal static List<string[]> SplitFullAddress(string fullAddress)
@@ -1848,7 +1963,7 @@ namespace OfficeOpenXml
             bool isInAddress = false;
             bool isInText = false;
             var prevPos = 0;
-            for (int i=0;i<fullAddress.Length;i++)
+            for (int i = 0; i < fullAddress.Length; i++)
             {
                 if (isInWorkbook == false &&
                     isInWorksheet == false &&
@@ -1859,13 +1974,13 @@ namespace OfficeOpenXml
                         isInWorkbook = true;
                         prevPos = i + 1;
                     }
-                    else if(fullAddress[i] == '\'')
+                    else if (fullAddress[i] == '\'')
                     {
                         isInWorksheet = true;
                         isInText = true;
                         prevPos = i + 1;
                     }
-                    else if (fullAddress[i]=='!')
+                    else if (fullAddress[i] == '!')
                     {
                         isInAddress = true;
                         prevPos = i + 1;
@@ -1875,7 +1990,7 @@ namespace OfficeOpenXml
                         isInAddress = true;
                     }
                 }
-                else if(isInWorkbook)
+                else if (isInWorkbook)
                 {
                     if (fullAddress[i] == ']')
                     {
@@ -1883,27 +1998,27 @@ namespace OfficeOpenXml
                         isInWorkbook = false;
                     }
                 }
-                else if(isInWorksheet)
+                else if (isInWorksheet)
                 {
                     if (fullAddress[i] == '\'')
                     {
                         isInText = !isInText;
                     }
-                    else if (isInText==false && fullAddress[i] == '!')
+                    else if (isInText == false && fullAddress[i] == '!')
                     {
-                        currentAddress[1] = fullAddress.Substring(prevPos, i -prevPos - 1).Replace("''","'");
+                        currentAddress[1] = fullAddress.Substring(prevPos, i - prevPos - 1).Replace("''", "'");
                         prevPos = i + 1;
                         isInWorksheet = false;
                     }
                 }
-                else if(isInAddress)
+                else if (isInAddress)
                 {
-                    if(fullAddress[i] == '!')
+                    if (fullAddress[i] == '!')
                     {
                         currentAddress[1] = fullAddress.Substring(prevPos, i - prevPos);
                         prevPos = i + 1;
                     }
-                    else if (fullAddress[i]==',')
+                    else if (fullAddress[i] == ',')
                     {
                         currentAddress[2] = fullAddress.Substring(prevPos, i - prevPos);
                         addresses.Add(currentAddress);
@@ -1914,7 +2029,7 @@ namespace OfficeOpenXml
                 }
             }
 
-            if(isInWorkbook || isInWorksheet)
+            if (isInWorkbook || isInWorksheet)
             {
                 throw (new ArgumentException($"Invalid address {fullAddress}"));
             }
@@ -1937,7 +2052,7 @@ namespace OfficeOpenXml
 
         internal bool IsValidRowCol()
         {
-            return !(_fromRow > _toRow  ||
+            return !(_fromRow > _toRow ||
                    _fromCol > _toCol ||
                    _fromRow < 1 ||
                    _fromCol < 1 ||
@@ -1953,7 +2068,7 @@ namespace OfficeOpenXml
         {
             if (obj is ExcelAddressBase a)
             {
-                if (Addresses==null || a.Addresses==null)
+                if (Addresses == null || a.Addresses == null)
                 {
                     if (Addresses?.Count > 1 || a.Addresses?.Count > 1) return false;
                     return IsEqual(this, a);
@@ -1961,7 +2076,7 @@ namespace OfficeOpenXml
                 else
                 {
                     if (Addresses.Count != a.Addresses.Count) return false;
-                    for(int i=0;i<Addresses.Count;i++)
+                    for (int i = 0; i < Addresses.Count; i++)
                     {
                         if (IsEqual(Addresses[i], a.Addresses[i]) == false)
                         {
@@ -2013,7 +2128,7 @@ namespace OfficeOpenXml
             return false;
         }
 
-        internal FormulaRangeAddress AsFormulaRangeAddress(ParsingContext ctx=null)
+        internal FormulaRangeAddress AsFormulaRangeAddress(ParsingContext ctx = null)
         {
             return new FormulaRangeAddress(ctx)
             {
@@ -2054,10 +2169,10 @@ namespace OfficeOpenXml
                 {
                     var ca = a.CloneWithOffset(row, col);
                     ret.Addresses.Add(ca);
-                    if(sb.Length>0) sb.Append(",");
+                    if (sb.Length > 0) sb.Append(",");
                     sb.Append(ca.Address);
                 }
-                ret._address= sb.ToString();
+                ret._address = sb.ToString();
             }
             return ret;
         }

--- a/src/EPPlus/ExcelAddressBase.cs
+++ b/src/EPPlus/ExcelAddressBase.cs
@@ -192,19 +192,41 @@ namespace OfficeOpenXml
 
         internal void ResetAddress(string prevAddress)
         {
+            if(Addresses == null || Addresses.Count<2)
+            {
+                _address = ResetSingleAddress(this, prevAddress);
+
+            }
+            else
+            {
+                var sb=new StringBuilder();
+                foreach (var a in Addresses)
+                {
+                    var adr = ResetSingleAddress(a, a.Address);
+                    a.SetAddress(adr, null, _ws);
+                    sb.Append(a.Address);
+                    sb.Append(",");                    
+                }
+                _address = sb.ToString(0, sb.Length - 1);
+            }
+        }
+
+        private string ResetSingleAddress(ExcelAddressBase adr, string prevAddress)
+        {
             var prevAddressHasWs = prevAddress != null && prevAddress.IndexOf("!") > 0 && !prevAddress.EndsWith("!");
-            _address = GetAddress(_fromRow, _fromCol, _toRow, _toCol, _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed);
+            var address = GetAddress(adr._fromRow, adr._fromCol, adr._toRow, adr._toCol, _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed);
             if (prevAddressHasWs && !string.IsNullOrEmpty(_ws))
             {
                 if (ExcelWorksheet.NameNeedsApostrophes(_ws))
                 {
-                    _address = $"'{_ws.Replace("'", "''")}'!{_address}";
+                    address = $"'{_ws.Replace("'", "''")}'!{address}";
                 }
                 else
                 {
-                    _address = $"{_ws}!{_address}";
+                    address = $"{_ws}!{address}";
                 }
             }
+            return address;
         }
 
         /// <summary>

--- a/src/EPPlus/ExcelAddressBase.cs
+++ b/src/EPPlus/ExcelAddressBase.cs
@@ -115,30 +115,20 @@ namespace OfficeOpenXml
         }
 
 
+
         /// <summary>
-        /// 
+        /// Initializes a new instance of the <see cref="ExcelAddressBase"/> class
+        /// by combining multiple addresses into a single, comma-separated address string.
         /// </summary>
-        /// <param name="addresses"></param>
-        /// <param name="workbook"></param>
-        /// <param name="wsName"></param>
+        /// <param name="addresses">
+        /// A list of <see cref="ExcelAddressBase"/> instances to be combined. 
+        /// Each address in the list will be concatenated into a single address string, 
+        /// separated by commas.
+        /// </param>
+
         public ExcelAddressBase(List<ExcelAddressBase> addresses)
         {
-            //if(addresses == null || !addresses.Any())
-            //{
-            //    return;
-            //}
-            //var fa = addresses.First();
-            //_ws = fa.WorkSheetName;
-            //_fromRow = fa._fromRow;
-            //_fromRowFixed = fa._fromRowFixed;
-            //_fromCol = fa._fromCol;
-            //_fromColFixed = fa._fromColFixed;
-            //_toRow = fa._toRow;
-            //_toRowFixed = fa._toRowFixed;
-            //_toCol = fa._toCol;
-            //_toColFixed = fa._toColFixed;
-            //_address = fa._address;
-            //_addresses = addresses;
+            if (addresses == null || !addresses.Any()) return;
 
             var sb = new StringBuilder();
             foreach (var adr in addresses)

--- a/src/EPPlusTest/Core/Range/NamedRangeTests.cs
+++ b/src/EPPlusTest/Core/Range/NamedRangeTests.cs
@@ -456,6 +456,73 @@ namespace EPPlusTest.Core.Range
                 }
             }
         }
+        [TestMethod]
+        public void AddRowToDefinedNamesWithMultipleAddresses()
+        {
+            using (var p = new ExcelPackage())
+            {
+                // Add two worksheets
+                var sheet1 = p.Workbook.Worksheets.Add("Sheet1");
+                var wb = p.Workbook;
+                //Workbook level.
+                wb.Names.Add("WbName", sheet1.Cells["A5:F6,C7:D11,D4"]);
+                sheet1.Names.Add("SheetName", sheet1.Cells["A5,D7:D11,D1:D7"]);
+                sheet1.InsertRow(6, 2);
 
+                Assert.AreEqual("$A$5:$F$8,$C$9:$D$13,$D$4", wb.Names["wbName"].Address);
+                Assert.AreEqual("$A$5,$D$9:$D$13,$D$1:$D$9", sheet1.Names["sheetName"].Address);
+            }
+        }
+        [TestMethod]
+        public void DeleteRowToDefinedNamesWithMultipleAddresses()
+        {
+            using (var p = new ExcelPackage())
+            {
+                // Add two worksheets
+                var sheet1 = p.Workbook.Worksheets.Add("Sheet1");
+                var wb = p.Workbook;
+                //Workbook level.
+                wb.Names.Add("WbName", sheet1.Cells["A5:F6,C7:D11,D4"]);
+                sheet1.Names.Add("SheetName", sheet1.Cells["A5,D7:D11,D1:D7"]);
+                sheet1.DeleteRow(6, 2);
+
+                Assert.AreEqual("$A$5:$F$5,$C$6:$D$9,$D$4", wb.Names["wbName"].Address);
+                Assert.AreEqual("$A$5,$D$6:$D$9,$D$1:$D$5", sheet1.Names["sheetName"].Address);
+            }
+        }
+        [TestMethod]
+        public void DeleteColumnToDefinedNamesWithMultipleAddresses()
+        {
+            using (var p = new ExcelPackage())
+            {
+                // Add two worksheets
+                var sheet1 = p.Workbook.Worksheets.Add("Sheet1");
+                var wb = p.Workbook;
+                //Workbook level.
+                wb.Names.Add("WbName", sheet1.Cells["A5:F6,C7:D11,D4"]);
+                sheet1.Names.Add("SheetName", sheet1.Cells["A5,D7:D11,D1:D7"]);
+                sheet1.DeleteColumn(2, 2);
+
+                Assert.AreEqual("$A$5:$D$6,$B$7:$B$11,$B$4", wb.Names["wbName"].Address);
+                Assert.AreEqual("$A$5,$B$7:$B$11,$B$1:$B$7", sheet1.Names["sheetName"].Address);
+            }
+        }
+        [TestMethod]
+        public void AddColumnToDefinedNamesWithMultipleAddresses()
+        {
+            using (var p = new ExcelPackage())
+            {
+                // Add two worksheets
+                var sheet1 = p.Workbook.Worksheets.Add("Sheet1");
+                var wb = p.Workbook;
+                //Workbook level.
+                wb.Names.Add("WbName", sheet1.Cells["A5:F6,C7:D11,D4"]);
+                sheet1.Names.Add("SheetName", sheet1.Cells["A5,D7:D11,D1:D7"]);
+                sheet1.InsertColumn(2, 2);
+
+                Assert.AreEqual("$A$5:$H$6,$E$7:$F$11,$F$4", wb.Names["wbName"].Address);
+                Assert.AreEqual("$A$5,$F$7:$F$11,$F$1:$F$7", sheet1.Names["sheetName"].Address);
+            }
+        }
     }
 }


### PR DESCRIPTION
Visual Studio added spaces in the code, so almost every line is changed. Here are the changes to `ExcelAddressBase` that implements the change:

Line 129 - new constructor
Line 1137 - AddRow
Line 1197 - DeleteRow
Line 1305 - AddColumn
Line 1340 - DeleteColumn
