### PR TITLE
#2235 - Invalid UTF‑16 surrogate sequences in comment text are now sanitized before XML generation to prevent XmlException

### DIFF
--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -58,6 +58,7 @@ using OfficeOpenXml.Utils.String;
 using OfficeOpenXml.Core.RangeQuadTree;
 using OfficeOpenXml.Data.QueryTable;
 using OfficeOpenXml.Data.Connection.IOHandlers;
+using System.Security.Permissions;
 
 namespace OfficeOpenXml
 {
@@ -2636,6 +2637,10 @@ namespace OfficeOpenXml
         {
             foreach (ExcelComment comment in _comments)
             {
+                foreach(var rt in comment.RichText)
+                {
+                    rt.Text = StringUtil.SanitizeUtf16(rt.Text);
+                }
                 var textNode = comment._commentHelper.GetNode("d:text");
                 textNode.InnerXml = comment.RichText.GetXML();
             }

--- a/src/EPPlus/Utils/StringUtil.cs
+++ b/src/EPPlus/Utils/StringUtil.cs
@@ -149,5 +149,41 @@ namespace OfficeOpenXml.Utils
                 }
             }
         }
+
+        internal static string SanitizeUtf16(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return s;
+
+            var sb = new StringBuilder(s.Length);
+
+            for (int i = 0; i < s.Length; i++)
+            {
+                char c = s[i];
+
+                if (char.IsHighSurrogate(c))
+                {
+                    if (i + 1 < s.Length && char.IsLowSurrogate(s[i + 1]))
+                    {
+                        sb.Append(c);
+                        sb.Append(s[i + 1]);
+                        i++;
+                    }
+                    else
+                    {
+                        sb.Append('\uFFFD');
+                    }
+                }
+                else if (char.IsLowSurrogate(c))
+                {
+                    sb.Append('\uFFFD');
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+            }
+
+            return sb.ToString();
+        }
     }
 }

--- a/src/EPPlusTest/Issues/PackageIssues.cs
+++ b/src/EPPlusTest/Issues/PackageIssues.cs
@@ -140,5 +140,18 @@ namespace EPPlusTest.Issues
                 SaveAndCleanup(package);
             }
         }
+
+        [TestMethod]
+        public void i2235()
+        {
+            using var package = OpenTemplatePackage("SurrogatePairs.xlsx");
+            var sheet = package.Workbook.Worksheets[0];
+            sheet.Cells["A8"].Value = "hello \uDC00";
+            sheet.Cells["A9"].Value = "hello 2 \uDFFF\uDFFF";
+            sheet.Cells["A10"].AddComment("testing testing \uDFFF\uDFFF");
+            sheet.Cells["A11"].Value = "End test";
+            sheet.Calculate(o => o.EnableUnicodeAwareStringOperations = true);
+            SaveAndCleanup(package);
+        }
     }
 }


### PR DESCRIPTION
See #2235 
