### PR TITLE
Bug/issue2234

### DIFF
--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -85,8 +85,8 @@ namespace OfficeOpenXml
         {
             internal uint cm;
             internal uint vm;
-            internal bool aca;
-            internal bool ca;
+            //internal bool aca; //Removed, is set as a flag instead in the _flags store.
+            //internal bool ca;  //Removed, is set as a flag instead in the _flags store.
         }
         /// <summary>
         /// Removes all formulas within the entire worksheet, but keeps the calculated values.

--- a/src/EPPlus/FormulaParsing/CalculateExtensions.cs
+++ b/src/EPPlus/FormulaParsing/CalculateExtensions.cs
@@ -81,6 +81,34 @@ namespace OfficeOpenXml
                 workbook.FormulaParser.Logger.Log(msg);
             }
         }
+        internal static RpnOptimizedDependencyChain CalculateWithDC(this ExcelWorkbook workbook, Action<ExcelCalculationOption> configHandler)
+        {
+            var option = new ExcelCalculationOption();
+            configHandler.Invoke(option);
+            return CalculateWithDC(workbook, option);
+        }
+        internal static RpnOptimizedDependencyChain CalculateWithDC(this ExcelWorkbook workbook, ExcelCalculationOption options)
+        {
+            Init(workbook);
+
+            var filterInfo = new FilterInfo(workbook);
+            workbook.FormulaParser.InitNewCalc(filterInfo);
+
+            if (workbook.FormulaParser.Logger != null)
+            {
+                var msg = string.Format("Starting formula calculation.");
+                workbook.FormulaParser.Logger.Log(msg);
+            }
+
+            //CalcChain(workbook, workbook.FormulaParser, dc, options);
+            var dc = RpnFormulaExecution.Execute(workbook, options);
+            if (workbook.FormulaParser.Logger != null)
+            {
+                var msg = string.Format("Calculation done...number of cells parsed: {0}", dc.processedCells.Count);
+                workbook.FormulaParser.Logger.Log(msg);
+            }
+            return dc;
+        }
         /// <summary>
         /// Calculate all formulas in the current worksheet
         /// </summary>

--- a/src/EPPlus/FormulaParsing/DependencyChain/ArrayFormulaOutput.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/ArrayFormulaOutput.cs
@@ -240,8 +240,10 @@ namespace OfficeOpenXml.FormulaParsing
 
         private static void ClearDynamicFormulaIndex(ExcelWorksheet ws, int fromRow, int fromCol, int toRow, int toCol)
         {
-            ws._formulas.Clear(fromRow, fromCol, toRow, toCol);
-            ws._flags.Clear(fromRow, fromCol, toRow, toCol);
+            var rows = toRow - fromRow + 1;
+            var cols = toCol - fromCol + 1;
+            ws._formulas.Clear(fromRow, fromCol, rows, cols);
+            ws._flags.Clear(fromRow, fromCol, rows, cols);
 
             for (int col = fromCol; col <= toCol; col++)
             {

--- a/src/EPPlus/FormulaParsing/DependencyChain/ArrayFormulaOutput.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/ArrayFormulaOutput.cs
@@ -151,6 +151,7 @@ namespace OfficeOpenXml.FormulaParsing
                 CleanupSharedFormulaValues(f, ws, sf, endRow, endCol);
                 sf.EndRow = endRow;
                 sf.EndCol = endCol;
+                
             }
             FillArrayFromRangeInfo(f, array, rd, depChain);
             return dirtyRange;

--- a/src/EPPlus/FormulaParsing/DependencyChain/RpnFormula.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/RpnFormula.cs
@@ -261,12 +261,28 @@ namespace OfficeOpenXml.FormulaParsing
             }
         }
 
-        internal void ClearCache()
+        internal void ClearCache(RpnOptimizedDependencyChain depChain)
         {
             foreach (var e in _expressions.Values)
             {
                 if (e.ExpressionType == ExpressionType.CellAddress)
+                {
                     e._cachedCompileResult = null;
+                }
+                if(e.ExpressionType == ExpressionType.Function)
+                {
+                    var funcExp= e as FunctionExpression;
+                    funcExp.Status = ExpressionStatus.NoSet;
+                    var key = funcExp.GetExpressionKey(this);
+                    if (key != null)
+                    {
+                        var cache = depChain.GetCache(_ws);
+                        if (cache.ContainsKey(key))
+                        {
+                            cache.Remove(key);
+                        }
+                    }
+                }
             }
         }
 

