### PR TITLE
Performance improvements SUMIFS, AVERAGEIFS, COUNTIFS

### DIFF
--- a/src/EPPlus/ExcelCalculationCacheSettings.cs
+++ b/src/EPPlus/ExcelCalculationCacheSettings.cs
@@ -1,0 +1,42 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  02/10/2026         EPPlus Software AB       Initial release
+ *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
+
+namespace OfficeOpenXml
+{
+    /// <summary>
+    /// Settings for formula calculation caching and optimization
+    /// </summary>
+    public class ExcelCalculationCacheSettings
+    {
+        /// <summary>
+        /// Maximum number of flattened ranges to cache for RangeCriteria functions (SUMIFS, AVERAGEIFS, COUNTIFS).
+        /// Default is 100. Set to 0 to disable flattened range caching.
+        /// </summary>
+        public int MaxFlattenedRanges { get; set; } = RangeCriteriaCache.DEFAULT_MAX_FLATTENED_RANGES;
+
+        /// <summary>
+        /// Maximum number of match indexes to cache for RangeCriteria functions (SUMIFS, AVERAGEIFS, COUNTIFS).
+        /// Default is 1000. Set to 0 to disable match index caching.
+        /// </summary>
+        public int MaxMatchIndexes { get; set; } = RangeCriteriaCache.DEFAULT_MAX_MATCH_INDEXES;
+
+        /// <summary>
+        /// Gets the default configuration for Excel calculation cache settings.
+        /// </summary>
+        /// <remarks>Use this property to obtain a standard set of cache settings suitable for most
+        /// scenarios. The returned instance is immutable and can be shared safely across multiple components.</remarks>
+        public static ExcelCalculationCacheSettings Default { get; } = new ExcelCalculationCacheSettings();
+
+    }
+}

--- a/src/EPPlus/ExcelPackageSettings.cs
+++ b/src/EPPlus/ExcelPackageSettings.cs
@@ -70,6 +70,23 @@ namespace OfficeOpenXml
                 return _imageSettings;
             }
         }
+
+        private ExcelCalculationCacheSettings _calculationCacheSettings = null;
+
+        /// <summary>
+        /// Cache settings for formula calculation optimization.
+        /// </summary>
+        public ExcelCalculationCacheSettings CalculationCacheSettings
+        {
+            get
+            {
+                if (_calculationCacheSettings == null)
+                {
+                    _calculationCacheSettings = new ExcelCalculationCacheSettings();
+                }
+                return _calculationCacheSettings;
+            }
+        }
         /// <summary>
         /// Any auto- or table- filters created will be applied on save.
         /// In the case you want to handle this manually, set this property to false.

--- a/src/EPPlus/FormulaParsing/CalculateExtensions.cs
+++ b/src/EPPlus/FormulaParsing/CalculateExtensions.cs
@@ -75,6 +75,7 @@ namespace OfficeOpenXml
 
             //CalcChain(workbook, workbook.FormulaParser, dc, options);
             var dc=RpnFormulaExecution.Execute(workbook, options);
+            dc._parsingContext.RangeCriteriaCache?.Clear();
             if (workbook.FormulaParser.Logger != null)
             {
                 var msg = string.Format("Calculation done...number of cells parsed: {0}", dc.processedCells.Count);
@@ -130,6 +131,7 @@ namespace OfficeOpenXml
         {
             Init(worksheet.Workbook);
             var dc = RpnFormulaExecution.Execute(worksheet, options);
+            dc._parsingContext.RangeCriteriaCache?.Clear();
         }
 
         /// <summary>
@@ -172,6 +174,8 @@ namespace OfficeOpenXml
             //var dc = DependencyChainFactory.Create(range, options);
             //CalcChain(range._workbook, parser, dc, options);
             var dc = RpnFormulaExecution.Execute(range, options);
+            // Clear RangeCriteriaCache after calculation completes
+            dc._parsingContext.RangeCriteriaCache?.Clear();
         }
 
         /// <summary>
@@ -202,7 +206,9 @@ namespace OfficeOpenXml
                 //var filterInfo = new FilterInfo(worksheet.Workbook);
                 //parser.InitNewCalc(filterInfo);
                 if (Formula[0] == '=') Formula = Formula.Substring(1); //Remove any starting equal sign
-                return RpnFormulaExecution.ExecuteFormula(worksheet.Workbook, Formula,new FormulaCellAddress(worksheet.IndexInList, -1, 0), options);
+                var result = RpnFormulaExecution.ExecuteFormula(worksheet.Workbook, Formula,new FormulaCellAddress(worksheet.IndexInList, -1, 0), options);
+                worksheet.Workbook.FormulaParser.ParsingContext?.RangeCriteriaCache?.Clear();
+                return result;
             }
             catch (Exception ex)
             {

--- a/src/EPPlus/FormulaParsing/DependencyChain/RpnFormulaExecution.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/RpnFormulaExecution.cs
@@ -1544,7 +1544,7 @@ namespace OfficeOpenXml.FormulaParsing
                 {
                     args = CompileFunctionArguments(f, funcExp);
                     funcExp.Status = ExpressionStatus.CanCompile;
-                    return funcExp.SetArguments(args);
+                    return funcExp.SetArguments(args, depChain._parsingContext);
                 }
                 else
                 {
@@ -1559,7 +1559,7 @@ namespace OfficeOpenXml.FormulaParsing
             else
             {
                 args = CompileFunctionArguments(f, funcExp);
-                return funcExp.SetArguments(args);
+                return funcExp.SetArguments(args, depChain._parsingContext);
             }
             return false;
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/ExcelFunction.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/ExcelFunction.cs
@@ -122,8 +122,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
         /// </summary>
         /// <param name="args">The function arguments that will be supplied to the execute method.</param>
         /// <param name="index">The index of the argument that should be adjusted.</param>
+        /// <param name="ctx">The parsing context</param>
         /// <param name="addresses">A queue of addresses that will be calculated before calling the Execute function.</param>
-        public virtual void GetNewParameterAddress(IList<CompileResult> args, int index, ref Queue<FormulaRangeAddress> addresses)
+        public virtual void GetNewParameterAddress(IList<CompileResult> args, int index, ParsingContext ctx, ref Queue<FormulaRangeAddress> addresses)
         {
             
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/AverageIf.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/AverageIf.cs
@@ -42,14 +42,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         {
             config.SetArrayParameterIndexes(1);
         }
-        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ref Queue<FormulaRangeAddress> addresses)
+        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ParsingContext ctx, ref Queue<FormulaRangeAddress> addresses)
         {
             if (index == 2)
             {
                 if (args[0].Result is IRangeInfo rangeInfo && args[2].Result is IRangeInfo valueRange)
                 {
                     var rv = new RangeOrValue { Range = rangeInfo };
-                    var mi = GetMatchIndexes(rv, args[1].Result, null);
+                    var mi = GetMatchIndexes(rv, args[1].Result, ctx);
                     EnqueueMatchingAddresses(valueRange, mi, ref addresses);
                 }
             }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/AverageIfs.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/AverageIfs.cs
@@ -55,12 +55,12 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         {
             if (index == 0 && args[0].Result is IRangeInfo valueRange)
             {
-                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args, ctx);
+                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args, ctx, convertNumericStrings: false);
                 EnqueueMatchingAddresses(valueRange, matchIndexes, ref addresses);
             }
             else if (args[index].Result is IRangeInfo criteriaRange)
             {
-                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args, ctx, index);
+                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args, ctx, index, convertNumericStrings: false);
                 EnqueueMatchingAddresses(criteriaRange, matchIndexes, ref addresses);
             }
         }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/AverageIfs.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/AverageIfs.cs
@@ -50,19 +50,21 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             }
             return FunctionParameterInformation.AdjustParameterAddress;
         }));
-        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ref Queue<FormulaRangeAddress> addresses)
+
+        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ParsingContext ctx, ref Queue<FormulaRangeAddress> addresses)
         {
             if (index == 0 && args[0].Result is IRangeInfo valueRange)
             {
-                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args);
+                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args, ctx);
                 EnqueueMatchingAddresses(valueRange, matchIndexes, ref addresses);
             }
             else if (args[index].Result is IRangeInfo criteriaRange)
             {
-                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args, index);
+                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args, ctx, index);
                 EnqueueMatchingAddresses(criteriaRange, matchIndexes, ref addresses);
             }
         }
