### PR TITLE
Added fix for #2240

### DIFF
--- a/src/EPPlus/Style/HeaderFooterTextFormat/ExcelHeaderFooterTextCollection.cs
+++ b/src/EPPlus/Style/HeaderFooterTextFormat/ExcelHeaderFooterTextCollection.cs
@@ -645,8 +645,9 @@ namespace OfficeOpenXml.Style.HeaderFooterTextFormat
                         if (hfText[i] == '+' || hfText[i] == '-')
                         {
                             temp.PageNumberSuffix += hfText[i];
+                            i++;
                         }
-                        i++;
+
                         while (char.IsDigit( hfText[i]))
                         {
                             temp.PageNumberSuffix += hfText[i];

--- a/src/EPPlusTest/Issues/WorksheetIssues.cs
+++ b/src/EPPlusTest/Issues/WorksheetIssues.cs
@@ -1049,5 +1049,15 @@ namespace EPPlusTest.Issues
 
             Assert.AreEqual("B2", dbv.Address);
         }
+        [TestMethod]
+        public void i2240()
+        {
+            using (var package = OpenTemplatePackage("i2240.xlsx"))
+            {
+                var theText = package.Workbook.Worksheets.First().HeaderFooter.OddFooter.LeftAlignedText;
+
+                SaveAndCleanup(package);
+            }
+        }
     }
 }


### PR DESCRIPTION
We entered suffix calculation for footers/headers when reading even when non-relevant. Causing certain characters (e.g. whitespaces) to be skipped.

This caused whitespaces to dissappear when left-aligning oddheaders