--- a/src/EPPlus/FormulaParsing/DependencyChain/RpnFormulaExecution.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/RpnFormulaExecution.cs
@@ -111,7 +111,7 @@ namespace OfficeOpenXml.FormulaParsing
         {
             var formula = new RpnFormula(null, 0, 0);
             formula.SetFormula(tokens, depChain);
-            return AddChainForFormula(depChain, formula, options, false).Result;
+            return CalculateFormulaChain(depChain, formula, options, false).Result;
         }
 
         private static void ExecuteChain(RpnOptimizedDependencyChain depChain, ExcelRangeBase range, ExcelCalculationOption options, bool writeToCell)
@@ -129,7 +129,7 @@ namespace OfficeOpenXml.FormulaParsing
                     {
                         if (GetFormula(depChain, ws, fs.Row, fs.Column, fs.Value, ref f))
                         {
-                            AddChainForFormula(depChain, f, options, writeToCell);
+                            CalculateFormulaChain(depChain, f, options, writeToCell);
                         }
                     }
                     catch (CircularReferenceException)
@@ -263,7 +263,7 @@ namespace OfficeOpenXml.FormulaParsing
                 if (string.IsNullOrEmpty(name.NameFormula) == false)
                 {
                     var f = GetNameFormula(depChain, ws, depChain._parsingContext.ExcelDataProvider.GetName(name), 1, 1);
-                    AddChainForFormula(depChain, f, options, writeToCell);
+                    CalculateFormulaChain(depChain, f, options, writeToCell);
                 }
                 else if (ws != null && name.IsValidRowCol())
                 {
@@ -287,7 +287,7 @@ namespace OfficeOpenXml.FormulaParsing
                 var f = new RpnFormula(ws, cell.Row, cell.Column);
                 depChain._parsingContext.CurrentCell = new FormulaCellAddress(ws?.Index??-1, -1, 0);
                 f.SetFormula(formula, depChain);
-                return AddChainForFormula(depChain, f, options, writeToCell).Result;
+                return CalculateFormulaChain(depChain, f, options, writeToCell).Result;
             }
             catch (CircularReferenceException)
             {
@@ -307,7 +307,7 @@ namespace OfficeOpenXml.FormulaParsing
                 var f = new RpnFormula(ws, 0, 0);
                 f.SetFormula(formula, depChain);
                 f._row = -1;
-                return AddChainForFormula(depChain, f, options, writeToCell).Result;
+                return CalculateFormulaChain(depChain, f, options, writeToCell).Result;
             }
             catch (CircularReferenceException)
             {
@@ -401,36 +401,29 @@ namespace OfficeOpenXml.FormulaParsing
 
         internal static CompileResult ExecutePartialFormula(RpnOptimizedDependencyChain depChain, RpnFormula f, ExcelCalculationOption options, bool writeToCell)
         {
-            return AddChainForFormula(depChain, f, options, writeToCell);
+            return CalculateFormulaChain(depChain, f, options, writeToCell);
         }
 
-        internal static CompileResult ExecutePartialFormula(RpnOptimizedDependencyChain depChain, RpnFormula f, ExcelCalculationOption options, bool writeToCell, VariableStorageScope scope)
-        {
-            return AddChainForFormula(depChain, f, options, writeToCell, scope);
-        }
-
-        private static CompileResult AddChainForFormula(RpnOptimizedDependencyChain depChain, RpnFormula f, ExcelCalculationOption options, bool writeToCell, VariableStorageScope scope = null)
+        private static CompileResult CalculateFormulaChain(RpnOptimizedDependencyChain depChain, RpnFormula f, ExcelCalculationOption options, bool writeToCell, int depChainPos=-1)
         {
             FormulaRangeAddress[] addresses;
-            //FormulaRangeAddress address = null;
             RangeHashset rd = AddOrGetRDFromWsIx(depChain, f._ws == null ? -1 : f._ws.IndexInList);
             object v = null;
             bool hasLogger = depChain._parsingContext.Parser.Logger != null;
-            rd?.Merge(f._row, f._column);
-            var followChain = options.FollowDependencyChain;
-            depChain.StartOfChain();
+            var followChain = options.FollowDependencyChain && depChainPos==-1;
+            if (depChainPos == -1)
+            {
+                rd?.Merge(f._row, f._column);
+                depChain.StartOfChain();
+            }
         ExecuteFormula:
             try
             {
                 SetCurrentCell(depChain, f);
                 var ws = f._ws;
-                if((depChain._parsingContext.CurrentCell.Column==15 || depChain._parsingContext.CurrentCell.Column == 16) && depChain._parsingContext.CurrentCell.Row==2)
-                {
-                    ws = ws;
-                }
                 if (f._tokenIndex < f._tokens.Count)
                 {
-                    addresses = ExecuteNextToken(depChain, f, followChain);
+                    addresses = ExecuteNextToken(depChain, f, followChain || depChain._formulaStack.Count>0);
                     if (f._tokenIndex < f._tokens.Count)
                     {
                         if (addresses == null && f._expressions.ContainsKey(f._tokenIndex) && f._expressions[f._tokenIndex].ExpressionType == ExpressionType.NameValue)
@@ -489,7 +482,7 @@ namespace OfficeOpenXml.FormulaParsing
 
                 if (cr != null && (writeToCell || depChain._formulaStack.Count > 0))  // If calculating single cell via the FormulaParser.Parse method we should not write to the cells
                 {
-                    SetValueToWorkbook(depChain, f, rd, cr, true);
+                    SetValueToWorkbook(depChain, f, rd, cr, options, ref depChainPos);
                 }
 
                 if (hasLogger)
@@ -694,7 +687,7 @@ namespace OfficeOpenXml.FormulaParsing
             }
             f._ws._metadataStore.Clear(f._row, f._column, 1, 1);
         }
-        private static void SetValueToWorkbook(RpnOptimizedDependencyChain depChain, RpnFormula f, RangeHashset rd, CompileResult cr, bool addToDepChain)
+        private static void SetValueToWorkbook(RpnOptimizedDependencyChain depChain, RpnFormula f, RangeHashset rd, CompileResult cr, ExcelCalculationOption options, ref int insertDepChainPos)
         {
             if(cr.DataType == DataType.LambdaCalculation)
             {
@@ -731,7 +724,7 @@ namespace OfficeOpenXml.FormulaParsing
                                     var dirtyRange = ArrayFormulaOutput.FillDynamicArrayFromRangeInfo(f, ri, rd, depChain);
                                     if (dirtyRange != null && dirtyRange.Length > 0)
                                     {
-                                        RecalculateDirtyCells(dirtyRange, depChain, rd);
+                                        RecalculateDirtyCells(dirtyRange, depChain, rd, options);
                                     }
                                 }
                                 else //Set implicit intersection
@@ -749,7 +742,7 @@ namespace OfficeOpenXml.FormulaParsing
                             var dirtyRange = ArrayFormulaOutput.FillDynamicArraySingleValue(f, cr, rd, depChain);
                             if (dirtyRange != null && dirtyRange.Length > 0)
                             {
-                                RecalculateDirtyCells(dirtyRange, depChain, rd);
+                                RecalculateDirtyCells(dirtyRange, depChain, rd, options);
                             }
                             depChain.HasAnyArrayFormula = true;
                         }
@@ -772,8 +765,21 @@ namespace OfficeOpenXml.FormulaParsing
                         {
                             if (f._arrayIndex != -1)
                             {
-                                var sf = f._ws._sharedFormulas[f._arrayIndex];
-                                f._ws.SetValueInner(sf.StartRow, sf.StartCol, sf.EndRow, sf.EndCol, cr.ResultValue ?? 0D);
+                                if((f._flags & FormulaFlags.IsDynamic)== FormulaFlags.IsDynamic)
+                                {
+                                    var dirtyRange = ArrayFormulaOutput.FillDynamicArraySingleValue(f, cr, rd, depChain);
+                                    if (dirtyRange != null && dirtyRange.Length > 0)
+                                    {
+                                        RecalculateDirtyCells(dirtyRange, depChain, rd, options);
+                                    }
+                                    depChain.HasAnyArrayFormula = true;
+
+                                }
+                                else
+                                {
+                                    var sf = f._ws._sharedFormulas[f._arrayIndex];
+                                    f._ws.SetValueInner(sf.StartRow, sf.StartCol, sf.EndRow, sf.EndCol, cr.ResultValue ?? 0D);
+                                }
                             }
                             else
                             {
@@ -788,13 +794,18 @@ namespace OfficeOpenXml.FormulaParsing
                         }
                     }
                 }
-                if (addToDepChain)
+
+                if (insertDepChainPos<0)
                 {
                     depChain.DependencyChain.Add(f.CellId);
                 }
+                else if(depChain._formulaStack.Count > 0)
+                {
+                    depChain.DependencyChain.Insert(++insertDepChainPos, f.CellId);
+                }
             }
         }
