### PR TITLE
#2168 - Fixes a bug when data label separator newline was ignored

### DIFF
--- a/docs/articles/fixedissues.md
+++ b/docs/articles/fixedissues.md
@@ -1,4 +1,34 @@
 # Features / Fixed issues - EPPlus 8
+## Version 8.3.0
+### Features
+Support for adding external connections and query tables [External connections and query tables](https://github.com/EPPlusSoftware/EPPlus/wiki/External-Connections-&-Query-Tables)
+* Adding, updating and removing connections.
+  * Power query connections.
+  * Database connections
+  * OLAP connections
+  * Web connections
+  * Text connections
+* Adding range and table query tables
+* Adding pivot tables with external connections as source.
+* 3 new functions:
+  * `PERCENTOF`
+  * `VALUETOTEXT`
+  * `BASE`
+Fixed issues 
+* The `RichText.Clear` caused any previous reference to the RichText object not to work.
+* EPPlus will now throw a `ObjectDisposedException` when a rich text object has been disposed.
+* Implemented shifting of multi-addresses in defined names on insert/delete (i.e a1:a3,c1:c3).
+* New constructor for `ExcelAddressBase` taking a list of addresses.
+* Fixed several formatting issues in the `ARRAYTOTEXT` function.
+* Fixed an issue with incorrect mapping of formula columns in the `ExcelRangeBase.LoadFromCollection` method.
+* `ExcelRangeBase.InsertColumn` could throw an unhandled Exception in rare cases, when a formula contain references to external workbooks.
+* `ExcelRange.DeleteRow` throw an unhandled exception when having a conditional formatting colors scales rule with an empty formula.
+* A calculated column formula of a table could not be set after it had been cleared.
+* `ExcelWorksheet.DimensionByValue` sometimes returned an incorrect range.
+* COUNTIF did not compare numeric strings as numeric.
+* SUMIF and AVERAGEIF did not take empty cells in the into account in the criteria.
+* Deleting a data validation and then add a new one to the same range sometimes failed.
+
 ## Version 8.2.1
 ### Minor Features
 * Added new method `SetAutoTitle` to `ExcelChartTitleStandard` to map chart titles on pivot charts to the pivot tables data fields.

--- a/src/EPPlus/Drawing/Chart/ExcelChart.cs
+++ b/src/EPPlus/Drawing/Chart/ExcelChart.cs
@@ -806,27 +806,30 @@ namespace OfficeOpenXml.Drawing.Chart
         internal static ExcelChart CreateChartFromXml(ExcelDrawings drawings, XmlNode node, Uri uriChart, ZipPackagePart part, XmlDocument chartXml, ExcelGroupShape parent = null)
         {
             ExcelChart topChart = null;
-            foreach (XmlElement n in chartXml.SelectSingleNode(topPath + "/" + plotAreaPath, drawings.NameSpaceManager).ChildNodes)
+            foreach (var n in chartXml.SelectSingleNode(topPath + "/" + plotAreaPath, drawings.NameSpaceManager).ChildNodes)
             {
-                if (n.LocalName.EndsWith("Chart"))
-                {
-                    if (topChart == null)
+                if(n is XmlElement element)
+                { 
+                    if (element.LocalName.EndsWith("Chart"))
                     {
-                        if (part == null)
+                        if (topChart == null)
                         {
-                            topChart = GetChart(drawings, node);
+                            if (part == null)
+                            {
+                                topChart = GetChart(drawings, node);
+                            }
+                            else
+                            {
+                                topChart = GetChart(element, drawings, node, uriChart, part, chartXml, null, parent);
+                            }
                         }
                         else
                         {
-                            topChart = GetChart(n, drawings, node, uriChart, part, chartXml, null, parent);
-                        }
-                    }
-                    else
-                    {
-                        var subChart = GetChart(n, null, null, null, null, null, topChart, parent);
-                        if (subChart != null)
-                        {
-                            topChart.PlotArea.ChartTypes.Add(subChart);
+                            var subChart = GetChart(element, null, null, null, null, null, topChart, parent);
+                            if (subChart != null)
+                            {
+                                topChart.PlotArea.ChartTypes.Add(subChart);
+                            }
                         }
                     }
                 }

--- a/src/EPPlus/Drawing/Chart/ExcelChart.cs
+++ b/src/EPPlus/Drawing/Chart/ExcelChart.cs
@@ -748,6 +748,7 @@ namespace OfficeOpenXml.Drawing.Chart
 
                 var part = drawings.Part.Package.GetPart(uriChart);
                 var chartXml = new XmlDocument();
+                chartXml.PreserveWhitespace = true;
                 LoadXmlSafe(chartXml, part.GetStream());
 
                 return CreateChartFromXml(drawings, node, uriChart, part, chartXml, parent);

--- a/src/EPPlus/Drawing/Chart/ExcelChartStandard.cs
+++ b/src/EPPlus/Drawing/Chart/ExcelChartStandard.cs
@@ -238,7 +238,7 @@ namespace OfficeOpenXml.Drawing.Chart
             List<ExcelChartAxis> l = new List<ExcelChartAxis>();
             foreach (XmlNode node in _chartNode.ParentNode.ChildNodes)
             {
-                if (node.LocalName.EndsWith("Ax"))
+                if (node.NodeType == XmlNodeType.Element && node.LocalName.EndsWith("Ax"))
                 {
                     ExcelChartAxis ax = new ExcelChartAxisStandard(this, NameSpaceManager, node, "c");
                     l.Add(ax);

--- a/src/EPPlus/Drawing/Chart/ExcelChartStandardSerie.cs
+++ b/src/EPPlus/Drawing/Chart/ExcelChartStandardSerie.cs
@@ -304,9 +304,9 @@ namespace OfficeOpenXml.Drawing.Chart
             //numberLiterals = new double[childNodes.Count];
             List<double> numLits = new();
 
-            foreach (XmlElement node in childNodes)
+            foreach (XmlNode node in childNodes)
             {
-                if(node.LocalName == "pt")
+                if(node.NodeType==XmlNodeType.Element && node.LocalName == "pt")
                 {
                     if(double.TryParse(node.InnerText, NumberStyles.Any, CultureInfo.InvariantCulture, out double numLit) == false)
                     {
@@ -327,9 +327,9 @@ namespace OfficeOpenXml.Drawing.Chart
             {
                 var childNodes = parentNode.ChildNodes;
 
-                foreach (XmlElement node in childNodes)
+                foreach (XmlNode node in childNodes)
                 {
-                    if (node.LocalName == "pt")
+                    if (node.NodeType == XmlNodeType.Element && node.LocalName == "pt")
                     {
                         strLits.Add(node.InnerText);
                     }

--- a/src/EPPlusTest/Issues/ChartIssues.cs
+++ b/src/EPPlusTest/Issues/ChartIssues.cs
@@ -387,6 +387,18 @@ namespace EPPlusTest.Issues
 			}
 		}
 
+		[TestMethod]
+		public void s968()
+		{
+			// the problem in this case was that the NEWLINE separator 
+			// for datalabels was ignored when the chartxml was read.
+			// we fixed this by adding xmlDocument.PreserveWhitespace=true
+			// when reading charts.
+			using var package = OpenTemplatePackage("ChartLabel.xlsx");
+			var workbook = package.Workbook;
+			SaveAndCleanup(package);
+		}
+
         [TestMethod]
         public void CreateStringLiterals()
         {


### PR DESCRIPTION
Set xmlDoc.PreserveWhitespace to true when reading chart xml
 