+
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
             var valueRange = arguments[0].ValueAsRangeInfo;
@@ -103,19 +105,13 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         }
         private double GetAvgValue(ParsingContext context, IRangeInfo valueRange, List<RangeOrValue> argRanges, List<RangeOrValue> criteria, int row, int col, out ExcelErrorValue ev)
         {
-            IEnumerable<int> matchIndexes = GetMatchIndexes(argRanges[0], GetCriteriaValue(criteria[0], row, col), context, false);
-            var enumerable = matchIndexes as IList<int> ?? matchIndexes.ToList();
-            for (var ix = 1; ix < argRanges.Count && enumerable.Any(); ix++)
-            {
-                var indexes = GetMatchIndexes(argRanges[ix], GetCriteriaValue(criteria[ix], row, col), context, false);
-                matchIndexes = matchIndexes.Intersect(indexes);
-            }
-            var sumRange = RangeFlattener.FlattenRangeObject(valueRange);
+            GetFilteredValueRange(context, valueRange, argRanges, criteria, row, col, out List<int> matchIndexes, out List<object> flattenedRange, convertNumericString: false);
+
             KahanSum sum = 0d;
             var count = 0;
             foreach (var index in matchIndexes)
             {
-                var obj = sumRange[index];
+                var obj = flattenedRange[index];
                 if (obj is ExcelErrorValue e1)
                 {
                     ev = e1;
@@ -127,14 +123,15 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     count++;
                 }
             }
+
             if (count == 0)
             {
-                ev = ErrorValues.Div0Error;;
+                ev = ErrorValues.Div0Error;
                 return double.NaN;
             }
+
             ev = null;
             return sum / count;
         }
-
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/CountIfs.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/CountIfs.cs
@@ -40,11 +40,11 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             }
             return FunctionParameterInformation.IgnoreErrorInPreExecute;
         }));
-        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ref Queue<FormulaRangeAddress> addresses)
+        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ParsingContext ctx, ref Queue<FormulaRangeAddress> addresses)
         {
             if (args[index].Result is IRangeInfo criteriaRange)
             {
-                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(0, args, index);
+                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(0, args, ctx, index);
                 EnqueueMatchingAddresses(criteriaRange, matchIndexes, ref addresses);
             }
         }
@@ -76,16 +76,24 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             }
         }
 
+
         private double GetCountValue(ParsingContext context, List<RangeOrValue> argRanges, List<RangeOrValue> criteria, int row, int col)
         {
-            IEnumerable<int> matchIndexes = GetMatchIndexes(argRanges[0], GetCriteriaValue(criteria[0], row, col), context, false);
-            var enumerable = matchIndexes as IList<int> ?? matchIndexes.ToList();
-            for (var ix = 1; ix < argRanges.Count && enumerable.Any(); ix++)
+            var matchIndexes = GetMatchIndexes(argRanges[0], GetCriteriaValue(criteria[0], row, col), context, false);
+
+            // Use HashSet.IntersectWith for multi-criteria (more efficient than LINQ Intersect)
+            if (argRanges.Count > 1)
             {
-                var indexes = GetMatchIndexes(argRanges[ix], GetCriteriaValue(criteria[ix], row, col), context, false);
-                matchIndexes = matchIndexes.Intersect(indexes);
+                var hashSet = new HashSet<int>(matchIndexes);
+                for (var ix = 1; ix < argRanges.Count && hashSet.Count > 0; ix++)
+                {
+                    var indexes = GetMatchIndexes(argRanges[ix], GetCriteriaValue(criteria[ix], row, col), context, false);
+                    hashSet.IntersectWith(indexes);
+                }
+                return (double)hashSet.Count;
             }
-            return (double)matchIndexes.Count();
+
+            return (double)matchIndexes.Count;
         }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/RangeCriteriaCache.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/RangeCriteriaCache.cs
@@ -232,7 +232,12 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         {
             // Create a unique key combining range address and criteria value
             var rangeKey = CreateRangeKey(rangeAddress);
-            var criteriaKey = criteriaValue?.ToString() ?? "null";
+            var cv = criteriaValue;
+            if(criteriaValue is RangeOrValue rov)
+            {
+                cv = rov.Value != null ? rov.Value : rov?.Range?.Address.ToString() ?? "null";
+            }
+            var criteriaKey = cv?.ToString() ?? "null";
             return $"{rangeKey}|{criteriaKey}";
         }
     }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/RangeCriteriaCache.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/RangeCriteriaCache.cs