-        private static void RecalculateDirtyCells(SimpleAddress[] dirtyRange, RpnOptimizedDependencyChain depChain, RangeHashset rd)
+        private static void RecalculateDirtyCells(SimpleAddress[] dirtyRange, RpnOptimizedDependencyChain depChain, RangeHashset rd, ExcelCalculationOption options)
         {
             if(depChain._isInRecalculateDirtyCells) return; //EPPlus will not recalculate dirty cells while recalculating other dirty cells to avoid stack overflow.
             var dirtyCells = dirtyRange.ToList();
@@ -839,20 +850,18 @@ namespace OfficeOpenXml.FormulaParsing
                     for (int i = fromIx; i < dcCount; i++)
                     {
                         ExcelCellBase.SplitCellId(depChain.DependencyChain[i], out int sheetId, out int row, out int col);
-                        if(row==5 && col==16)
-                        {
-                            row = row;
-                        }
                         RpnFormula f = null;
                         var ws = depChain._parsingContext.Package.Workbook.GetWorksheetByIndexInList(sheetId);
                         var v = ws._formulas.GetValue(row, col);
 
                         if (GetFormula(depChain, ws, row, col, v, ref f))
                         {
-                            ReCalculateFormula(f, depChain, rd);
-                            if (dcCount != depChain.DependencyChain.Count)
+                            f.ClearCache(depChain);
+                            CalculateFormulaChain(depChain, f, options, true, i);
+                            if (depChain.DependencyChain.Count > dcCount)
                             {
-                                continue;
+                                i += depChain.DependencyChain.Count - dcCount;
+                                dcCount = depChain.DependencyChain.Count;
                             }
                         }
                     }
@@ -860,14 +869,6 @@ namespace OfficeOpenXml.FormulaParsing
                 }
 
             }
