### PR TITLE
Fix/BoldItalics in OpenTypeFontCache caches incorrectly

### DIFF
--- a/src/EPPlus.Export.ImageRenderer/RenderItems/Shared/ParagraphContainer.cs
+++ b/src/EPPlus.Export.ImageRenderer/RenderItems/Shared/ParagraphContainer.cs
@@ -107,29 +107,18 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.Shared
             }
         }
 
-
-        /// <summary>
-        /// Each specific container must specify textrun type within this
-        /// </summary>
-        /// <param name="origTxtRun"></param>
-        /// <param name="runDisplayString"></param>
-        internal protected abstract void AddTextRun(ExcelParagraphTextRunBase origTxtRun, string runDisplayString);
-
         /// <summary>
         /// DisplayString is the text altered for display with respect to bounds etc.
         /// Containing line breaks appropriate for the given container
         /// </summary>
         /// <param name="origTxtRun"></param>
-        /// <param name="runDisplayString"></param>
-        internal protected void AddTextRun<T>(ExcelParagraphTextRunBase origTxtRun, string runDisplayString) where T : TextRunItem
+        /// <param name="displayText"></param>
+        internal protected void AddTextRun(ExcelParagraphTextRunBase origTxtRun, string displayText)
         {
             var maxWidth = Bounds.Width;
 
-            //Specify type
-            var textRunType = typeof(T);
-
             //Create object of type
-            var targetTxtRun = (T)Activator.CreateInstance(textRunType, origTxtRun, Bounds, runDisplayString);
+            var targetTxtRun = CreateTextRun(origTxtRun, Bounds, displayText);
 
             if (_textRunItems.Count == 0 && _isFirstParagraph == true)
             {
@@ -251,11 +240,6 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.Shared
             return TextUtils.RoundToWhole(x);
         }
 
-        //public override void Render(StringBuilder sb)
-        //{
-        //    throw new NotImplementedException();
-        //}
-
         internal override void GetBounds(out double il, out double it, out double ir, out double ib)
         {
             il = Bounds.Left + _leftMargin;
@@ -263,5 +247,14 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.Shared
             ir = Bounds.Right - _rightMargin;
             ib = Bounds.Bottom;
         }
+
+        /// <summary>
+        /// Type of textrun defined by child type
+        /// </summary>
+        /// <param name="run"></param>
+        /// <param name="parent"></param>
+        /// <param name="DisplayString"></param>
+        /// <returns></returns>
+        internal abstract TextRunItem CreateTextRun(ExcelParagraphTextRunBase run, BoundingBox parent, string displayText);
     }
 }

--- a/src/EPPlus.Export.ImageRenderer/RenderItems/Shared/ParagraphContainer.cs
+++ b/src/EPPlus.Export.ImageRenderer/RenderItems/Shared/ParagraphContainer.cs
@@ -119,16 +119,14 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.Shared
 
             //Create object of type
             var targetTxtRun = CreateTextRun(origTxtRun, Bounds, displayText);