@@ -1,0 +1,226 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  02/09/2026         EPPlus Software AB       RangeCriteria performance optimization
+ *************************************************************************************************/
+using System.Collections.Generic;
+using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
+
+namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
+{
+    /// <summary>
+    /// Cache for RangeCriteria functions (SumIfs, AverageIfs, CountIfs) to improve performance
+    /// during calculation by avoiding repeated expensive operations.
+    /// Uses FIFO eviction policy to limit memory usage and integer keys for efficient lookups.
+    /// </summary>
+    internal class RangeCriteriaCache
+    {
+        private const int DEFAULT_MAX_FLATTENED_RANGES = 100;
+        private const int DEFAULT_MAX_MATCH_INDEXES = 1000;
+
+        private readonly int _maxFlattenedRanges;
+        private readonly int _maxMatchIndexes;
+        private readonly ExcelPackage _package;
+
+        private Dictionary<int, List<object>> _flattenedRanges;
+        private Dictionary<int, List<int>> _matchIndexes;
+        private HashSet<int> _rangesWithFormulas;
+
+        private Queue<int> _flattenedRangesOrder;
+        private Queue<int> _matchIndexesOrder;
+
+        private Dictionary<string, int> _keyToId;
+        private int _nextId = 1;
+
+        /// <summary>
+        /// Creates a new RangeCriteriaCache with specified limits
+        /// </summary>
+        /// <param name="package"></param>The ExcelPackage where the cache operates.</param>
+        /// <param name="maxFlattenedRanges">Maximum number of flattened ranges to cache (default 100)</param>
+        /// <param name="maxMatchIndexes">Maximum number of matchIndexes to cache (default 1000)</param>
+        public RangeCriteriaCache(ExcelPackage package, int maxFlattenedRanges = DEFAULT_MAX_FLATTENED_RANGES,
+                                   int maxMatchIndexes = DEFAULT_MAX_MATCH_INDEXES)
+        {
+            _package = package;
+            _maxFlattenedRanges = maxFlattenedRanges;
+            _maxMatchIndexes = maxMatchIndexes;
+        }
+
+        /// <summary>
+        /// Gets a flattened range from cache, or null if not cached
+        /// </summary>
+        public List<object> GetFlattenedRange(FormulaRangeAddress address)
+        {
+            if (_flattenedRanges == null || address == null) return null;
+
+            var key = CreateRangeKey(address);
+            if (_keyToId != null && _keyToId.TryGetValue(key, out var id))
+            {
+                if (_flattenedRanges.TryGetValue(id, out var cached))
+                {
+                    return cached;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Stores a flattened range in cache with FIFO eviction if cache is full
+        /// </summary>
+        public void SetFlattenedRange(FormulaRangeAddress address, List<object> flattenedRange)
+        {
+            if (address == null || flattenedRange == null) return;
+
+            if (_flattenedRanges == null)
+            {
+                _flattenedRanges = new Dictionary<int, List<object>>();
+                _flattenedRangesOrder = new Queue<int>();
+                _keyToId = new Dictionary<string, int>();
+            }
+
+            var key = CreateRangeKey(address);
+
+            // Get or create ID for this key
+            if (!_keyToId.TryGetValue(key, out var id))
+            {
+                id = _nextId++;
+                _keyToId[key] = id;
+
+                // Check if cache is full and evict oldest entry (FIFO)
+                if (_flattenedRanges.Count >= _maxFlattenedRanges)
+                {
+                    var oldestId = _flattenedRangesOrder.Dequeue();
+                    _flattenedRanges.Remove(oldestId);
+                    // Note: we keep the key in _keyToId to avoid ID reuse within same calculation
+                }
+
+                _flattenedRangesOrder.Enqueue(id);
+            }
+
+            _flattenedRanges[id] = flattenedRange;
+        }
+
+        /// <summary>
+        /// Gets cached match indexes for a range+criteria combination.
+        /// Returns null if the range contains formulas (which might change during calculation).
+        /// </summary>
+        public List<int> GetMatchIndexes(FormulaRangeAddress rangeAddress, object criteriaValue)
+        {
+            if (_matchIndexes == null || rangeAddress == null || criteriaValue == null) return null;
+
+            var rangeKey = CreateRangeKey(rangeAddress);
+            if (_keyToId != null && _keyToId.TryGetValue(rangeKey, out var rangeId))
+            {
+                // Don't use cache if this range contains formulas that might change
+                if (_rangesWithFormulas != null && _rangesWithFormulas.Contains(rangeId))
+                {
+                    return null;
+                }
+            }
+
+            var key = CreateMatchIndexKey(rangeAddress, criteriaValue);
+            if (_keyToId != null && _keyToId.TryGetValue(key, out var id))
+            {
+                if (_matchIndexes.TryGetValue(id, out var cached))
+                {
+                    return cached;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Stores match indexes for a range+criteria combination with FIFO eviction if cache is full
+        /// </summary>
+        public void SetMatchIndexes(FormulaRangeAddress rangeAddress, object criteriaValue, List<int> matchIndexes)
+        {
+            if (rangeAddress == null || criteriaValue == null || matchIndexes == null) return;
+
+            if (_keyToId == null)
+            {
+                _keyToId = new Dictionary<string, int>();
+            }
+
+            // Track if this range has formulas
+            var rangeKey = CreateRangeKey(rangeAddress);
+            if (rangeAddress.HasFormulas(_package))
+            {
+                if (!_keyToId.TryGetValue(rangeKey, out var rangeId))
+                {
+                    rangeId = _nextId++;
+                    _keyToId[rangeKey] = rangeId;
+                }
+
+                if (_rangesWithFormulas == null)
+                {
+                    _rangesWithFormulas = new HashSet<int>();
+                }
+                _rangesWithFormulas.Add(rangeId);
+                // Don't cache matchIndexes for ranges with formulas
+                return;
+            }
+
+            if (_matchIndexes == null)
+            {
+                _matchIndexes = new Dictionary<int, List<int>>();
+                _matchIndexesOrder = new Queue<int>();
+            }
+
+            var key = CreateMatchIndexKey(rangeAddress, criteriaValue);
+
+            // Get or create ID for this key
+            if (!_keyToId.TryGetValue(key, out var id))
+            {
+                id = _nextId++;
+                _keyToId[key] = id;
+
+                // Check if cache is full and evict oldest entry (FIFO)
+                if (_matchIndexes.Count >= _maxMatchIndexes)
+                {
+                    var oldestId = _matchIndexesOrder.Dequeue();
+                    _matchIndexes.Remove(oldestId);
+                    // Note: we keep the key in _keyToId to avoid ID reuse within same calculation
+                }
+
+                _matchIndexesOrder.Enqueue(id);
+            }
+
+            _matchIndexes[id] = matchIndexes;
+        }
+
+        /// <summary>
+        /// Clears all cached data. Should be called after calculation completes.
+        /// </summary>
+        public void Clear()
+        {
+            _flattenedRanges?.Clear();
+            _matchIndexes?.Clear();
+            _rangesWithFormulas?.Clear();
+            _flattenedRangesOrder?.Clear();
+            _matchIndexesOrder?.Clear();
+            _keyToId?.Clear();
+            _nextId = 1;
+        }
+
+        private string CreateRangeKey(FormulaRangeAddress address)
+        {
+            // Create a unique key for the range address
+            return $"{address.WorksheetIx}:{address.FromRow}:{address.FromCol}:{address.ToRow}:{address.ToCol}";
+        }
+
+        private string CreateMatchIndexKey(FormulaRangeAddress rangeAddress, object criteriaValue)
+        {
+            // Create a unique key combining range address and criteria value
+            var rangeKey = CreateRangeKey(rangeAddress);
+            var criteriaKey = criteriaValue?.ToString() ?? "null";
+            return $"{rangeKey}|{criteriaKey}";
+        }
+    }
+}

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/RangeCriteriaCache.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/RangeCriteriaCache.cs
@@ -22,12 +22,11 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
     /// </summary>
     internal class RangeCriteriaCache
     {
-        private const int DEFAULT_MAX_FLATTENED_RANGES = 100;
-        private const int DEFAULT_MAX_MATCH_INDEXES = 1000;
+        internal const int DEFAULT_MAX_FLATTENED_RANGES = 100;
+        internal const int DEFAULT_MAX_MATCH_INDEXES = 1000;
 
-        private readonly int _maxFlattenedRanges;
-        private readonly int _maxMatchIndexes;
         private readonly ExcelPackage _package;
+        private readonly ExcelCalculationCacheSettings _settings;
 
         private Dictionary<int, List<object>> _flattenedRanges;
         private Dictionary<int, List<int>> _matchIndexes;
@@ -43,14 +42,17 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         /// Creates a new RangeCriteriaCache with specified limits
         /// </summary>
         /// <param name="package"></param>The ExcelPackage where the cache operates.</param>
-        /// <param name="maxFlattenedRanges">Maximum number of flattened ranges to cache (default 100)</param>
-        /// <param name="maxMatchIndexes">Maximum number of matchIndexes to cache (default 1000)</param>
-        public RangeCriteriaCache(ExcelPackage package, int maxFlattenedRanges = DEFAULT_MAX_FLATTENED_RANGES,
-                                   int maxMatchIndexes = DEFAULT_MAX_MATCH_INDEXES)
+        public RangeCriteriaCache(ExcelPackage package)
         {
             _package = package;
-            _maxFlattenedRanges = maxFlattenedRanges;
-            _maxMatchIndexes = maxMatchIndexes;
+            if(package != null)
+            {
+                _settings = package.Settings.CalculationCacheSettings;
+            }
+            else
+            {
+                _settings = ExcelCalculationCacheSettings.Default;
+            }
         }
 
         /// <summary>
@@ -78,6 +80,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         {
             if (address == null || flattenedRange == null) return;
 
+            // Guard against disabled caching
+            var maxCapacity = _settings?.MaxFlattenedRanges ?? DEFAULT_MAX_FLATTENED_RANGES;
+            if (maxCapacity <= 0) return;
+
             if (_flattenedRanges == null)
             {
                 _flattenedRanges = new Dictionary<int, List<object>>();
@@ -87,18 +93,17 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
 
             var key = CreateRangeKey(address);
 
-            // Get or create ID for this key
             if (!_keyToId.TryGetValue(key, out var id))
             {
                 id = _nextId++;
                 _keyToId[key] = id;
 
-                // Check if cache is full and evict oldest entry (FIFO)
-                if (_flattenedRanges.Count >= _maxFlattenedRanges)
+                // Evict entries until we're under the limit
+                // This handles both: cache full + capacity reduced scenarios
+                while (_flattenedRanges.Count >= maxCapacity)
                 {
                     var oldestId = _flattenedRangesOrder.Dequeue();
                     _flattenedRanges.Remove(oldestId);
-                    // Note: we keep the key in _keyToId to avoid ID reuse within same calculation
                 }
 
                 _flattenedRangesOrder.Enqueue(id);
@@ -139,9 +144,16 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         /// <summary>
         /// Stores match indexes for a range+criteria combination with FIFO eviction if cache is full
         /// </summary>
+        /// <summary>
+        /// Stores match indexes for a range+criteria combination with FIFO eviction if cache is full
+        /// </summary>
         public void SetMatchIndexes(FormulaRangeAddress rangeAddress, object criteriaValue, List<int> matchIndexes)
         {
             if (rangeAddress == null || criteriaValue == null || matchIndexes == null) return;
+
+            // Guard against disabled caching
+            var maxCapacity = _settings?.MaxMatchIndexes ?? DEFAULT_MAX_MATCH_INDEXES;
+            if (maxCapacity <= 0) return;
 
             if (_keyToId == null)
             {
@@ -181,8 +193,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                 id = _nextId++;
                 _keyToId[key] = id;
 
-                // Check if cache is full and evict oldest entry (FIFO)
-                if (_matchIndexes.Count >= _maxMatchIndexes)
+                // Evict entries until we're under the limit
+                // This handles both: cache full + capacity reduced scenarios
+                while (_matchIndexes.Count >= maxCapacity)
                 {
                     var oldestId = _matchIndexesOrder.Dequeue();
                     _matchIndexes.Remove(oldestId);

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/RangeCriteriaFunction.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/RangeCriteriaFunction.cs
@@ -10,10 +10,7 @@
  *************************************************************************************************
   01/27/2020         EPPlus Software AB       Initial release EPPlus 5
  *************************************************************************************************/
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
 using OfficeOpenXml.FormulaParsing.ExcelUtilities;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
@@ -21,6 +18,10 @@ using OfficeOpenXml.FormulaParsing.Ranges;
 using OfficeOpenXml.FormulaParsing.Utilities;
 using OfficeOpenXml.Sorting.Internal;
 using OfficeOpenXml.Utils.TypeConversion;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Require = OfficeOpenXml.FormulaParsing.Utilities.Require;
 
 
@@ -45,7 +46,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                 }
                 else
                 {
-                    if(arg.Address!=null && arg.Address.FromRow!=arg.Address.ToRow && arg.Address.FromCol != arg.Address.ToCol)
+                    if (arg.Address != null && arg.Address.FromRow != arg.Address.ToRow && arg.Address.FromCol != arg.Address.ToCol)
                     {
                         var wsIx = arg.Address.WorksheetIx < 0 ? context.CurrentCell.WorksheetIx : arg.Address.WorksheetIx;
                         var rangeInfo = context.ExcelDataProvider.GetRange(wsIx, arg.Address.FromRow, arg.Address.FromCol);
@@ -107,31 +108,31 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
 
         protected bool Evaluate(object obj, object expression, ParsingContext ctx, bool convertNumericString = true)
         {
-            if(expression is ExcelErrorValue e)
+            if (expression is ExcelErrorValue e)
             {
                 if (obj == null) return false;
                 return obj.Equals(e);
             }
 
-            if(obj is bool b1)
+            if (obj is bool b1)
             {
-                if(expression is bool b2)
+                if (expression is bool b2)
                 {
                     return b1 == b2;
                 }
-                else if(expression != null && bool.TryParse(expression.ToString(), out bool b3))
+                else if (expression != null && bool.TryParse(expression.ToString(), out bool b3))
                 {
                     return b1 == b3;
                 }
                 return false;
             }
 
-            var expressionEvaluator = new ExpressionEvaluator(ctx);
+            var expressionEvaluator = ctx.ExpressionEvaluator;
             double? candidate = default(double?);
             if (IsNumeric(obj))
             {
                 candidate = ConvertUtil.GetValueDouble(obj);
-                if(IsNumeric(expression))
+                if (IsNumeric(expression))
                 {
                     var dblE = ConvertUtil.GetValueDouble(expression);
                     var compResult = candidate.Value.CompareTo(dblE);
@@ -139,22 +140,34 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                 }
             }
 
-            var expressionString = expression==null ? string.Empty : expression.ToString();
+            var expressionString = expression == null ? string.Empty : expression.ToString();
             if (candidate.HasValue)
             {
                 return expressionEvaluator.Evaluate(candidate.Value, expressionString, convertNumericString);
             }
-            return expressionEvaluator.Evaluate(obj, expressionString, convertNumericString);        
+            return expressionEvaluator.Evaluate(obj, expressionString, convertNumericString);
         }
+
         protected List<int> GetMatchIndexes(RangeOrValue rangeOrValue, object searched, ParsingContext ctx, bool convertNumericString = true)
         {
-            var expressionEvaluator = new ExpressionEvaluator(ctx);
+            // Try to get from cache if we have a range with address
+            if (rangeOrValue.Range != null && rangeOrValue.Range.Address != null && searched != null)
+            {
+                var cached = ctx.RangeCriteriaCache?.GetMatchIndexes(rangeOrValue.Range.Address, searched);
+                if (cached != null)
+                {
+                    return cached;
+                }
+            }
+
             var result = new List<int>();
             var internalIndex = 0;
+
             if (rangeOrValue.Range != null)
             {
                 var rangeInfo = rangeOrValue.Range;
                 var address = rangeInfo.GetAddressDimensionAdjusted(0).Address;
+
                 for (var row = address.FromRow; row <= address.ToRow; row++)
                 {
                     for (var col = address.FromCol; col <= address.ToCol; col++)
@@ -165,6 +178,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                         {
                             if (searched is RangeOrValue critRange)
                             {
+                                // Handle range criteria (less common case) - use original Evaluate
                                 if (critRange.Range != null)
                                 {
                                     foreach (var cell in critRange.Range)
@@ -175,7 +189,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                                         }
                                     }
                                 }
-                                else if(critRange.Value != null && Evaluate(candidate, critRange.Value, ctx, convertNumericString))
+                                else if (critRange.Value != null && Evaluate(candidate, critRange.Value, ctx, convertNumericString))
                                 {
                                     result.Add(internalIndex);
                                 }
@@ -190,23 +204,32 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     }
                 }
             }
-            else if (Evaluate(rangeOrValue.Value, searched, ctx, convertNumericString))
+            else if (searched != null && Evaluate(rangeOrValue.Value, searched, ctx, convertNumericString))
             {
                 result.Add(internalIndex);
             }
+
+            // Cache the result if we have a range with address
+            // Pass rangeHasFormulas flag so cache knows whether to store it
+            if (rangeOrValue.Range != null && rangeOrValue.Range.Address != null && searched != null)
+            {
+                ctx.RangeCriteriaCache?.SetMatchIndexes(rangeOrValue.Range.Address, searched, result);
+            }
+
             return result;
         }
+
         protected static Queue<FormulaRangeAddress> EnqueueMatchingAddresses(IRangeInfo valueRange, IEnumerable<int> matchIndexes, ref Queue<FormulaRangeAddress> addresses)
         {
-            if(addresses==null)
+            if (addresses == null)
             {
-                addresses=new Queue<FormulaRangeAddress>();
+                addresses = new Queue<FormulaRangeAddress>();
             }
             var pIx = int.MinValue;
             var valueAddress = valueRange.GetAddressDimensionAdjusted(0);
             var extRef = valueAddress.ExternalReferenceIx;
             var wsIx = valueAddress.WorksheetIx;
-            FormulaRangeAddress currentAddress=null;
+            FormulaRangeAddress currentAddress = null;
             if (valueAddress.FromCol == valueAddress.ToCol)
             {
                 var c = valueAddress.FromCol;
@@ -246,7 +269,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
 
             return addresses;
         }
-        protected IEnumerable<int> GetMatchingIndicesFromArguments(int argStartIx, IList<CompileResult> args, int maxIndex=31)
+        protected IEnumerable<int> GetMatchingIndicesFromArguments(int argStartIx, IList<CompileResult> args, ParsingContext ctx, int maxIndex = 31)
         {
             //Return the addresses matching the criteria in the queue
             var argRanges = new List<RangeOrValue>();
@@ -273,16 +296,58 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     criteria.Add(new RangeOrValue { Value = args[ix + 1].ResultValue });
                 }
             }
-            IEnumerable<int> matchIndexes = GetMatchIndexes(argRanges[0], criteria[0], null);
+            IEnumerable<int> matchIndexes = GetMatchIndexes(argRanges[0], criteria[0], ctx);
             var enumerable = matchIndexes as IList<int> ?? matchIndexes.ToList();
             for (var ix = 1; ix < argRanges.Count && enumerable.Any(); ix++)
             {
-                var indexes = GetMatchIndexes(argRanges[ix], criteria[ix], null);
+                var indexes = GetMatchIndexes(argRanges[ix], criteria[ix], ctx);
                 matchIndexes = matchIndexes.Intersect(indexes);
             }
 
             return matchIndexes;
         }
 
+        protected void GetFilteredValueRange(
+            ParsingContext context, 
+            IRangeInfo valueRange, 
+            List<RangeOrValue> argRanges,
+            List<RangeOrValue> criterias,
+            int row,
+            int col,
+            out List<int> matchIndexes,
+            out List<object> flattenedRange,
+            bool convertNumericString = true)
+        {
+            matchIndexes = GetMatchIndexes(argRanges[0], GetCriteriaValue(criterias[0], row, col), context, convertNumericString);
+
+            if (argRanges.Count > 1)
+            {
+                var hashSet = new HashSet<int>(matchIndexes);
+                for (var ix = 1; ix < argRanges.Count && hashSet.Count > 0; ix++)
+                {
+                    var indexes = GetMatchIndexes(argRanges[ix], GetCriteriaValue(criterias[ix], row, col), context, convertNumericString);
+                    hashSet.IntersectWith(indexes);
+                }
+                matchIndexes = hashSet.ToList();
+            }
+
+            // Try to get flattened range from cache only if it doesn't have formulas
+            var valueAddress = valueRange.Address;
+            if (valueAddress != null && !valueAddress.HasFormulas(context.Package))
+            {
+                flattenedRange = context.RangeCriteriaCache?.GetFlattenedRange(valueAddress);
+                if (flattenedRange == null)
+                {
+                    // Not in cache, flatten and cache it
+                    flattenedRange = RangeFlattener.FlattenRangeObject(valueRange);
+                    context.RangeCriteriaCache?.SetFlattenedRange(valueAddress, flattenedRange);
+                }
+            }
+            else
+            {
+                // Has formulas or no address - don't cache, always flatten fresh
+                flattenedRange = RangeFlattener.FlattenRangeObject(valueRange);
+            }
+        }
     }
 }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/RangeCriteriaFunction.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/RangeCriteriaFunction.cs
@@ -269,7 +269,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
 
             return addresses;
         }
-        protected IEnumerable<int> GetMatchingIndicesFromArguments(int argStartIx, IList<CompileResult> args, ParsingContext ctx, int maxIndex = 31)
+        protected IEnumerable<int> GetMatchingIndicesFromArguments(int argStartIx, IList<CompileResult> args, ParsingContext ctx, int maxIndex = 31, bool convertNumericStrings = true)
         {
             //Return the addresses matching the criteria in the queue
             var argRanges = new List<RangeOrValue>();
@@ -296,11 +296,11 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
                     criteria.Add(new RangeOrValue { Value = args[ix + 1].ResultValue });
                 }
             }
-            IEnumerable<int> matchIndexes = GetMatchIndexes(argRanges[0], criteria[0], ctx);
+            IEnumerable<int> matchIndexes = GetMatchIndexes(argRanges[0], criteria[0], ctx, convertNumericStrings);
             var enumerable = matchIndexes as IList<int> ?? matchIndexes.ToList();
             for (var ix = 1; ix < argRanges.Count && enumerable.Any(); ix++)
             {
-                var indexes = GetMatchIndexes(argRanges[ix], criteria[ix], ctx);
+                var indexes = GetMatchIndexes(argRanges[ix], criteria[ix], ctx, convertNumericStrings);
                 matchIndexes = matchIndexes.Intersect(indexes);
             }
 

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/SumIf.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/SumIf.cs
@@ -41,14 +41,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
         {
             config.SetArrayParameterIndexes(1);
         }
-        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ref Queue<FormulaRangeAddress> addresses)
+        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ParsingContext ctx, ref Queue<FormulaRangeAddress> addresses)
         {
             if(index == 2)
             {
                 if (args[0].Result is IRangeInfo criteriaRange && args[2].Result is IRangeInfo valueRange)
                 {
                     var rv = new RangeOrValue { Range = criteriaRange };                    
-                    var  mi=GetMatchIndexes(rv, args[1].Result, null);
+                    var  mi=GetMatchIndexes(rv, args[1].Result, ctx);
                     addresses = EnqueueMatchingAddresses(valueRange, mi, ref addresses);
                 }
             }

--- a/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/SumIfs.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/MathFunctions/SumIfs.cs
@@ -21,6 +21,7 @@ using OfficeOpenXml.Utils.TypeConversion;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
 using OfficeOpenXml.FormulaParsing.Ranges;
 using OfficeOpenXml.Utils;
+using System.Diagnostics;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
 {
@@ -49,34 +50,36 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             {
                 return FunctionParameterInformation.IgnoreErrorInPreExecute;
             }
-            else if(argumentIndex==1)
+            else if (argumentIndex == 1)
             {
                 return FunctionParameterInformation.Normal;
             }
             return FunctionParameterInformation.AdjustParameterAddress;
         }));
-        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ref Queue<FormulaRangeAddress> addresses)
+
+        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ParsingContext ctx, ref Queue<FormulaRangeAddress> addresses)
         {
             if (index == 0 && args[0].Result is IRangeInfo valueRange)
             {
-                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args);
+                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args, ctx);
                 addresses = EnqueueMatchingAddresses(valueRange, matchIndexes, ref addresses);
             }
-            else if(args[index].Result is IRangeInfo criteriaRange)
+            else if (args[index].Result is IRangeInfo criteriaRange)
             {
-                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args, index);
+                IEnumerable<int> matchIndexes = GetMatchingIndicesFromArguments(1, args, ctx, index);
                 addresses = EnqueueMatchingAddresses(criteriaRange, matchIndexes, ref addresses);
             }
         }
 
         public override CompileResult Execute(IList<FunctionArgument> arguments, ParsingContext context)
         {
-            var valueRange = arguments[0].ValueAsRangeInfo;           
+            var valueRange = arguments[0].ValueAsRangeInfo;
             GetArguments(context, arguments, out List<RangeOrValue> argRanges, out List<RangeOrValue> criteria, out int cols, out int rows, 1);
-            
+
             if (cols == 1 && rows == 1)
             {
                 var result = GetSumValue(context, valueRange, argRanges, criteria, 0, 0, out ExcelErrorValue ev);
+
                 if (double.IsNaN(result) && ev != null)
                 {
                     return CreateResult(ev, DataType.ExcelError);
@@ -108,16 +111,12 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions
             }
         }
 
+
         private double GetSumValue(ParsingContext context, IRangeInfo valueRange, List<RangeOrValue> argRanges, List<RangeOrValue> criterias, int row, int col, out ExcelErrorValue ev)
         {
-            IEnumerable<int> matchIndexes = GetMatchIndexes(argRanges[0], GetCriteriaValue(criterias[0], row, col), context);
-            var enumerable = matchIndexes as IList<int> ?? matchIndexes.ToList();
-            for (var ix = 1; ix < argRanges.Count && enumerable.Any(); ix++)
-            {
-                var indexes = GetMatchIndexes(argRanges[ix], GetCriteriaValue(criterias[ix], row, col), context);
-                matchIndexes = matchIndexes.Intersect(indexes);
-            }
-            var sumRange = RangeFlattener.FlattenRangeObject(valueRange);
+
+            GetFilteredValueRange(context, valueRange, argRanges, criterias, row, col, out List<int> matchIndexes, out List<object> sumRange);
+
             KahanSum result = 0d;
             foreach (var index in matchIndexes)
             {

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/HLookup.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/HLookup.cs
@@ -83,7 +83,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             }
             return CompileResultFactory.Create(lookupRange.GetOffset(lookupIndex - 1, index));
         }
-        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ref Queue<FormulaRangeAddress> addresses)
+        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ParsingContext ctx, ref Queue<FormulaRangeAddress> addresses)
         {
             if (args.Count > 2)
             {

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/VLookup.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/VLookup.cs
@@ -97,7 +97,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             }
             return CompileResultFactory.Create(lookupRange.GetOffset(index, lookupIndex - 1));            
         }