-        }
-        private static void ReCalculateFormula(RpnFormula f, RpnOptimizedDependencyChain depChain, RangeHashset rd)
-        {
-            f._tokenIndex = 0;
-            f.ClearCache(depChain);
-            ExecuteNextToken(depChain, f, false);
-            var e = f._expressionStack.Pop();
-            SetValueToWorkbook(depChain, f, rd, e.Compile(), false);
         }
         private static void MergeToRd(RangeHashset rd, int fromRow, int fromCol, int rangePos, CellStoreEnumerator<object> fe, bool atEnd)
         {
@@ -1251,7 +1252,7 @@ namespace OfficeOpenXml.FormulaParsing
                                     f.IgnoreCaching = true;
                                 }
 
-                                if (PreExecFunc(depChain, f, funcExp) && returnAddresses)
+                                if (PreExecFunc(depChain, f, funcExp))
                                 {
                                     f._currentFunction = funcExp;
                                     f._tokenIndex--; //We should stay on this token when we continue on this formula.
@@ -1268,10 +1269,7 @@ namespace OfficeOpenXml.FormulaParsing
                                     f._tokenIndex--; //We should stay on this token when we continue on this formula.
                                     var a = funcExp._dependencyAddresses.ToArray();
                                     funcExp._dependencyAddresses.Clear();
-                                    if (returnAddresses)
-                                    {
-                                        return a;
-                                    }
+                                    return a;
                                 }
                                 f._currentFunction = null;
                             }
