### PR TITLE
Fixes several issues in #2210.

### DIFF
--- a/src/EPPlus/FormulaParsing/DependencyChain/RpnFormulaExecution.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/RpnFormulaExecution.cs
@@ -1329,6 +1329,9 @@ namespace OfficeOpenXml.FormulaParsing
                     case TokenType.NameError:
                         s.Push(ErrorExpression.NameError);
                         break;
+                    case TokenType.Div0Error:
+                        s.Push(ErrorExpression.Div0Error);
+                        break;
                     case TokenType.Null:
                         s.Push(ErrorExpression.NullError);
                         break;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Information/IsBlank.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Information/IsBlank.cs
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Information
                 }
                 else
                 {
-                    if (arg.Value != null && (arg.Value.ToString() != string.Empty))
+                    if (arg.Value != null)
                     {
                         result = false;
                         break;

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Mod.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Mod.cs
@@ -10,12 +10,10 @@
  *************************************************************************************************
   01/27/2020         EPPlus Software AB       Initial release EPPlus 5
  *************************************************************************************************/
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Metadata;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
+using System;
+using System.Collections.Generic;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
 {
@@ -31,13 +29,17 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         public override int ArgumentMinLength => 2;
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var n1 = ArgToDecimal(arguments, 0, out ExcelErrorValue e1);
+            var number = ArgToDecimal(arguments, 0, out ExcelErrorValue e1);
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
 
-            var n2 = ArgToDecimal(arguments, 1, out ExcelErrorValue e2);
+            var divisor = ArgToDecimal(arguments, 1, out ExcelErrorValue e2);
             if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
+            if (divisor == 0) return CompileResult.GetErrorResult(eErrorType.Div0);
+            
+            double q = Math.Floor(number / divisor);
+            var result = number - divisor * q;
 
-            return new CompileResult(n1 % n2, DataType.Decimal);
+            return new CompileResult(result, DataType.Decimal);
         }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Power.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/Power.cs
@@ -35,6 +35,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             if (e1 != null) return CompileResult.GetErrorResult(e1.Type);
             var power = ArgToDecimal(arguments, 1, out ExcelErrorValue e2);
             if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
+            if(number==0 && power==0)
+            {
+                return CompileResult.GetErrorResult(eErrorType.Num);
+            }
             var result = Math.Pow(number, power);
             return CreateResult(result, DataType.Decimal);
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Indirect.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Indirect.cs
@@ -33,6 +33,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
             var address = ArgToString(arguments, 0);
+            if (string.IsNullOrEmpty(address)) return CompileResult.GetErrorResult(eErrorType.Ref);
             FormulaRangeAddress adr;
             IRangeInfo result;
             var arg = arguments[0];

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Concatenate.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Concatenate.cs
@@ -38,7 +38,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
                 var v = arg.ValueFirst;
                 if (v != null)
                 {
-                    sb.Append(v);
+                    if(v is bool b)
+                    {
+                        sb.Append(b.ToString().ToUpper()); //bools should always be uppercase in Excel.
+                    }
+                    else
+                    {
+                        sb.Append(v);
+                    }
                 }
             }
             return CreateResult(sb.ToString(), DataType.String);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/Text/Rept.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/Text/Rept.cs
@@ -39,6 +39,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
             var str = ArgToString(arguments, 0);
             var n = ArgToInt(arguments, 1, out ExcelErrorValue e2);
             if (e2 != null) return CompileResult.GetErrorResult(e2.Type);
+            if (n < 0) return CompileResult.GetErrorResult(eErrorType.Value);
             var sb = new StringBuilder();
             for (var x = 0; x < n; x++)
             {

--- a/src/EPPlus/FormulaParsing/FormulaExpressions/FormulaExecutor.cs
+++ b/src/EPPlus/FormulaParsing/FormulaExpressions/FormulaExecutor.cs
@@ -555,16 +555,19 @@ namespace OfficeOpenXml.FormulaParsing.FormulaExpressions
                     case TokenType.Comma:
                         break;
                     case TokenType.NAError:
-                        array.Add(ExcelErrorValue.Create(eErrorType.NA));
+                        array.Add(ErrorValues.NAError);
                         break;
                     case TokenType.InvalidReference:
-                        array.Add(ExcelErrorValue.Create(eErrorType.Ref));
+                        array.Add(ErrorValues.RefError);
                         break;
                     case TokenType.NumericError:
-                        array.Add(ExcelErrorValue.Create(eErrorType.Num));
+                        array.Add(ErrorValues.NumError);
                         break;
                     case TokenType.ValueDataTypeError:
-                        array.Add(ExcelErrorValue.Create(eErrorType.Value));
+                        array.Add(ErrorValues.ValueError);
+                        break;
+                    case TokenType.Div0Error:                        
+                        array.Add(ErrorValues.Div0Error);
                         break;
                     default:
                         throw new InvalidFormulaException("Array contains invalid tokens. Cell "+ parsingContext.CurrentCell.WorksheetIx);

--- a/src/EPPlus/FormulaParsing/LexicalAnalysis/SourceCodeTokenizer.cs
+++ b/src/EPPlus/FormulaParsing/LexicalAnalysis/SourceCodeTokenizer.cs
@@ -241,9 +241,15 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
                     }
                     else if (isInString == 0 && _charTokens.ContainsKey(c) && (flags & statFlags.isExponential) == 0)
                     {
+                        var currentString = current.ToString();
+                        if (currentString.Equals("#DIV", StringComparison.OrdinalIgnoreCase) && c=='/')
+                        {
+                            current.Append(c);
+                            ix++;
+                            continue;
+                        }
                         if (c == '!' && current.Length > 0 && current[0] == '#' && current[current.Length - 1] != '\'')
                         {
-                            var currentString = current.ToString();
                             if (currentString.Equals("#NUM", StringComparison.OrdinalIgnoreCase))
                             {
                                 l.Add(new Token("#NUM!", TokenType.NumericError));
@@ -259,6 +265,10 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
                             else if(currentString.Equals("#REF", StringComparison.OrdinalIgnoreCase))
                             {
                                 l.Add(new Token("#REF!", TokenType.InvalidReference));
+                            }
+                            else if (currentString.Equals("#DIV/0", StringComparison.OrdinalIgnoreCase))
+                            {
+                                l.Add(new Token("#DIV/0!", TokenType.Div0Error));
                             }
                             else
                             {

--- a/src/EPPlus/FormulaParsing/LexicalAnalysis/TokenType.cs
+++ b/src/EPPlus/FormulaParsing/LexicalAnalysis/TokenType.cs
@@ -227,5 +227,9 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
         /// Represent a eta Lambda.
         /// </summary>
         EtaReducedLambda = (ulong)1 << 50,
+        /// <summary>
+        /// Represents a Div/0! error
+        /// </summary>
+        Div0Error = (ulong)1 << 51,
     }
 }

--- a/src/EPPlus/Table/PivotTable/Calculation/PivotTableColumnCalculation.cs
+++ b/src/EPPlus/Table/PivotTable/Calculation/PivotTableColumnCalculation.cs
@@ -105,7 +105,9 @@ namespace OfficeOpenXml.Table.PivotTable
 						return new Token(ev.ToString(), TokenType.NAError);
 					case eErrorType.Num:
 						return new Token(ev.ToString(), TokenType.NumericError);
-					default:
+					case eErrorType.Div0:
+						return new Token(ev.ToString(), TokenType.Div0Error);
+                    default:
 						return new Token(ev.ToString(), TokenType.ValueDataTypeError);
 				}
 			}

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/InformationFunctionsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/InformationFunctionsTests.cs
@@ -60,12 +60,12 @@ namespace EPPlusTest.Excel.Functions
         }
 
         [TestMethod]