+            targetTxtRun.LineSpacingPerNewLine = ParagraphLineSpacing;
 
             if (_textRunItems.Count == 0 && _isFirstParagraph == true)
             {
                 targetTxtRun.BaseLineSpacing = _lineSpacingAscendantOnly;
-                targetTxtRun.LineSpacingPerNewLine = ParagraphLineSpacing;
             }
             else
             {
-                targetTxtRun.LineSpacingPerNewLine = ParagraphLineSpacing;
-
                 //If there are multiple sizes/multiple fonts with multiple sizes
                 if (_lsMultiplier.HasValue)
                 {
@@ -182,7 +180,7 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.Shared
             for (int i = 0; i < runs.Count(); i++)
             {
                 var txtRun = runs[i];
-                var runFont = txtRun.GetMeasureFont();
+                var runFont = txtRun.GetMeasurementFont();
 
                 runContents.Add(txtRun.Text);
                 fonts.Add(runFont);

--- a/src/EPPlus.Export.ImageRenderer/RenderItems/Shared/ShapeItem.cs
+++ b/src/EPPlus.Export.ImageRenderer/RenderItems/Shared/ShapeItem.cs
@@ -21,7 +21,7 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.Shared
     /// </summary>
     internal abstract class ShapeItem : DrawingShape
     {
-        TextBody<SvgParagraphItem> _textBox;
+        TextBody _textBox;
 
         internal ShapeItem(ExcelShape shape) : base(shape) 
         {

--- a/src/EPPlus.Export.ImageRenderer/RenderItems/Shared/TextBody.cs
+++ b/src/EPPlus.Export.ImageRenderer/RenderItems/Shared/TextBody.cs
@@ -18,7 +18,7 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.Shared
     /// Margin left = X
     /// Margin right = Y
     /// </summary>
-    internal abstract class TextBody<T>: SvgRenderItem where T : ParagraphContainer
+    internal abstract class TextBody: SvgRenderItem
     {
         /// <summary>
         /// Shorthand for Bounds.Width
@@ -34,7 +34,7 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.Shared
 
         internal eTextAnchoringType VerticalAlignment = eTextAnchoringType.Top;
 
-        internal abstract List<T> Paragraphs { get; set; }
+        internal abstract List<ParagraphContainer> Paragraphs { get; set; }
 
         public bool AllowOverflow;
 
@@ -63,12 +63,7 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.Shared
 
             if (_measurer != null)
             {
-                //Specify type
-                var paragraphType = typeof(T);
-
-                //Create object of type
-                var paragraph = (T)Activator.CreateInstance(paragraphType, Bounds);
-
+                var paragraph = CreateParagraph(Bounds);
                 Paragraphs.Add(paragraph);
 
                 paragraph.AddText(text, measurer);
@@ -84,11 +79,7 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.Shared
             var measureFont = item.DefaultRunProperties.GetMeasureFont();
             bool isFirst = Paragraphs.Count == 0;
 
-            //Specify type
-            var paragraphType = typeof(T);
-
-            //Create object of type
-            var paragraph = (T)Activator.CreateInstance(paragraphType, item, Bounds);
+            var paragraph = CreateParagraph(item, Bounds);
 
             paragraph.Bounds.Top = startingY;
 
@@ -204,5 +195,17 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.Shared
         {
             il = Bounds.Left; it = Bounds.Top; ir = Bounds.Right; ib = Bounds.Bottom;
         }
+
+        /// <summary>
+        /// Each file format defines its own paragraph
+        /// </summary>
+        /// <returns></returns>
+        internal abstract ParagraphContainer CreateParagraph(ExcelDrawingParagraph paragraph, BoundingBox parent);
+
+        /// <summary>
+        /// Each file format defines its own paragraph
+        /// </summary>
+        /// <returns></returns>
+        internal abstract ParagraphContainer CreateParagraph(BoundingBox parent);
     }
 }

--- a/src/EPPlus.Export.ImageRenderer/RenderItems/SvgItem/SvgParagraphItem.cs
+++ b/src/EPPlus.Export.ImageRenderer/RenderItems/SvgItem/SvgParagraphItem.cs
@@ -30,11 +30,6 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.SvgItem
             }
         }
 
-        //internal protected override void AddTextRun(ExcelParagraphTextRunBase origTxtRun, string runDisplayString)
-        //{
-        //    AddTextRun<SvgTextRunItem>(origTxtRun, runDisplayString);
-        //}
-
         private string GetHorizontalAlignmentAttribute(double indentX)
         {
             string ret = "";

--- a/src/EPPlus.Export.ImageRenderer/RenderItems/SvgItem/SvgParagraphItem.cs
+++ b/src/EPPlus.Export.ImageRenderer/RenderItems/SvgItem/SvgParagraphItem.cs
@@ -30,10 +30,10 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.SvgItem
             }
         }
 
-        internal protected override void AddTextRun(ExcelParagraphTextRunBase origTxtRun, string runDisplayString)
-        {
-            AddTextRun<SvgTextRunItem>(origTxtRun, runDisplayString);
-        }
+        //internal protected override void AddTextRun(ExcelParagraphTextRunBase origTxtRun, string runDisplayString)
+        //{
+        //    AddTextRun<SvgTextRunItem>(origTxtRun, runDisplayString);
+        //}
 
         private string GetHorizontalAlignmentAttribute(double indentX)
         {
@@ -113,6 +113,11 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.SvgItem
         internal override SvgRenderItem Clone(SvgShape svgDocument)
         {
             throw new System.NotImplementedException();
+        }
+
+        internal override TextRunItem CreateTextRun(ExcelParagraphTextRunBase run, BoundingBox parent, string displayText)
+        {
+            return new SvgTextRunItem(run, parent, displayText);
         }
     }
 }

--- a/src/EPPlus.Export.ImageRenderer/RenderItems/SvgItem/SvgTextBodyItem.cs
+++ b/src/EPPlus.Export.ImageRenderer/RenderItems/SvgItem/SvgTextBodyItem.cs
@@ -2,19 +2,20 @@
 using EPPlus.Graphics;
 using EPPlusImageRenderer.RenderItems;
 using EPPlusImageRenderer.Svg;
+using OfficeOpenXml.Drawing;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace EPPlus.Export.ImageRenderer.RenderItems.SvgItem
 {
-    internal class SvgTextBodyItem : TextBody<SvgParagraphItem>
+    internal class SvgTextBodyItem : TextBody
     {
         public SvgTextBodyItem(BoundingBox parent) : base(parent)
         {
         }
 
-        internal override List<SvgParagraphItem> Paragraphs { get; set; } = new List<SvgParagraphItem>();
+        internal override List<ParagraphContainer> Paragraphs { get; set; } = new List<ParagraphContainer>();
 
         public override void Render(StringBuilder sb)
         {
@@ -33,6 +34,16 @@ namespace EPPlus.Export.ImageRenderer.RenderItems.SvgItem
         internal override SvgRenderItem Clone(SvgShape svgDocument)
         {
             throw new NotImplementedException();
+        }
+
+        internal override ParagraphContainer CreateParagraph(BoundingBox parent)
+        {
+            return new SvgParagraphItem(parent);
+        }
+
+        internal override ParagraphContainer CreateParagraph(ExcelDrawingParagraph paragraph, BoundingBox parent)
+        {
+            return new SvgParagraphItem(paragraph, parent);
         }
     }
 }

--- a/src/EPPlus.Fonts.OpenType.Tests/FontMeasurerPerformanceTest.cs
+++ b/src/EPPlus.Fonts.OpenType.Tests/FontMeasurerPerformanceTest.cs
@@ -134,49 +134,5 @@ namespace EPPlus.Fonts.OpenType.Tests
             //Assert.AreEqual(0, differingStrings.Count());
             //Assert.AreEqual(UnOptimizedOriginalWrappingString, currStr);
         }
-        [TestMethod]
-        public void SettingBoldItalicAgainShouldNotTimeout()
-        {
-            MeasurementFont boldItalic = new MeasurementFont()
-            {
-                FontFamily = "Aptos Narrow",
-                Size = 11f,
-                Style = MeasurementFontStyles.Bold | MeasurementFontStyles.Italic
-            };
-
-            var ttTextMeasurer = new FontMeasurerTrueType();
-
-            Stopwatch timer = new Stopwatch();
-            timer.Start();
-            ttTextMeasurer.SetFont(boldItalic);
-            timer.Stop();
-            var firstTime = timer.ElapsedMilliseconds;
-
-            timer.Restart();
-            ttTextMeasurer.SetFont(boldItalic);
-            timer.Stop();
-
-            //Doing the same operation again should not be a whole second longer
-            Assert.IsTrue((firstTime + 1000) > timer.ElapsedMilliseconds);
-            //At time of writing OpenTypeFontCache.GetFromCache is 2s therefore it should take less
-            Assert.IsTrue(timer.ElapsedMilliseconds < 2000);
-        }
-
-        [TestMethod]
-        public void GetFromCacheBoldItalicShouldWork()
-        {
-            MeasurementFont boldItalic = new MeasurementFont()
-            {
-                FontFamily = "Aptos Narrow",
-                Size = 11f,
-                Style = MeasurementFontStyles.Bold | MeasurementFontStyles.Italic
-            };
-
-            var ttTextMeasurer = new FontMeasurerTrueType();
-            ttTextMeasurer.SetFont(boldItalic);
-
-            var cachedFont = OpenTypeFontCache.GetFromCache("Aptos Narrow", FontSubFamily.BoldItalic);
-            Assert.IsNotNull(cachedFont);
-        }
     }
 }