-        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ref Queue<FormulaRangeAddress> addresses)
+        public override void GetNewParameterAddress(IList<CompileResult> args, int index, ParsingContext ctx, ref Queue<FormulaRangeAddress> addresses)
         {
             if (args.Count > 2)
             {

--- a/src/EPPlus/FormulaParsing/FormulaExpressions/FunctionExpression.cs
+++ b/src/EPPlus/FormulaParsing/FormulaExpressions/FunctionExpression.cs
@@ -116,7 +116,7 @@ namespace OfficeOpenXml.FormulaParsing.FormulaExpressions
         }
         protected IList<CompileResult> _args=null;
         internal Queue<FormulaRangeAddress> _dependencyAddresses = null;
-        internal bool SetArguments(IList<CompileResult> argsResults)
+        internal bool SetArguments(IList<CompileResult> argsResults, ParsingContext ctx)
         {
             _args = argsResults;
             if (_function.ParametersInfo.HasNormalArguments == false)
@@ -126,7 +126,7 @@ namespace OfficeOpenXml.FormulaParsing.FormulaExpressions
                     var pi = _function.ParametersInfo.GetParameterInfo(i);
                     if (EnumUtil.HasFlag(pi, FunctionParameterInformation.AdjustParameterAddress) && argsResults[i].Address != null)
                     {
-                        _function.GetNewParameterAddress(argsResults, i, ref _dependencyAddresses);
+                        _function.GetNewParameterAddress(argsResults, i, ctx, ref _dependencyAddresses);
                     }
                 }
                 return _dependencyAddresses != null;

--- a/src/EPPlus/FormulaParsing/LexicalAnalysis/FormulaAddress.cs
+++ b/src/EPPlus/FormulaParsing/LexicalAnalysis/FormulaAddress.cs
@@ -697,6 +697,51 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
                 return FromRow == ToRow && FromCol == ToCol;
             }
         }