@@ -1292,7 +1290,7 @@ namespace OfficeOpenXml.FormulaParsing
                                 f.LambdaSettings.LambdaStackNumbers.Push(s.Count);
                                 f.LambdaSettings.NumberOfLambdaVariables.Push(clc.NumberOfVariables);
                             }
-                            if (r.Address != null && returnAddresses)
+                            if (r.Address != null)
                             {
                                 if ((f._funcStack.Count == 0 || ShouldIgnoreAddress(f._funcStack.Peek()) == false) && r.Address != null)
                                 {

--- a/src/EPPlus/FormulaParsing/DependencyChain/RpnFormulaExecution.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/RpnFormulaExecution.cs
@@ -424,6 +424,10 @@ namespace OfficeOpenXml.FormulaParsing
             {
                 SetCurrentCell(depChain, f);
                 var ws = f._ws;
+                if((depChain._parsingContext.CurrentCell.Column==15 || depChain._parsingContext.CurrentCell.Column == 16) && depChain._parsingContext.CurrentCell.Row==2)
+                {
+                    ws = ws;
+                }
                 if (f._tokenIndex < f._tokens.Count)
                 {
                     addresses = ExecuteNextToken(depChain, f, followChain);
@@ -485,7 +489,7 @@ namespace OfficeOpenXml.FormulaParsing
 
                 if (cr != null && (writeToCell || depChain._formulaStack.Count > 0))  // If calculating single cell via the FormulaParser.Parse method we should not write to the cells
                 {
-                    SetValueToWorkbook(depChain, f, rd, cr);
+                    SetValueToWorkbook(depChain, f, rd, cr, true);
                 }
 
                 if (hasLogger)
@@ -690,7 +694,7 @@ namespace OfficeOpenXml.FormulaParsing
             }
             f._ws._metadataStore.Clear(f._row, f._column, 1, 1);
         }
-        private static void SetValueToWorkbook(RpnOptimizedDependencyChain depChain, RpnFormula f, RangeHashset rd, CompileResult cr)
+        private static void SetValueToWorkbook(RpnOptimizedDependencyChain depChain, RpnFormula f, RangeHashset rd, CompileResult cr, bool addToDepChain)
         {
             if(cr.DataType == DataType.LambdaCalculation)
             {
@@ -727,7 +731,6 @@ namespace OfficeOpenXml.FormulaParsing
                                     var dirtyRange = ArrayFormulaOutput.FillDynamicArrayFromRangeInfo(f, ri, rd, depChain);
                                     if (dirtyRange != null && dirtyRange.Length > 0)
                                     {
-
                                         RecalculateDirtyCells(dirtyRange, depChain, rd);
                                     }
                                 }
@@ -785,18 +788,21 @@ namespace OfficeOpenXml.FormulaParsing
                         }
                     }
                 }
-                depChain.DependencyChain.Add(f.CellId);
+                if (addToDepChain)
+                {
+                    depChain.DependencyChain.Add(f.CellId);
+                }
             }
         }