--- a/src/EPPlus.Fonts.OpenType.Tests/FontMeasurerPerformanceTest.cs
+++ b/src/EPPlus.Fonts.OpenType.Tests/FontMeasurerPerformanceTest.cs
@@ -79,7 +79,8 @@ namespace EPPlus.Fonts.OpenType.Tests
             //Assert.AreEqual(UnOptimizedOriginalWrappingString, currStr);
         }
 
-        [TestMethod]
+        [TestMethod, Ignore("This test should not run in a multithreaded test run. If we want to keep it, it should be moved to a separate benchmark project.")]
+        [TestCategory("Benchmark")]
         public void Wrap20Paragraphs100TimesMultipleTextFragments()
         {
             List<string> longTexts = new List<string>();

--- a/src/EPPlus.Fonts.OpenType.Tests/FontMeasurerPerformanceTest.cs
+++ b/src/EPPlus.Fonts.OpenType.Tests/FontMeasurerPerformanceTest.cs
@@ -132,5 +132,43 @@ namespace EPPlus.Fonts.OpenType.Tests
             //Assert.AreEqual(0, differingStrings.Count());
             //Assert.AreEqual(UnOptimizedOriginalWrappingString, currStr);
         }
+        [TestMethod]
+        public void TestRegularToBoldItalic()
+        {
+            FontMeasurerTrueType measurer = new FontMeasurerTrueType();
+            MeasurementFont font = new MeasurementFont
+            {
+                FontFamily = "Aptos Narrow",
+                Size = 12,
+                Style = MeasurementFontStyles.Regular
+            };
+
+            measurer.SetFont(font);
+
+            MeasurementFont fontBoldItalic = new MeasurementFont
+            {
+                FontFamily = "Aptos Narrow",
+                Size = 12,
+                Style = MeasurementFontStyles.Bold | MeasurementFontStyles.Italic
+            };
+
+            measurer.SetFont(fontBoldItalic);
+            //string testStr = "I am having so much fun so quickly!";
+
+            //var strLst = new List<string>();
+            //strLst.Add(testStr);
+
+            //List<MeasurementFont> fonts = new List<MeasurementFont>();
+            //fonts.Add(font);
+
+            //measurer.WrapMultipleTextFragments(strLst, fonts, 500);
+
+            //MeasurementFont fontBoldItalic = new MeasurementFont
+            //{
+            //    FontFamily = "Aptos Narrow",
+            //    Size = 12,
+            //    Style = MeasurementFontStyles.Bold | MeasurementFontStyles.Italic
+            //};
+        }
     }
 }