+
+
+        private bool? _hasFormulas; // Nullable for lazy evaluation
+
+        /// <summary>
+        /// Returns true of the address contains formulas. 
+        /// This is used to determine if we can use cached flattened ranges or if we need to evaluate 
+        /// the formulas in the range to get the correct values. The result is cached for performance.
+        /// </summary>
+        /// <param name="package">The <see cref="ExcelPackage"/> that contains the address</param>
+        /// <returns></returns>
+        public bool HasFormulas(ExcelPackage package)
+        {
+            if (_hasFormulas.HasValue) return _hasFormulas.Value;
+
+            if (package == null || WorksheetIx < 0)
+            {
+                _hasFormulas = false;
+                return false;
+            }
+
+            var ws = package.Workbook.GetWorksheetByIndexInList(WorksheetIx);
+            if (ws == null)
+            {
+                _hasFormulas = false;
+                return false;
+            }
+
+            // Check if range contains formulas
+            for (var row = FromRow; row <= ToRow; row++)
+            {
+                for (var col = FromCol; col <= ToCol; col++)
+                {
+                    if (ws._formulas.GetValue(row, col) != null)
+                    {
+                        _hasFormulas = true;
+                        return true;
+                    }
+                }
+            }
+
+            _hasFormulas = false;
+            return false;
+        }
+
         /// <summary>
         /// Empty
         /// </summary>