-
         private static void RecalculateDirtyCells(SimpleAddress[] dirtyRange, RpnOptimizedDependencyChain depChain, RangeHashset rd)
         {
+            if(depChain._isInRecalculateDirtyCells) return; //EPPlus will not recalculate dirty cells while recalculating other dirty cells to avoid stack overflow.
             var dirtyCells = dirtyRange.ToList();
             if (depChain.FormulaRangeReferences.ContainsKey(depChain._parsingContext.CurrentWorksheet.IndexInList))
             {
                 var qt = depChain.FormulaRangeReferences[depChain._parsingContext.CurrentWorksheet.IndexInList];
                 int fromIx = int.MaxValue;
-                int toIx = int.MinValue;
+                //int toIx = int.MinValue;
                 foreach (var a in dirtyRange)
                 {
                     var ir = qt.GetIntersectingRangeItems(new QuadRange(a.FromRow, a.FromCol, a.ToRow, a.ToCol));
@@ -804,34 +810,39 @@ namespace OfficeOpenXml.FormulaParsing
                     {
                         foreach (var r in ir.Select(x => x.Value).Distinct())
                         {
+                            ExcelAddressBase.SplitCellId(r, out int sheet, out int row, out int col);
+
                             var ix = depChain.DependencyChain.IndexOf(r);
                             if (ix < 0) continue;
                             if (ix < fromIx)
                             {
                                 fromIx = ix;
                             }
-                            var ixEnd = depChain._startOfChain.BinarySearch(ix + 1);
 
-                            if (ixEnd < 0)
+                            if(fromIx==0)
                             {
-                                ixEnd = ~ixEnd;
-                            }
-
-                            if (ixEnd - 1 > toIx)
-                            {
-                                toIx = ixEnd - 1;
+                                break;
                             }
                         }
+                    }
+                    if (fromIx == 0)
+                    {
+                        break;
                     }
                 }
 
                 if (fromIx != int.MaxValue)
                 {
-
-                    for (int i = fromIx; i <= toIx; i++)
+                    depChain._isInRecalculateDirtyCells = true;
+                    var dcCount = depChain.DependencyChain.Count;
+                    var cc = depChain._parsingContext.CurrentCell;
+                    for (int i = fromIx; i < dcCount; i++)
                     {
                         ExcelCellBase.SplitCellId(depChain.DependencyChain[i], out int sheetId, out int row, out int col);
-
+                        if(row==5 && col==16)
+                        {
+                            row = row;
+                        }
                         RpnFormula f = null;
                         var ws = depChain._parsingContext.Package.Workbook.GetWorksheetByIndexInList(sheetId);
                         var v = ws._formulas.GetValue(row, col);
@@ -839,8 +850,13 @@ namespace OfficeOpenXml.FormulaParsing
                         if (GetFormula(depChain, ws, row, col, v, ref f))
                         {
                             ReCalculateFormula(f, depChain, rd);
+                            if (dcCount != depChain.DependencyChain.Count)
+                            {
+                                continue;
+                            }
                         }
                     }
+                    depChain._isInRecalculateDirtyCells = false;
                 }
 
             }
@@ -848,10 +864,10 @@ namespace OfficeOpenXml.FormulaParsing
         private static void ReCalculateFormula(RpnFormula f, RpnOptimizedDependencyChain depChain, RangeHashset rd)
         {
             f._tokenIndex = 0;
-            f.ClearCache();
+            f.ClearCache(depChain);
             ExecuteNextToken(depChain, f, false);
             var e = f._expressionStack.Pop();
-            SetValueToWorkbook(depChain, f, rd, e.Compile());
+            SetValueToWorkbook(depChain, f, rd, e.Compile(), false);
         }
         private static void MergeToRd(RangeHashset rd, int fromRow, int fromCol, int rangePos, CellStoreEnumerator<object> fe, bool atEnd)
         {
@@ -1161,7 +1177,7 @@ namespace OfficeOpenXml.FormulaParsing
                             var nameAddress = ne.GetAddress();
                             if (nameAddress == null)
                             {
-                                if (string.IsNullOrEmpty(ne._name?.Formula) == false)
+                                if (returnAddresses && string.IsNullOrEmpty(ne._name?.Formula) == false)
                                 {
                                     return null;
                                 }
@@ -1235,7 +1251,7 @@ namespace OfficeOpenXml.FormulaParsing
                                     f.IgnoreCaching = true;
                                 }
 
-                                if (PreExecFunc(depChain, f, funcExp))
+                                if (PreExecFunc(depChain, f, funcExp) && returnAddresses)
                                 {
                                     f._currentFunction = funcExp;
                                     f._tokenIndex--; //We should stay on this token when we continue on this formula.
@@ -1252,7 +1268,10 @@ namespace OfficeOpenXml.FormulaParsing
                                     f._tokenIndex--; //We should stay on this token when we continue on this formula.
                                     var a = funcExp._dependencyAddresses.ToArray();
                                     funcExp._dependencyAddresses.Clear();
-                                    return a;
+                                    if (returnAddresses)
+                                    {
+                                        return a;
+                                    }
                                 }
                                 f._currentFunction = null;
                             }
@@ -1303,7 +1322,7 @@ namespace OfficeOpenXml.FormulaParsing
                     case TokenType.Operator:
                         ApplyOperator(depChain._parsingContext, t, f);
 
-                        if (s.Count > 0 && s.Peek().Status == ExpressionStatus.IsAddress && (f._funcStack.Count == 0 || ShouldIgnoreAddress(f._funcStack.Peek()) == false))
+                        if (returnAddresses && s.Count > 0 && s.Peek().Status == ExpressionStatus.IsAddress && (f._funcStack.Count == 0 || ShouldIgnoreAddress(f._funcStack.Peek()) == false))
                         {
                             var cr = s.Peek().Compile();
                             if (cr.Address != null)

--- a/src/EPPlus/FormulaParsing/DependencyChain/RpnOptimizedDependencyChain.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/RpnOptimizedDependencyChain.cs
@@ -23,6 +23,8 @@ namespace OfficeOpenXml.FormulaParsing
         internal List<int> _startOfChain = new List<int>();
         internal bool HasDynamicArrayFormula=false;
         internal Dictionary<int, Dictionary<string, CompileResult>> expressionCache = new Dictionary<int, Dictionary<string, CompileResult>>();
+        internal bool _isInRecalculateDirtyCells=false;
+
         internal bool HasAnyArrayFormula { get; set; } = false;
         public RpnOptimizedDependencyChain(ExcelWorkbook wb, ExcelCalculationOption options)
         {

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Indirect.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Indirect.cs
@@ -71,7 +71,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             {
                 return CompileResult.Empty;
             }
-            return new AddressCompileResult(result, DataType.ExcelRange, result.Address);
+            return new DynamicArrayCompileResult(result, DataType.ExcelRange, result.Address, CompileResultType.DynamicArray_AlwaysSetCellAsDynamic);
         }
 
 

--- a/src/EPPlusTest/FormulaParsing/CalculateCompareDirectoryTest.cs
+++ b/src/EPPlusTest/FormulaParsing/CalculateCompareDirectoryTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
 using OfficeOpenXml.Core.CellStore;
+using OfficeOpenXml.FormulaParsing;
 using OfficeOpenXml.Utils.TypeConversion;
 using System;
 using System.Collections;
@@ -120,9 +121,11 @@ namespace EPPlusTest.FormulaParsing
                 
                 p.Workbook.ClearFormulaValues();
                 logWriter.WriteLine($"Calculating {xlFile} starting {DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss")}.  Elapsed {new TimeSpan(sw.ElapsedTicks)}");
+                RpnOptimizedDependencyChain dc=null;
                 try
                 {
-                    p.Workbook.Calculate(x => { x.AllowCircularReferences = true; x.CacheExpressions = true; });
+                    dc=p.Workbook.CalculateWithDC(x => { x.AllowCircularReferences = true; x.CacheExpressions = true; });
+                    
                     //p.Workbook.Worksheets["Monthly Cash Flow"].Cells["F10"].Calculate(x => x.CacheExpressions = false);
                 }
                 catch (Exception ex)
@@ -135,9 +138,9 @@ namespace EPPlusTest.FormulaParsing
                 logWriter.WriteLine($"Differences:");
                 logWriter.WriteLine($"Formula values to compare: {values.Count}");
                 logWriter.WriteLine($"Worksheet\tCell\tValue Excel\tValue EPPlus");
-                foreach (var value in values)
+                foreach (var key in dc.DependencyChain)
                 {
-                    ExcelCellBase.SplitCellId(value.Key, out int wsIndex, out int row, out int col);
+                    ExcelCellBase.SplitCellId(key, out int wsIndex, out int row, out int col);
                     object v;
                     ExcelWorksheet ws;
                     string nameOrAddress;
@@ -165,7 +168,7 @@ namespace EPPlusTest.FormulaParsing
                     //if ((v==null && value.Value!=null) || !(v!=null && v.Equals(value.Value) || ConvertUtil.GetValueDouble(v) == ConvertUtil.GetValueDouble(value.Value)))
                     //{
                     ////Assert.Fail($"Value differs worksheet {ws.Name}\tRow {row}\tColumn  {col}\tDiff");
-                    var diff = ConvertUtil.GetValueDouble(v) - ConvertUtil.GetValueDouble(value.Value);
+                    var diff = ConvertUtil.GetValueDouble(v) - ConvertUtil.GetValueDouble(values[key]);
                     //if(col==0)
                     //{
                     //    logWriter.WriteLine($"{ws?.Name}\t{row}\t{value.Value:0.0000000000}\t{v:0.0000000000}\t{diff}");
@@ -174,7 +177,7 @@ namespace EPPlusTest.FormulaParsing
                     //{
                     //    logWriter.WriteLine($"{ws?.Name}\t{ExcelCellBase.GetAddress(row, col)}\t{value.Value:0.0000000000}\t{v:0.0000000000}\t{diff}");
                     //}
-                    var s1 = (value.Value ?? "").ToString().Replace("\r", "").Replace("\n", "");
+                    var s1 = (values[key] ?? "").ToString().Replace("\r", "").Replace("\n", "");
                     var s2 = (v ?? "").ToString().Replace("\r", "").Replace("\n", "");
                     
                     logWriter.WriteLine($"{ws?.Name}\t{nameOrAddress}\t{s1}\t{s2}\t{diff}");

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -1443,7 +1443,7 @@ namespace EPPlusTest.Issues
         [TestMethod]
         public void s965_3()
         {
-            using var package = OpenTemplatePackage("s965-2-Not Calculated.xlsx");
+            using var package = OpenTemplatePackage("s965-Not Calculated.xlsx");
             //package.Workbook.Calculate();
             var ws = package.Workbook.Worksheets["Calculation"];
             package.Workbook.Calculate(); 
@@ -1467,9 +1467,10 @@ namespace EPPlusTest.Issues
 
             Assert.AreEqual(394547.21, ws2.Cells["D45"].Value);
             Assert.AreEqual(1954159.28, ws2.Cells["D46"].Value);
-            Assert.AreEqual(27535.48, ws2.Cells["D47"].Value); 
-        }
+            Assert.AreEqual(27535.48, ws2.Cells["D47"].Value);
 
+            SaveAndCleanup(package);
+        }
     }
 }
 

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -1440,6 +1440,36 @@ namespace EPPlusTest.Issues
                 package.Workbook.Calculate(new ExcelCalculationOption { AllowCircularReferences = true });
             }
         }