-        public void IsBlankShouldReturnTrueIfFirstArgIsEmptyString()
+        public void IsBlankShouldReturnFalseIfFirstArgIsEmptyString()
         {
             var func = new IsBlank();
             var args = FunctionsHelper.CreateArgs(string.Empty);
             var result = func.Execute(args, _context);
-            Assert.IsTrue((bool)result.Result);
+            Assert.IsFalse((bool)result.Result);
         }
 
         [TestMethod]

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -1356,6 +1356,35 @@ namespace EPPlusTest.Issues
             package.Workbook.Calculate();
             Assert.AreEqual("12,35²", package.Workbook.Worksheets[0].Cells["A3"].Value);
         }
+        [TestMethod]
+        public void Issue2210_1()
+        {
+            using var p = new ExcelPackage();
+            var ws = p.Workbook.Worksheets.Add("Sheet1");
+
+            ws.Cells["A1"].Formula = "ISBLANK(\"\")";
+            ws.Cells["A2"].Formula = "ERROR.TYPE(#DIV/0!)";
+            ws.Cells["A3"].Formula = "INDIRECT(\"\")";
+            ws.Cells["A4"].Formula = "CONCATENATE(TRUE, FALSE)";
+            ws.Cells["A5"].Formula = "REPT(\"ab\", -1)";
+            ws.Cells["A6"].Formula = "MOD(5, 0)";
+            ws.Cells["A7"].Formula = "MOD(-5, 3)";
+            ws.Cells["A8"].Formula = "MOD(5, -3)";
+            ws.Cells["A9"].Formula = "POWER(0, 0)";
+            ws.Cells["A10"].Formula = "MOD(3, 2.1)";
+            ws.Calculate();
+
+            Assert.IsFalse((bool)ws.Cells["A1"].Value);
+            Assert.AreEqual(2, ws.Cells["A2"].Value);
+            Assert.AreEqual(ErrorValues.RefError, ws.Cells["A3"].Value);
+            Assert.AreEqual("TRUEFALSE",ws.Cells["A4"].Value);
+            Assert.AreEqual(ErrorValues.ValueError, ws.Cells["A5"].Value);
+            Assert.AreEqual(ErrorValues.Div0Error, ws.Cells["A6"].Value);
+            Assert.AreEqual(1D, ws.Cells["A7"].Value);
+            Assert.AreEqual(-1D, ws.Cells["A8"].Value);
+            Assert.AreEqual(ErrorValues.NumError, ws.Cells["A9"].Value);
+            Assert.AreEqual(0.9, (double)ws.Cells["A10"].Value, 0.000000001);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes for first nine issues in #2210.
* #DIV/0! was not handled as as an Error in the tokenizer when used directly as an argument.
* ISBLANK("") now returns false.
* The MOD function did not work as expected when used with negative numbers or divisors.
* POWER now returns a #NUM! error if both arguments were 0, as Excel does.
* INDIRECT now returns a #REF! error if an empty argument is supplied.
* CONCATENATE now returns boolean values in upper-case.
* REPT now returns a #VALUE! error if the number_times argument is negative.