--- a/src/EPPlus/FormulaParsing/ParsingContext.cs
+++ b/src/EPPlus/FormulaParsing/ParsingContext.cs
@@ -20,6 +20,8 @@ using System.Collections.Generic;
 using NvProvider = OfficeOpenXml.FormulaParsing.NameValueProvider;
 using OfficeOpenXml.Utils.RemoteCalls;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions.VariableStorage;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
+
 
 
 #if (!NET35)
@@ -33,9 +35,11 @@ namespace OfficeOpenXml.FormulaParsing
     /// </summary>
     public class ParsingContext 
     {
-        private ParsingContext(ExcelPackage package) {
+        private ParsingContext(ExcelPackage package) 
+        {
             SubtotalAddresses = new HashSet<ulong>();
             Package = package;
+            ExpressionEvaluator = new ExpressionEvaluator(this);
         }
 
         internal FunctionCompilerFactory FunctionCompilerFactory
@@ -104,6 +108,13 @@ namespace OfficeOpenXml.FormulaParsing
         }
 
         /// <summary>
+        /// Cache for RangeCriteria functions to improve performance during calculation
+        /// </summary>
+        internal RangeCriteriaCache RangeCriteriaCache { get; set; }
+
+        internal ExpressionEvaluator ExpressionEvaluator { get; private set; }
+
+        /// <summary>
         /// Factory method.
         /// </summary>
         /// <param name="package">The ExcelPackage where calculation is done</param>
@@ -116,6 +127,7 @@ namespace OfficeOpenXml.FormulaParsing
             //context.AddressCache = new ExcelAddressCache();
             context.NameValueProvider = NvProvider.Empty;
             context.FunctionCompilerFactory = new FunctionCompilerFactory(context.Configuration.FunctionRepository);
+            context.RangeCriteriaCache = new RangeCriteriaCache(package);
             return context;
         }
 