--- a/src/EPPlus.Fonts.OpenType.Tests/FontMeasurerPerformanceTest.cs
+++ b/src/EPPlus.Fonts.OpenType.Tests/FontMeasurerPerformanceTest.cs
@@ -1,5 +1,7 @@
-﻿using OfficeOpenXml.Interfaces.Drawing.Text;
+﻿using EPPlus.Fonts.OpenType.FontCache;
+using OfficeOpenXml.Interfaces.Drawing.Text;
 using System.Diagnostics;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace EPPlus.Fonts.OpenType.Tests
 {
@@ -133,42 +135,48 @@ namespace EPPlus.Fonts.OpenType.Tests
             //Assert.AreEqual(UnOptimizedOriginalWrappingString, currStr);
         }
         [TestMethod]
-        public void TestRegularToBoldItalic()
+        public void SettingBoldItalicAgainShouldNotTimeout()
         {
-            FontMeasurerTrueType measurer = new FontMeasurerTrueType();
-            MeasurementFont font = new MeasurementFont
+            MeasurementFont boldItalic = new MeasurementFont()
             {
                 FontFamily = "Aptos Narrow",
-                Size = 12,
-                Style = MeasurementFontStyles.Regular
-            };
-
-            measurer.SetFont(font);
-
-            MeasurementFont fontBoldItalic = new MeasurementFont
-            {
-                FontFamily = "Aptos Narrow",
-                Size = 12,
+                Size = 11f,
                 Style = MeasurementFontStyles.Bold | MeasurementFontStyles.Italic
             };
 
-            measurer.SetFont(fontBoldItalic);
-            //string testStr = "I am having so much fun so quickly!";
+            var ttTextMeasurer = new FontMeasurerTrueType();
 
-            //var strLst = new List<string>();
-            //strLst.Add(testStr);
+            Stopwatch timer = new Stopwatch();
+            timer.Start();
+            ttTextMeasurer.SetFont(boldItalic);
+            timer.Stop();
+            var firstTime = timer.ElapsedMilliseconds;
 
-            //List<MeasurementFont> fonts = new List<MeasurementFont>();
-            //fonts.Add(font);
+            timer.Restart();
+            ttTextMeasurer.SetFont(boldItalic);
+            timer.Stop();
 
-            //measurer.WrapMultipleTextFragments(strLst, fonts, 500);
+            //Doing the same operation again should not be a whole second longer
+            Assert.IsTrue((firstTime + 1000) > timer.ElapsedMilliseconds);
+            //At time of writing OpenTypeFontCache.GetFromCache is 2s therefore it should take less
+            Assert.IsTrue(timer.ElapsedMilliseconds < 2000);
+        }
 
