### PR TITLE
fixed versions of MSTest.TestAdapter and MSTest.TestFramework

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,8 +18,8 @@
     <PackageVersion Include="FakeItEasy" Version="8.0.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.0.2" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.10.4" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.10.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Before submitting this pull request I have...
- [x] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [x] ensured that the functionality I have added/changed is covered by new unit tests.
- [x] merged the target branch into the PR branch and resolved any merge conflicts
- [x] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).