+        [TestMethod]
+        public void s965_3()
+        {
+            using var package = OpenTemplatePackage("s965-2-Not Calculated.xlsx");
+            //package.Workbook.Calculate();
+            var ws = package.Workbook.Worksheets["Calculation"];
+            package.Workbook.Calculate(); 
+            Assert.AreEqual("72201004296", ws.Cells["J2"].Value);
+            Assert.AreEqual("72201024296", ws.Cells["J4"].Value);
+            Assert.IsNull(ws.Cells["J5"].Value);
+
+            Assert.AreEqual("7300030", ws.Cells["M5"].Value);
+            Assert.AreEqual("7300031", ws.Cells["M6"].Value);
+            Assert.AreEqual("7300032", ws.Cells["M7"].Value);
+
+            Assert.AreEqual(394547.21, ws.Cells["P5"].Value);
+            Assert.AreEqual(1954159.28, ws.Cells["P6"].Value);
+            Assert.AreEqual(27535.48, ws.Cells["P7"].Value);
+
+
+            var ws2 = package.Workbook.Worksheets["Aico Data"];
+            Assert.AreEqual("53210040", ws2.Cells["V42"].Value);
+            Assert.AreEqual("53210040", ws2.Cells["V44"].Value);
+            Assert.IsNull(ws2.Cells["W44"].Value);
+
+            Assert.AreEqual(394547.21, ws2.Cells["D45"].Value);
+            Assert.AreEqual(1954159.28, ws2.Cells["D46"].Value);
+            Assert.AreEqual(27535.48, ws2.Cells["D47"].Value); 
+        }
+
     }
 }
 


### PR DESCRIPTION
Fixes serveral issues when having expanding(spilling) and contracting dynamic array formulas. 
* EPPlus did not take changning dependies into account when recalculating dirty cells from dynamic array formulas.
* Clearing of dynamic formulas that reduces in size did not work correctly.
* Cells containing formulas with the INDIRECT function is now always set as dynamic.