-            //MeasurementFont fontBoldItalic = new MeasurementFont
-            //{
-            //    FontFamily = "Aptos Narrow",
-            //    Size = 12,
-            //    Style = MeasurementFontStyles.Bold | MeasurementFontStyles.Italic
-            //};
+        [TestMethod]
+        public void GetFromCacheBoldItalicShouldWork()
+        {
+            MeasurementFont boldItalic = new MeasurementFont()
+            {
+                FontFamily = "Aptos Narrow",
+                Size = 11f,
+                Style = MeasurementFontStyles.Bold | MeasurementFontStyles.Italic
+            };
+
+            var ttTextMeasurer = new FontMeasurerTrueType();
+            ttTextMeasurer.SetFont(boldItalic);
+
+            var cachedFont = OpenTypeFontCache.GetFromCache("Aptos Narrow", FontSubFamily.BoldItalic);
+            Assert.IsNotNull(cachedFont);
         }
     }
 }

--- a/src/EPPlus.Fonts.OpenType.Tests/Regression/RegressionTests.cs
+++ b/src/EPPlus.Fonts.OpenType.Tests/Regression/RegressionTests.cs
@@ -10,8 +10,11 @@
  *************************************************************************************************
   12/22/2025         EPPlus Software AB           Regression tests
  *************************************************************************************************/
+using EPPlus.Fonts.OpenType.FontCache;
 using EPPlus.Fonts.OpenType.Tests.Helpers;
+using OfficeOpenXml.Interfaces.Drawing.Text;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -269,6 +272,51 @@ namespace EPPlus.Fonts.OpenType.Tests.Regression
 
             // Verify in FontDrop or similar tool that ligatures render correctly
             FontTestHelper.AssertFontValid(subset);
+        }
+
+        [TestMethod]
+        public void SettingBoldItalicAgainShouldNotTimeout()
+        {
+            MeasurementFont boldItalic = new MeasurementFont()
+            {
+                FontFamily = "Aptos Narrow",
+                Size = 11f,
+                Style = MeasurementFontStyles.Bold | MeasurementFontStyles.Italic
+            };
+
+            var ttTextMeasurer = new FontMeasurerTrueType();
+
+            Stopwatch timer = new Stopwatch();
+            timer.Start();
+            ttTextMeasurer.SetFont(boldItalic);
+            timer.Stop();
+            var firstTime = timer.ElapsedMilliseconds;
+
+            timer.Restart();
+            ttTextMeasurer.SetFont(boldItalic);
+            timer.Stop();
+
+            //Doing the same operation again should not be a whole second longer
+            Assert.IsTrue((firstTime + 1000) > timer.ElapsedMilliseconds);
+            //At time of writing OpenTypeFontCache.GetFromCache is 2s therefore it should take less
+            Assert.IsTrue(timer.ElapsedMilliseconds < 2000);
+        }
+
+        [TestMethod]
+        public void GetFromCacheBoldItalicShouldWork()
+        {
+            MeasurementFont boldItalic = new MeasurementFont()
+            {
+                FontFamily = "Aptos Narrow",
+                Size = 11f,
+                Style = MeasurementFontStyles.Bold | MeasurementFontStyles.Italic
+            };
+
+            var ttTextMeasurer = new FontMeasurerTrueType();
+            ttTextMeasurer.SetFont(boldItalic);
+
+            var cachedFont = OpenTypeFontCache.GetFromCache("Aptos Narrow", FontSubFamily.BoldItalic);
+            Assert.IsNotNull(cachedFont);
         }
     }
 }

--- a/src/EPPlus.Fonts.OpenType/FontCache/OpenTypeFontCache.cs
+++ b/src/EPPlus.Fonts.OpenType/FontCache/OpenTypeFontCache.cs
@@ -21,16 +21,23 @@ namespace EPPlus.Fonts.OpenType.FontCache
             }
         }
 