--- a/src/EPPlus/FormulaParsing/ParsingContext.cs
+++ b/src/EPPlus/FormulaParsing/ParsingContext.cs
@@ -123,8 +123,6 @@ namespace OfficeOpenXml.FormulaParsing
         {
             var context = new ParsingContext(package);
             context.Configuration = ParsingConfiguration.Create();
-            //context.Scopes = new ParsingScopes(context);
-            //context.AddressCache = new ExcelAddressCache();
             context.NameValueProvider = NvProvider.Empty;
             context.FunctionCompilerFactory = new FunctionCompilerFactory(context.Configuration.FunctionRepository);
             context.RangeCriteriaCache = new RangeCriteriaCache(package);

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/AverageIfsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/AverageIfsTests.cs
@@ -17,15 +17,15 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
             using (var package = new ExcelPackage())
             {
                 var sheet = package.Workbook.Worksheets.Add("test");
-                sheet.Cells[1, 1].Value = 3;
-                sheet.Cells[2, 1].Value = 4;
-                sheet.Cells[3, 1].Value = 5;
-                sheet.Cells[1, 2].Value = 1;
-                sheet.Cells[2, 2].Value = "2";
-                sheet.Cells[3, 2].Value = 3;
-                sheet.Cells[1, 3].Value = 2;
-                sheet.Cells[2, 3].Value = 1;
-                sheet.Cells[3, 3].Value = "4";
+                sheet.Cells["A1"].Value = 3;
+                sheet.Cells["A2"].Value = 4;
+                sheet.Cells["A3"].Value = 5;
+                sheet.Cells["B1"].Value = 1;
+                sheet.Cells["B2"].Value = "2";
+                sheet.Cells["B3"].Value = 3;
+                sheet.Cells["C1"].Value = 2;
+                sheet.Cells["C2"].Value = 1;
+                sheet.Cells["C3"].Value = "4";
 
                 sheet.Cells[4, 1].Formula = "AVERAGEIFS(A1:A3,B1:B3,\">0\",C1:C3,\">1\")";
                 sheet.Calculate();

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/CriteriaRangeFunctionsTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/MathFunctions/CriteriaRangeFunctionsTests.cs
@@ -36,5 +36,49 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.MathFunctions
             Assert.AreEqual(10.5D, ws.Cells["C7"].Value);
             SaveAndCleanup(p);
         }
+
+
+        [TestMethod]
+        public void AverageIfsShouldNotCacheWhenValueRangeHasFormulas()
+        {
+            using var p = new ExcelPackage();
+            var ws = p.Workbook.Worksheets.Add("Sheet1");
+            ws.Cells["A1"].Value = "Fruit";
+            ws.Cells["B1"].Value = "Employee";
+            ws.Cells["A2:A3"].Value = "Apples";
+            ws.Cells["A4:A5"].Value = "Artichokes";
+            ws.Cells["A6:A7"].Value = "Bananas";
+            ws.Cells["A8:A9"].Value = "Carrots";
+            ws.Cells["B2,B4,B8"].Value = "Mats";
+            ws.Cells["B3,B5,B9"].Value = "Jan";
+            ws.Cells["B6,B7"].Value = "Ossian";  // Both B6 and B7 are Ossian
+
+            // C2, C3 have values
+            ws.Cells["C2"].Value = 10D;
+            ws.Cells["C3"].Value = 11D;
+
+            // C4 and C5 have formulas that reference C2:C9 (circular reference scenario)
+            ws.Cells["C4"].Formula = "AVERAGEIFS(C2:C9,A2:A9,\"=B*\",B2:B9,\"Ossian\")";
+            ws.Cells["C5"].Formula = "AVERAGEIFS(C2:C9,A2:A9,\"=A*\",B2:B9,\"Mats\")";
+
+            ws.Cells["C6"].Value = 12D;
+            ws.Cells["C7"].Value = 13D;
+            ws.Cells["C8"].Value = 14D;
+            ws.Cells["C9"].Value = 15D;
+
+            ws.Calculate();
+
+            // C4 = AVERAGEIFS(C2:C9, A2:A9, "=B*", B2:B9, "Ossian")
+            // Matches: A6="Bananas" (B*), B6="Ossian" -> C6=12
+            //          A7="Bananas" (B*), B7="Ossian" -> C7=13
+            // Average = (12+13)/2 = 12.5
+            Assert.AreEqual(12.5D, ws.Cells["C4"].Value, "C4 should be 12.5");
+
+            // C5 = AVERAGEIFS(C2:C9, A2:A9, "=A*", B2:B9, "Mats")
+            // Matches: A2="Apples" (A*), B2="Mats" -> C2=10
+            //          A4="Artichokes" (A*), B4="Mats" -> C4=12.5 (calculated earlier!)
+            // Average = (10+12.5)/2 = 11.25
+            Assert.AreEqual(11.25D, ws.Cells["C5"].Value, "C5 should be 11.25 (including calculated C4 value)");
+        }
     }
 }

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/RangeCriteriaCacheTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/RangeCriteriaCacheTests.cs
@@ -1,0 +1,228 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
+using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
+using System.Collections.Generic;
+
+namespace EPPlusTest.FormulaParsing.Excel.Functions
+{
+    [TestClass]
+    public class RangeCriteriaCacheTests
+    {
+        private ExcelPackage _package;
+        private RangeCriteriaCache _cache;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _package = new ExcelPackage();
+            _package.Workbook.Worksheets.Add("Sheet1");
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _package?.Dispose();
+        }
+
+        [TestMethod]
+        public void FlattenedRange_ShouldCacheAndRetrieve()
+        {
+            _cache = new RangeCriteriaCache(_package);
+            var address = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 1, FromCol = 1, ToRow = 10, ToCol = 1 };
+            var data = new List<object> { 1, 2, 3, 4, 5 };
+
+            _cache.SetFlattenedRange(address, data);
+            var retrieved = _cache.GetFlattenedRange(address);
+
+            Assert.IsNotNull(retrieved);
+            Assert.AreEqual(5, retrieved.Count);
+            Assert.AreEqual(1, retrieved[0]);
+        }
+
+        [TestMethod]
+        public void FlattenedRange_FIFO_ShouldEvictOldest()
+        {
+            _cache = new RangeCriteriaCache(_package, maxFlattenedRanges: 3);
+
+            var address1 = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 1, FromCol = 1, ToRow = 10, ToCol = 1 };
+            var address2 = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 11, FromCol = 1, ToRow = 20, ToCol = 1 };
+            var address3 = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 21, FromCol = 1, ToRow = 30, ToCol = 1 };
+            var address4 = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 31, FromCol = 1, ToRow = 40, ToCol = 1 };
+
+            var data1 = new List<object> { 1 };
+            var data2 = new List<object> { 2 };
+            var data3 = new List<object> { 3 };
+            var data4 = new List<object> { 4 };
+
+            _cache.SetFlattenedRange(address1, data1);
+            _cache.SetFlattenedRange(address2, data2);
+            _cache.SetFlattenedRange(address3, data3);
+
+            // Cache is now full (3/3)
+            Assert.IsNotNull(_cache.GetFlattenedRange(address1), "Address1 should be in cache");
+            Assert.IsNotNull(_cache.GetFlattenedRange(address2), "Address2 should be in cache");
+            Assert.IsNotNull(_cache.GetFlattenedRange(address3), "Address3 should be in cache");
+
+            // Adding 4th item should evict the oldest (address1)
+            _cache.SetFlattenedRange(address4, data4);
+
+            Assert.IsNull(_cache.GetFlattenedRange(address1), "Address1 should be evicted (oldest)");
+            Assert.IsNotNull(_cache.GetFlattenedRange(address2), "Address2 should still be in cache");
+            Assert.IsNotNull(_cache.GetFlattenedRange(address3), "Address3 should still be in cache");
+            Assert.IsNotNull(_cache.GetFlattenedRange(address4), "Address4 should be in cache");
+        }
+
+        [TestMethod]
+        public void MatchIndexes_ShouldCacheAndRetrieve()
+        {
+            _cache = new RangeCriteriaCache(_package);
+            var address = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 1, FromCol = 1, ToRow = 10, ToCol = 1 };
+            var criteria = "test";
+            var indexes = new List<int> { 1, 3, 5, 7 };
+
+            _cache.SetMatchIndexes(address, criteria, indexes);
+            var retrieved = _cache.GetMatchIndexes(address, criteria);
+
+            Assert.IsNotNull(retrieved);
+            Assert.AreEqual(4, retrieved.Count);
+            Assert.AreEqual(1, retrieved[0]);
+            Assert.AreEqual(7, retrieved[3]);
+        }
+
+        [TestMethod]
+        public void MatchIndexes_FIFO_ShouldEvictOldest()
+        {
+            _cache = new RangeCriteriaCache(_package, maxMatchIndexes: 3);
+
+            var address = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 1, FromCol = 1, ToRow = 10, ToCol = 1 };
+            var criteria1 = "A";
+            var criteria2 = "B";
+            var criteria3 = "C";
+            var criteria4 = "D";
+
+            var indexes1 = new List<int> { 1 };
+            var indexes2 = new List<int> { 2 };
+            var indexes3 = new List<int> { 3 };
+            var indexes4 = new List<int> { 4 };
+
+            _cache.SetMatchIndexes(address, criteria1, indexes1);
+            _cache.SetMatchIndexes(address, criteria2, indexes2);
+            _cache.SetMatchIndexes(address, criteria3, indexes3);
+
+            // Cache is now full (3/3)
+            Assert.IsNotNull(_cache.GetMatchIndexes(address, criteria1), "Criteria1 should be in cache");
+            Assert.IsNotNull(_cache.GetMatchIndexes(address, criteria2), "Criteria2 should be in cache");
+            Assert.IsNotNull(_cache.GetMatchIndexes(address, criteria3), "Criteria3 should be in cache");
+
+            // Adding 4th item should evict the oldest (criteria1)
+            _cache.SetMatchIndexes(address, criteria4, indexes4);
+
+            Assert.IsNull(_cache.GetMatchIndexes(address, criteria1), "Criteria1 should be evicted (oldest)");
+            Assert.IsNotNull(_cache.GetMatchIndexes(address, criteria2), "Criteria2 should still be in cache");
+            Assert.IsNotNull(_cache.GetMatchIndexes(address, criteria3), "Criteria3 should still be in cache");
+            Assert.IsNotNull(_cache.GetMatchIndexes(address, criteria4), "Criteria4 should be in cache");
+        }
+
+        [TestMethod]
+        public void MatchIndexes_WithFormulas_ShouldNotCache()
+        {
+            var ws = _package.Workbook.Worksheets[0];
+            ws.Cells["A1"].Formula = "=1+1";
+            ws.Cells["A2"].Value = 2;
+
+            _cache = new RangeCriteriaCache(_package);
+            var address = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 1, FromCol = 1, ToRow = 2, ToCol = 1 };
+            var criteria = "test";
+            var indexes = new List<int> { 1 };
+
+            _cache.SetMatchIndexes(address, criteria, indexes);
+
+            // Should not cache because range has formulas
+            var retrieved = _cache.GetMatchIndexes(address, criteria);
+            Assert.IsNull(retrieved, "Should not cache ranges with formulas");
+        }
+
+        [TestMethod]
+        public void MatchIndexes_DifferentCriteria_SamRange_ShouldCacheSeparately()
+        {
+            _cache = new RangeCriteriaCache(_package);
+            var address = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 1, FromCol = 1, ToRow = 10, ToCol = 1 };
+
+            var indexes1 = new List<int> { 1, 2 };
+            var indexes2 = new List<int> { 3, 4 };
+
+            _cache.SetMatchIndexes(address, "criteriaA", indexes1);
+            _cache.SetMatchIndexes(address, "criteriaB", indexes2);
+
+            var retrieved1 = _cache.GetMatchIndexes(address, "criteriaA");
+            var retrieved2 = _cache.GetMatchIndexes(address, "criteriaB");
+
+            Assert.IsNotNull(retrieved1);
+            Assert.IsNotNull(retrieved2);
+            Assert.AreEqual(2, retrieved1.Count);
+            Assert.AreEqual(2, retrieved2.Count);
+            Assert.AreEqual(1, retrieved1[0]);
+            Assert.AreEqual(3, retrieved2[0]);
+        }
+
+        [TestMethod]
+        public void Clear_ShouldRemoveAllCachedData()
+        {
+            _cache = new RangeCriteriaCache(_package);
+            var address = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 1, FromCol = 1, ToRow = 10, ToCol = 1 };
+
+            _cache.SetFlattenedRange(address, new List<object> { 1, 2, 3 });
+            _cache.SetMatchIndexes(address, "test", new List<int> { 1, 2 });
+
+            Assert.IsNotNull(_cache.GetFlattenedRange(address));
+            Assert.IsNotNull(_cache.GetMatchIndexes(address, "test"));
+
+            _cache.Clear();
+
+            Assert.IsNull(_cache.GetFlattenedRange(address));
+            Assert.IsNull(_cache.GetMatchIndexes(address, "test"));
+        }
+
+        [TestMethod]
+        public void FlattenedRange_UpdateExisting_ShouldNotDuplicate()
+        {
+            _cache = new RangeCriteriaCache(_package, maxFlattenedRanges: 2);
+            var address = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 1, FromCol = 1, ToRow = 10, ToCol = 1 };
+
+            var data1 = new List<object> { 1, 2, 3 };
+            var data2 = new List<object> { 4, 5, 6 };
+
+            // Add same address twice with different data
+            _cache.SetFlattenedRange(address, data1);
+            _cache.SetFlattenedRange(address, data2);
+
+            var retrieved = _cache.GetFlattenedRange(address);
+
+            // Should have updated value, not duplicated
+            Assert.IsNotNull(retrieved);
+            Assert.AreEqual(4, retrieved[0], "Should have updated data");
+        }
+
+        [TestMethod]
+        public void MatchIndexes_UpdateExisting_ShouldNotDuplicate()
+        {
+            _cache = new RangeCriteriaCache(_package, maxMatchIndexes: 2);
+            var address = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 1, FromCol = 1, ToRow = 10, ToCol = 1 };
+            var criteria = "test";
+
+            var indexes1 = new List<int> { 1, 2 };
+            var indexes2 = new List<int> { 3, 4 };
+
+            // Add same address+criteria twice with different data
+            _cache.SetMatchIndexes(address, criteria, indexes1);
+            _cache.SetMatchIndexes(address, criteria, indexes2);
+
+            var retrieved = _cache.GetMatchIndexes(address, criteria);
+
+            // Should have updated value, not duplicated
+            Assert.IsNotNull(retrieved);
+            Assert.AreEqual(3, retrieved[0], "Should have updated indexes");
+        }
+    }
+}

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/RangeCriteriaCacheTests.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/RangeCriteriaCacheTests.cs
@@ -16,6 +16,8 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions
         public void Setup()
         {
             _package = new ExcelPackage();
+            _package.Settings.CalculationCacheSettings.MaxFlattenedRanges = RangeCriteriaCache.DEFAULT_MAX_FLATTENED_RANGES;
+            _package.Settings.CalculationCacheSettings.MaxMatchIndexes = RangeCriteriaCache.DEFAULT_MAX_MATCH_INDEXES;
             _package.Workbook.Worksheets.Add("Sheet1");
         }
 
@@ -43,7 +45,8 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions
         [TestMethod]
         public void FlattenedRange_FIFO_ShouldEvictOldest()
         {
-            _cache = new RangeCriteriaCache(_package, maxFlattenedRanges: 3);
+            _package.Settings.CalculationCacheSettings.MaxFlattenedRanges = 3;
+            _cache = new RangeCriteriaCache(_package);
 
             var address1 = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 1, FromCol = 1, ToRow = 10, ToCol = 1 };
             var address2 = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 11, FromCol = 1, ToRow = 20, ToCol = 1 };
@@ -93,7 +96,8 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions
         [TestMethod]
         public void MatchIndexes_FIFO_ShouldEvictOldest()
         {
-            _cache = new RangeCriteriaCache(_package, maxMatchIndexes: 3);
+            _package.Settings.CalculationCacheSettings.MaxMatchIndexes = 3;
+            _cache = new RangeCriteriaCache(_package);
 
             var address = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 1, FromCol = 1, ToRow = 10, ToCol = 1 };
             var criteria1 = "A";
@@ -187,7 +191,8 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions
         [TestMethod]
         public void FlattenedRange_UpdateExisting_ShouldNotDuplicate()
         {
-            _cache = new RangeCriteriaCache(_package, maxFlattenedRanges: 2);
+            _package.Settings.CalculationCacheSettings.MaxFlattenedRanges = 2;
+            _cache = new RangeCriteriaCache(_package);
             var address = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 1, FromCol = 1, ToRow = 10, ToCol = 1 };
 
             var data1 = new List<object> { 1, 2, 3 };
@@ -207,7 +212,8 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions
         [TestMethod]
         public void MatchIndexes_UpdateExisting_ShouldNotDuplicate()
         {
-            _cache = new RangeCriteriaCache(_package, maxMatchIndexes: 2);
+            _package.Settings.CalculationCacheSettings.MaxMatchIndexes = 2;
+            _cache = new RangeCriteriaCache(_package);
             var address = new FormulaRangeAddress { WorksheetIx = 0, FromRow = 1, FromCol = 1, ToRow = 10, ToCol = 1 };
             var criteria = "test";
 


### PR DESCRIPTION
## Performance Optimization for SUMIFS, AVERAGEIFS, and COUNTIFS

### Problem
The *IFS functions (SUMIFS, AVERAGEIFS, COUNTIFS) were experiencing severe performance issues when processing large datasets with multiple criteria. A test with 10,000 identical formulas took 42.9 seconds to calculate.

### Root Cause Analysis
- **RangeFlattener.FlattenRangeObject** was called 10,000 times for the same value range
- **GetMatchIndexes** performed 100 million cell evaluations (10,000 formulas × 10,000 cells)
- No caching between identical criteria evaluations
- LINQ `Intersect` was less efficient than HashSet operations for multi-criteria filtering

### Solution
Implemented a **calculation-scoped cache** in `ParsingContext` via new `RangeCriteriaCache` class:

1. **Flattened Range Cache**: Value ranges are flattened once and cached for reuse across multiple formulas
2. **Match Indexes Cache**: Criteria evaluation results are cached by (range address + criteria value) key
3. **Formula Detection**: Ranges containing formulas are excluded from caching to handle circular references correctly
4. **FIFO Eviction**: Memory-bounded cache with configurable limits (default: 100 flattened ranges, 1000 match indexes)
5. **Integer Keys**: Using int-based cache keys instead of strings for faster lookups

Additional optimizations:
- HashSet.IntersectWith for multi-criteria instead of LINQ Intersect
- ExpressionEvaluator singleton per calculation
- Lazy evaluation of FormulaRangeAddress.HasFormulas with caching
- Refactored common logic into `GetFilteredValueRange` helper method

### Configuration
Added new `ExcelCalculationCacheSettings` class accessible via `ExcelPackage.Settings.CalculationCacheSettings`:
- **MaxFlattenedRanges** (default: 100) - Maximum number of flattened ranges to cache. Set to 0 to disable.
- **MaxMatchIndexes** (default: 1000) - Maximum number of match indexes to cache. Set to 0 to disable.

Users can adjust these settings for optimal performance based on their workload:
```csharp
var package = new ExcelPackage();
package.Settings.CalculationCacheSettings.MaxFlattenedRanges = 200;
package.Settings.CalculationCacheSettings.MaxMatchIndexes = 2000;
```

The cache automatically handles capacity reductions by evicting oldest entries when settings are changed between calculations.

### Results
- **10 unique criteria (realistic)**: 42.9s → 7.6s (**82% faster**)
- **Identical criteria (optimal)**: 42.9s → 4.4s (**90% faster**)
- All 6,214 unit tests pass
- Correctly handles circular references and edge cases

### Breaking Changes
None - fully backward compatible

Fixes #2266