-
-
-        static string BuildCacheKey(string familyName, string subFamily)
+        /// <summary>
+        /// THE SUBFAMILY ENUM SHOULD ALWAYS BE INPUT PARAMETER
+        /// Fonts can name themselves however they want. But we map other values in the font to the subfamily
+        /// Therefore Never change it to e.g. a string input-parameter
+        /// and Never use e.g font.GetEnglishSubfamily name as this could create miss-matches.
+        /// </summary>
+        /// <param name="familyName"></param>
+        /// <param name="subFamily">MUST STAY as FontSubFamily enum</param>
+        /// <returns></returns>
+        static string BuildCacheKey(string familyName, FontSubFamily subFamily)
         {
-            return $"{familyName}-{subFamily}";
+            return $"{familyName}-{subFamily.ToString()}";
         }
 
         public static bool Contains(string familyName, FontSubFamily subFamily)
         {
-            var key = BuildCacheKey(familyName, subFamily.ToString());
+            var key = BuildCacheKey(familyName, subFamily);
             lock (_syncRoot)
             {
 
@@ -44,7 +51,7 @@ namespace EPPlus.Fonts.OpenType.FontCache
         {
             lock (_syncRoot)
             {
-                var key = BuildCacheKey(familyName, subFamily.ToString());
+                var key = BuildCacheKey(familyName, subFamily);
                 if (!_cache.ContainsKey(key))
                 {
                     _cache[key] = new CachedOpenTypeFont()
@@ -55,11 +62,11 @@ namespace EPPlus.Fonts.OpenType.FontCache
             }
         }
 
-        public static void AddToCache(OpenTypeFont font)
+        public static void AddToCache(OpenTypeFont font, string familyName, FontSubFamily subFamily)
         {
             lock (_syncRoot)
             {
-                var key = BuildCacheKey(font.GetEnglishFontFamilyName(), font.GetEnglishFontSubFamilyName());
+                var key = BuildCacheKey(familyName, subFamily);
                 if (!_cache.ContainsKey(key))
                 {
                     _cache[key] = new CachedOpenTypeFont();
@@ -76,7 +83,7 @@ namespace EPPlus.Fonts.OpenType.FontCache
 
         public static CachedOpenTypeFont GetFromCache(string familyName, FontSubFamily subFamily)
         {
-            var key = BuildCacheKey(familyName, subFamily.ToString());
+            var key = BuildCacheKey(familyName, subFamily);
             lock (_syncRoot)
             {
                 if (_cache.TryGetValue(key, out var cached))

--- a/src/EPPlus.Fonts.OpenType/OpenTypeFonts.cs
+++ b/src/EPPlus.Fonts.OpenType/OpenTypeFonts.cs
@@ -144,7 +144,7 @@ namespace EPPlus.Fonts.OpenType
                 var font = OpenTypeFontFactory.CreateFromFace(face);
 
                 if (!ignoreCache)
-                    OpenTypeFontCache.AddToCache(font);
+                    OpenTypeFontCache.AddToCache(font, fontName, subFamily);
 
                 return font;
             }

--- a/src/EPPlus.Fonts.OpenType/TrueTypeMeasurer/FontMeasurerTrueType.cs
+++ b/src/EPPlus.Fonts.OpenType/TrueTypeMeasurer/FontMeasurerTrueType.cs
@@ -31,6 +31,8 @@ namespace EPPlus.Fonts.OpenType
         private OpenTypeFont _defaultFont = TextData.GetFontData("Calibri", FontSubFamily.Regular);
         private double _defaultSize = 11d;
 
+        OpenTypeFont LastFont = null;
+
         OpenTypeFont CurrentFont;
         private double _widthInPoints;
         private double _heightInPoints;
@@ -93,7 +95,8 @@ namespace EPPlus.Fonts.OpenType
         public void SetFont(double fontSize, string fontName, FontSubFamily subFamily = FontSubFamily.Regular)
         {
             CurrentFontName = fontName;
-            CurrentFont = TextData.GetFontData(fontName, subFamily);
+            var newFont = TextData.GetFontData(fontName, subFamily);
+            CurrentFont = newFont;
             FontSize = fontSize;
         }
 


### PR DESCRIPTION
Added abstract "CreateParagraph() and CreateTextRun()" functions instead of needless and confusing generics.

Fixed and tested a bug in OpenTypeFontCache.GetFromCache for BoldItalics.
There was a miss-match between the FontSubFamily.BoldItalic and the Free text of some font files (including aptos narrow)