### PR TITLE
#2288 - Fix calculated field computation in pivot tables

### DIFF
--- a/src/EPPlus/Drawing/Chart/ExcelChart.cs
+++ b/src/EPPlus/Drawing/Chart/ExcelChart.cs
@@ -17,6 +17,7 @@ using OfficeOpenXml.Drawing.Style.Effect;
 using OfficeOpenXml.Drawing.Style.ThreeD;
 using OfficeOpenXml.Packaging;
 using OfficeOpenXml.Style;
+
 using OfficeOpenXml.Table.PivotTable;
 using OfficeOpenXml.Utils.FileUtils;
 using System;

--- a/src/EPPlus/Table/PivotTable/Calculation/PivotTableCalculation.cs
+++ b/src/EPPlus/Table/PivotTable/Calculation/PivotTableCalculation.cs
@@ -57,47 +57,50 @@ namespace OfficeOpenXml.Table.PivotTable
 		};
         internal static bool Calculate(ExcelPivotTable pivotTable, out List<PivotCalculationStore> calculatedItems, out List<Dictionary<int[], HashSet<int[]>>> keys)
         {
-			calculatedItems = new List<PivotCalculationStore>();
-			keys = new List<Dictionary<int[], HashSet<int[]>>>();
+            calculatedItems = new List<PivotCalculationStore>();
+            keys = new List<Dictionary<int[], HashSet<int[]>>>();
             var fieldIndex = pivotTable.RowColumnFieldIndicies;
-			pivotTable.InitCalculation();
-			int dfIx = 0;
-			bool hasCalculatedField = false;
-			foreach(var df in pivotTable.GetFieldsToCalculate())
+            pivotTable.InitCalculation();
+            int dfIx = 0;
+            bool hasCalculatedField = false;
+
+
+            foreach (var df in pivotTable.GetFieldsToCalculate())
             {
-				var dataFieldItems = new PivotCalculationStore();
-				calculatedItems.Add(dataFieldItems);
-				var keyDict = PivotTableCalculation.GetNewKeys();
-				keys.Add(keyDict);
-				if (string.IsNullOrEmpty(df.Field.Cache.Formula))
-				{
-					CalculateField(pivotTable, calculatedItems[calculatedItems.Count - 1], keys, df.Field.Cache, df.Function);
+                var dataFieldItems = new PivotCalculationStore();
+                calculatedItems.Add(dataFieldItems);
+                var keyDict = PivotTableCalculation.GetNewKeys();
+                keys.Add(keyDict);
+
+                if (string.IsNullOrEmpty(df.Field.Cache.Formula))
+                {
+                    CalculateField(pivotTable, calculatedItems[calculatedItems.Count - 1], keys, df.Field.Cache, df.Function);
+
                     SetRowColumnsItemsToHashSets(pivotTable);
 
                     if (df.ShowDataAs.Value != eShowDataAs.Normal)
-					{
-						_calculateShowAs[df.ShowDataAs.Value].Calculate(df, fieldIndex, keys[dfIx], ref dataFieldItems);
-						calculatedItems[dfIx] = dataFieldItems;
-					}
-				}
-				else
-				{
-					hasCalculatedField=true;
-				}
-				dfIx++;
-			}
+                    {
+                        _calculateShowAs[df.ShowDataAs.Value].Calculate(df, fieldIndex, keys[dfIx], ref dataFieldItems);
+                        calculatedItems[dfIx] = dataFieldItems;
+                    }
+                }
+                else
+                {
+                    hasCalculatedField = true;
+                }
+                dfIx++;
+            }
 
-			CalculateRowColumnSubtotals(pivotTable, keys);
+            CalculateRowColumnSubtotals(pivotTable, keys);
 
             //Handle Calculated fields after the pivot table fields has been calculated.
-			if (hasCalculatedField)
-			{
-				CalculateSourceFields(pivotTable);
-				var ptCalc = new PivotTableColumnCalculation(pivotTable);
-				ptCalc.CalculateFormulaFields(fieldIndex);
-			}
-
-			return true;
+            if (hasCalculatedField)
+            {
+                CalculateSourceFields(pivotTable);
+                var ptCalc = new PivotTableColumnCalculation(pivotTable);
+                ptCalc.CalculateFormulaFields(fieldIndex);
+            }
+            return true;
         }
 
         private static void CalculateRowColumnSubtotals(ExcelPivotTable pivotTable, List<Dictionary<int[], HashSet<int[]>>> keys)
@@ -188,44 +191,98 @@ namespace OfficeOpenXml.Table.PivotTable
         }
 
         private static void CalculateSourceFields(ExcelPivotTable pivotTable)
-		{
-			var keys = new List<Dictionary<int[], HashSet<int[]>>>();
-			var calcFields = new Dictionary<string, PivotCalculationStore>(StringComparer.InvariantCultureIgnoreCase);
-			foreach(var field in pivotTable.Fields.Where(x=>string.IsNullOrEmpty(x.Cache.Formula)==false).Select(x=>x.Cache))
-			{ 
-				foreach(var token in field.FormulaTokens)
-				{
-					if(token.TokenType==TokenType.PivotField && calcFields.ContainsKey(token.Value)==false)
-					{
-						if(!GetSumCalcItems(pivotTable, token.Value, out PivotCalculationStore store))
-						{
-                            var keyDict = PivotTableCalculation.GetNewKeys();
-							keys.Add(keyDict);
-							store = new PivotCalculationStore();
-							CalculateField(pivotTable, store, keys, pivotTable.Fields[token.Value].Cache, DataFieldFunctions.Sum);
-						}
-						calcFields.Add(token.Value, store);
-					}
-				}
-			}
-			pivotTable.CalculatedFieldReferencedItems = calcFields;
-		}
+        {
+            var keys = new List<Dictionary<int[], HashSet<int[]>>>();
+            var calcFields = new Dictionary<string, PivotCalculationStore>(
+                StringComparer.InvariantCultureIgnoreCase);
 
-		private static bool GetSumCalcItems(ExcelPivotTable pivotTable, string fieldName, out PivotCalculationStore store)
-		{
-			foreach(var ds in pivotTable.DataFields)
-			{
-				if(ds.Field!=null && ds.Field.Name.Equals(fieldName, StringComparison.InvariantCultureIgnoreCase) && ds.Function==DataFieldFunctions.Sum && ds.ShowDataAsInternal == eShowDataAs.Normal)
-				{
-					store = pivotTable.CalculatedItems[ds.Index];
-					return true;
-				}
-			}
-			store = null;
-			return false;
-		}
+            // Find calculated cache fields via DataFields (not pivotTable.Fields)
+            var calcCacheFields = new List<ExcelPivotTableCacheField>();
+            foreach (var df in pivotTable.DataFields)
+            {
+                if (!string.IsNullOrEmpty(df.Field.Cache.Formula))
+                {
+                    if (!calcCacheFields.Contains(df.Field.Cache))
+                    {
+                        calcCacheFields.Add(df.Field.Cache);
+                    }
+                }
+            }
 
-		private static void CalculateField(ExcelPivotTable pivotTable, PivotCalculationStore dataFieldItems, List<Dictionary<int[], HashSet<int[]>>> keys,  ExcelPivotTableCacheField cacheField, DataFieldFunctions function)
+            // Also check transitive dependencies: calculated fields referencing
+            // other calculated fields
+            var cacheFieldsList = pivotTable.CacheDefinition._cacheReference.Fields;
+            for (int i = 0; i < calcCacheFields.Count; i++) // Count may grow during iteration
+            {
+                var cf = calcCacheFields[i];
+                foreach (var token in cf.FormulaTokens)
+                {
+                    if (token.TokenType == TokenType.PivotField)
+                    {
+                        var refCf = cacheFieldsList.FirstOrDefault(
+                            x => x.Name.Equals(token.Value, StringComparison.InvariantCultureIgnoreCase));
+                        if (refCf != null && !string.IsNullOrEmpty(refCf.Formula)
+                            && !calcCacheFields.Contains(refCf))
+                        {
+                            calcCacheFields.Add(refCf);
+                        }
+                    }
+                }
+            }
+
+            // Now resolve each referenced source field for all calculated fields
+            foreach (var cf in calcCacheFields)
+            {
+                foreach (var token in cf.FormulaTokens)
+                {
+                    if (token.TokenType == TokenType.PivotField
+                        && !calcFields.ContainsKey(token.Value))
+                    {
+                        if (!GetSumCalcItems(pivotTable, token.Value, out PivotCalculationStore store))
+                        {
+                            // Look up via cache fields, not pivotTable.Fields
+                            var refCf = cacheFieldsList.FirstOrDefault(
+                                x => x.Name.Equals(
+                                    token.Value, StringComparison.InvariantCultureIgnoreCase));
+                            if (refCf != null && string.IsNullOrEmpty(refCf.Formula))
+                            {
+                                var keyDict = PivotTableCalculation.GetNewKeys();
+                                keys.Add(keyDict);
+                                store = new PivotCalculationStore();
+                                CalculateField(pivotTable, store, keys, refCf, DataFieldFunctions.Sum);
+                            }
+                            else
+                            {
+                                // Referenced field is itself calculated or doesn't exist —
+                                // it will be resolved during CalculateFormulaFields
+                                store = new PivotCalculationStore();
+                            }
+                        }
+                        calcFields.Add(token.Value, store);
+                    }
+                }
+            }
+            pivotTable.CalculatedFieldReferencedItems = calcFields;
+        }
+
+        private static bool GetSumCalcItems(ExcelPivotTable pivotTable, string fieldName, out PivotCalculationStore store)
+        {
+            foreach (var ds in pivotTable.DataFields)
+            {
+                if (ds.Field != null &&
+                   ds.Field.Name.Equals(fieldName, StringComparison.InvariantCultureIgnoreCase) &&
+                   ds.Function == DataFieldFunctions.Sum &&
+                   ds.ShowDataAsInternal == eShowDataAs.Normal)
+                {
+                    store = pivotTable.CalculatedItems[pivotTable.DataFields.IndexOf(ds)];
+                    return true;
+                }
+            }
+            store = null;
+            return false;
+        }
+
+        private static void CalculateField(ExcelPivotTable pivotTable, PivotCalculationStore dataFieldItems, List<Dictionary<int[], HashSet<int[]>>> keys,  ExcelPivotTableCacheField cacheField, DataFieldFunctions function)
 		{
 			var ci = pivotTable.CacheDefinition._cacheReference;
 			var recs = ci.Records;

--- a/src/EPPlus/Table/PivotTable/Calculation/PivotTableColumnCalculation.cs
+++ b/src/EPPlus/Table/PivotTable/Calculation/PivotTableColumnCalculation.cs
@@ -10,20 +10,15 @@
  *************************************************************************************************
   03/07/2024         EPPlus Software AB       EPPlus 7.2
  *************************************************************************************************/
-using OfficeOpenXml.DataValidation.Exceptions;
 using OfficeOpenXml.FormulaParsing;
 using OfficeOpenXml.FormulaParsing.Excel.Functions;
-using OfficeOpenXml.FormulaParsing.Excel.Functions.Finance;
-using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
-using OfficeOpenXml.LoadFunctions.ReflectionHelpers;
 using OfficeOpenXml.Table.PivotTable.Calculation;
 using OfficeOpenXml.Utils.TypeConversion;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Net;
 
 namespace OfficeOpenXml.Table.PivotTable
 {
@@ -40,55 +35,140 @@ namespace OfficeOpenXml.Table.PivotTable
 			_fr = _tbl.WorkSheet.Workbook.FormulaParser.ParsingContext.Configuration.FunctionRepository;
 			_calcItems = tbl.CalculatedItems;
         }
-		internal void CalculateFormulaFields(List<int> fieldIndex)
-		{
-			var calcOrder = GetCalcOrder();
-			foreach(var i in calcOrder)
-			{
-				var f = _tbl.Fields[i];
-				var tokens = f.Cache.FormulaTokens;
-				var calcTokens = GetPivotFieldReferencesInFormula(f, tokens);
-				PivotCalculationStore store;
-				if(calcTokens.Any(x => x == null))
-				{
-					//Contains invalid field reference or functions not supported in PT.
-					throw (new InvalidOperationException($"Pivot table {_tbl.Name} contains invalid column calculated formula : {f.Cache.Formula}. The formula contains an invalid field, an unsupported function or cell reference."));
+        internal void CalculateFormulaFields(List<int> fieldIndex)
+        {
+            var calcOrder = GetCalcOrder();
+            var cacheFields = _tbl.CacheDefinition._cacheReference.Fields;
+
+            foreach (var cfIndex in calcOrder)
+            {
+                var cf = cacheFields[cfIndex];
+                var tokens = cf.FormulaTokens;
+
+                // Build pivot field references from tokens
+                // (mirrors original GetPivotFieldReferencesInFormula logic, but against cache)
+                var calcTokens = new List<int[]>();
+                bool hasInvalid = false;
+                int ix = 0;
+                foreach (var t in tokens)
+                {
+                    if (t.TokenType == TokenType.PivotField)
+                    {
+                        var refCf = cacheFields.FirstOrDefault(
+                            x => x.Name.Equals(t.Value, StringComparison.InvariantCultureIgnoreCase));
+                        if (refCf != null)
+                        {
+                            calcTokens.Add(new int[] { ix });
+                        }
+                        else
+                        {
+                            hasInvalid = true;
+                            break;
+                        }
+                    }
+                    else if (t.TokenType == TokenType.Array ||
+                             t.TokenType == TokenType.CellAddress ||
+                             t.TokenType == TokenType.FullColumnAddress ||
+                             t.TokenType == TokenType.FullRowAddress ||
+                             t.TokenType == TokenType.TableName ||
+                             t.TokenType == TokenType.WorksheetName)
+                    {
+                        hasInvalid = true;
+                        break;
+                    }
+                    else if (t.TokenType == TokenType.Function)
+                    {
+                        var func = _fr.GetFunction(t.Value);
+                        if (func != null && func.IsAllowedInCalculatedPivotTableField == false)
+                        {
+                            hasInvalid = true;
+                            break;
+                        }
+                    }
+                    ix++;
+                }
+
+                PivotCalculationStore store;
+                if (hasInvalid)
+                {
+                    throw new InvalidOperationException(
+                        $"Pivot table {_tbl.Name} contains invalid column calculated formula : " +
+                        $"{cf.Formula}. The formula contains an invalid field, an unsupported " +
+                        "function or cell reference.");
                 }
                 else
-				{
-					store = CalculateField(f, tokens, calcTokens, fieldIndex);
-                }
-                if (f.IsDataField)
                 {
-                    var ix = _tbl.DataFields.IndexOf(f.DataField);
-                    _tbl.CalculatedItems[ix] = store;
+                    store = new PivotCalculationStore();
+                    var options = new ExcelCalculationOption();
+                    var depChain = new RpnOptimizedDependencyChain(_tbl.WorkSheet.Workbook, options);
+                    var ct = new List<Token>();
+                    ct.AddRange(tokens.Select(x => new Token(x.Value, x.TokenType, x.IsNegated)));
+
+                    // Collect ALL unique keys across all referenced source fields,
+                    // so we don't miss keys that only exist in some fields.
+                    var allKeys = new List<int[]>();
+                    var seenKeys = new HashSet<string>();
+                    foreach (var c in calcTokens)
+                    {
+                        var fieldName = tokens[c[0]].Value;
+                        if (_tbl.CalculatedFieldReferencedItems.TryGetValue(fieldName, out var refStore))
+                        {
+                            foreach (var k in refStore.Index)
+                            {
+                                var keyStr = string.Join(",", k.Key.Select(x => x.ToString()).ToArray());
+                                if (seenKeys.Add(keyStr))
+                                {
+                                    allKeys.Add(k.Key);
+                                }
+                            }
+                        }
+                    }
+
+                    // Calculate formula for each key combination
+                    foreach (var key in allKeys)
+                    {
+
+                        foreach (var c in calcTokens)
+                        {
+                            var fieldName = tokens[c[0]].Value;
+                            if (_tbl.CalculatedFieldReferencedItems.TryGetValue(fieldName, out var refStore)
+                                && refStore.ContainsKey(key))
+                            {
+                                ct[c[0]] = GetTokenFromValue(refStore[key]);
+                            }
+                            else
+                            {
+                                // Key doesn't exist for this field — use 0 as default
+                                // (Excel treats missing pivot values as 0 in calculated fields)
+                                ct[c[0]] = new Token("0", TokenType.Decimal);
+                            }
+                        }
+                        var cv = RpnFormulaExecution.ExecutePivotFieldFormula(depChain, ct, options);
+                        store.Add(key, cv);
+                    }
                 }
-                else
+
+                // Map back to DataField by matching the cache field.
+                // Multiple DataFields can reference the same calculated cache field
+                // (e.g. same field with different ShowDataAs), so don't break on first match.
+                bool stored = false;
+                for (int d = 0; d < _tbl.DataFields.Count; d++)
                 {
-                    _tbl.CalculatedFieldReferencedItems.Add(f.Name, store);
+                    var dfCache = _tbl.DataFields[d].Field.Cache;
+                    if (dfCache == cf ||
+                        dfCache.Name.Equals(cf.Name, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        _tbl.CalculatedItems[d] = store;
+                        stored = true;
+                    }
+                }
+                if (!stored)
+                {
+                    _tbl.CalculatedFieldReferencedItems[cf.Name] = store;
                 }
             }
         }
 
-		private PivotCalculationStore CalculateField(ExcelPivotTableField f, IList<Token> tokens, List<int[]> calcTokens, List<int> fieldIndex)
-		{
-			var store = new PivotCalculationStore();
-			var options = new ExcelCalculationOption();
-			var depChain = new RpnOptimizedDependencyChain(_tbl.WorkSheet.Workbook, options);
-			var ct = new List<Token>();
-			ct.AddRange(tokens.Select(x => new Token(x.Value, x.TokenType, x.IsNegated)));
-			foreach (var ci in _tbl.CalculatedFieldReferencedItems.First().Value.Index)
-			{
-				foreach (var c in calcTokens)
-				{
-					var v = _tbl.CalculatedFieldReferencedItems[tokens[c[0]].Value][ci.Key];
-					ct[c[0]] = GetTokenFromValue(v);
-				}
-				var cv=RpnFormulaExecution.ExecutePivotFieldFormula(depChain, ct, options);
-				store.Add(ci.Key, cv);
-			}
-			return store;
-		}
 		private Token GetTokenFromValue(object v)
 		{
 			if(ConvertUtil.IsNumericOrDate(v))
@@ -116,88 +196,67 @@ namespace OfficeOpenXml.Table.PivotTable
 			return new Token(v.ToString(),TokenType.String);
 		}
 
-		private List<int[]> GetPivotFieldReferencesInFormula(ExcelPivotTableField f, IList<Token> tokens)
-		{
-			var ret = new List<int[]>();
-			int ix = 0;
-			foreach (var t in tokens)
-			{
-				if(t.TokenType==TokenType.PivotField)
-				{
-					var ff = _tbl.Fields[t.Value];
-					if (ff == null)
-					{
-						ret.Add(null);
-						return ret;
-					}
-					else
-					{
-						ret.Add([ix, ff.Index]);
-					}
-				}
-				else if(
-					t.TokenType == TokenType.Array ||
-				    t.TokenType == TokenType.CellAddress ||
-				    t.TokenType == TokenType.FullColumnAddress ||
-					t.TokenType == TokenType.FullRowAddress ||
-					t.TokenType == TokenType.TableName ||
-					t.TokenType == TokenType.WorksheetName)
-				{
-					ret.Add(null);
-					return ret;
-				}
-				else if(t.TokenType==TokenType.Function)
-				{
-					var function = _fr.GetFunction(t.Value);
-					if(function.IsAllowedInCalculatedPivotTableField==false)
-					{
-						ret.Add(null);
-						return ret;
-					}
-				}
-				ix++;
-			}
-			return ret;
-		}
+        private List<int> GetCalcOrder()
+        {
+            var calcOrder = new List<int>();
+            var cacheFields = _tbl.CacheDefinition._cacheReference.Fields;
 
-		private List<int> GetCalcOrder()
-		{
-			var calcOrder = new List<int>();
-			foreach (var f in _tbl.Fields.Where(x => string.IsNullOrEmpty(x.Cache.Formula) == false))
-			{
-				if (calcOrder.Contains(f.Index)) continue;
-				ValidateNoCircularReference(f, calcOrder);
-			}
-			return calcOrder;
-		}
+            // Collect cache field indices that are used as DataFields and have formulas
+            var relevantCfIndices = new HashSet<int>();
+            foreach (var df in _tbl.DataFields)
+            {
+                if (!string.IsNullOrEmpty(df.Field.Cache.Formula))
+                {
+                    var cfIndex = cacheFields.IndexOf(df.Field.Cache);
+                    if (cfIndex >= 0)
+                    {
+                        relevantCfIndices.Add(cfIndex);
+                    }
+                }
+            }
 
-		private bool ValidateNoCircularReference(ExcelPivotTableField f, List<int> calcOrder, Stack<ExcelPivotTableField> prevFields = null)
-		{
-			if (prevFields == null) prevFields = new Stack<ExcelPivotTableField>();
-			var tokens = SourceCodeTokenizer.PivotFormula.Tokenize(f.Cache.Formula);
-			foreach (var t in tokens)
-			{
-				if (t.TokenType == TokenType.PivotField)
-				{
-					var f2 = _tbl.Fields[t.Value];
-					if (f2 != null && string.IsNullOrEmpty(f2.Cache.Formula)==false)
-					{
-						if (t.Value.Equals(f.Name, StringComparison.InvariantCultureIgnoreCase))
-						{
-							throw(new InvalidOperationException($"Circular reference in pivot table {_tbl.Name} Calculated Field {f.Name}"));
-						}
-						if(prevFields.Any(x=>x.Name.Equals(t.Value, StringComparison.InvariantCultureIgnoreCase)))
-						{
-							throw(new InvalidOperationException($"Circular reference in pivot table {_tbl.Name} Calculated Field {f.Name}"));
-						}
+            foreach (var cfIndex in relevantCfIndices)
+            {
+                if (calcOrder.Contains(cfIndex)) continue;
+                ValidateNoCircularReferenceCacheField(
+                    cacheFields[cfIndex], cfIndex, calcOrder, cacheFields);
+            }
+            return calcOrder;
+        }
 
-						prevFields.Push(f);
-						ValidateNoCircularReference(f2, calcOrder, prevFields);
-					}
-				}
-			}
-			calcOrder.Add(f.Index);
-			return true;
-		}
+        private bool ValidateNoCircularReferenceCacheField(
+            ExcelPivotTableCacheField cf,
+            int cfIndex,
+            List<int> calcOrder,
+            List<ExcelPivotTableCacheField> cacheFields,
+            Stack<int> prevIndices = null)
+        {
+            if (prevIndices == null) prevIndices = new Stack<int>();
+            var tokens = SourceCodeTokenizer.PivotFormula.Tokenize(cf.Formula);
+            foreach (var t in tokens)
+            {
+                if (t.TokenType == TokenType.PivotField)
+                {
+                    var refIndex = cacheFields.FindIndex(
+                        x => x.Name.Equals(t.Value, StringComparison.InvariantCultureIgnoreCase));
+                    if (refIndex >= 0 && !string.IsNullOrEmpty(cacheFields[refIndex].Formula))
+                    {
+                        if (refIndex == cfIndex || prevIndices.Contains(refIndex))
+                        {
+                            throw new InvalidOperationException(
+                                $"Circular reference in pivot table {_tbl.Name} Calculated Field {cf.Name}");
+                        }
+                        prevIndices.Push(cfIndex);
+                        ValidateNoCircularReferenceCacheField(
+                            cacheFields[refIndex], refIndex, calcOrder, cacheFields, prevIndices);
+                    }
+                }
+            }
+            if (!calcOrder.Contains(cfIndex))
+            {
+                calcOrder.Add(cfIndex);
+            }
+            return true;
+        }
 	}
 }

--- a/src/EPPlus/Table/PivotTable/ExcelPivotTable.cs
+++ b/src/EPPlus/Table/PivotTable/ExcelPivotTable.cs
@@ -406,15 +406,23 @@ namespace OfficeOpenXml.Table.PivotTable
         /// <param name="refreshCache">If the pivot cache should be refreshed from the source data, before calculating the pivot table.</param>
         public void Calculate(bool refreshCache = false)
         {
-            if(CacheDefinition.Connection!=null)
+            if (CacheDefinition.Connection != null)
             {
                 return;
             }
-            if (refreshCache || CacheDefinition._cacheReference.Records == null  || CacheDefinition._cacheReference.Records.RecordCount == 0)
+
+            if (!IsCalculated)
+            {
+                refreshCache = true;
+            }
+
+            if (refreshCache || CacheDefinition._cacheReference.Records == null || CacheDefinition._cacheReference.Records.RecordCount == 0)
             {
                 CacheDefinition.Refresh();
             }
+
             PivotTableCalculation.Calculate(this, out CalculatedItems, out Keys);
+
             IsCalculated = true;
         }
         /// <summary>
@@ -452,17 +460,36 @@ namespace OfficeOpenXml.Table.PivotTable
                 return ErrorValues.RefError;
             }
 
+            var dfIx = DataFields.IndexOf(dataField);
+            if (dfIx == -1)
+            {
+                for (int i = 0; i < DataFields.Count; i++)
+                {
+                    if (DataFields[i].Name == dataFieldName)
+                    {
+                        dfIx = i;
+                        break;
+                    }
+                }
+                if (dfIx == -1)
+                {
+                    return ErrorValues.RefError;
+                }
+            }
+
             if (IsCalculated == false)
             {
                 Calculate();
             }
 
             var items = CacheDefinition._cacheReference.Records.CacheItems;
-
             var keyFieldIndex = RowColumnFieldIndicies;
+
             var key = new int[keyFieldIndex.Count];
+
             var functionFieldIx = -1;
             var function = eSubTotalFunctions.None;
+
             for (int i = 0; i < keyFieldIndex.Count; i++)
             {
                 key[i] = PivotCalculationStore.SumLevelValue;
@@ -470,7 +497,7 @@ namespace OfficeOpenXml.Table.PivotTable
                 {
                     var field = Fields[fieldItemSelection[j].FieldName];
 
-                    if (field == null || (field.IsColumnField==false && field.IsRowField==false))
+                    if (field == null || (field.IsColumnField == false && field.IsRowField == false))
                     {
                         return ErrorValues.RefError;
                     }
@@ -487,7 +514,6 @@ namespace OfficeOpenXml.Table.PivotTable
                     if (field.Index == keyFieldIndex[i])
                     {
                         var cache = field.GetLookup();
-
                         var isGrouping = field.Grouping != null;
 
                         if (isGrouping)
@@ -507,9 +533,9 @@ namespace OfficeOpenXml.Table.PivotTable
                             }
                             else
                             {
-                                if(v != null && bool.TryParse(v.ToString(), out bool b))
+                                if (v != null && bool.TryParse(v.ToString(), out bool b))
                                 {
-                                    if(cache.ContainsKey(b))
+                                    if (cache.ContainsKey(b))
                                     {
                                         key[i] = cache[b];
                                     }
@@ -529,7 +555,6 @@ namespace OfficeOpenXml.Table.PivotTable
                 }
             }
 
-            var dfIx = DataFields.IndexOf(dataField);
             if (PivotTableCalculation.IsReferencingUngroupableKey(key, dataField.Field.PivotTable.RowFields.Count))
             {
                 if (Keys[dfIx].TryGetValue(key, out HashSet<int[]> uniqueItems))
@@ -564,10 +589,17 @@ namespace OfficeOpenXml.Table.PivotTable
                 }
             }
 
-            //Check if the cell is collapsed or if a subtotal function is set to none and the subtotal is not the lowest collapsed row/column.
             if (IsCollapsedOrNoSubTotalFunction(key, keyFieldIndex, dataField))
             {
                 return ErrorValues.RefError;
+            }
+
+            if (CalculatedItems[dfIx] != null)
+            {
+                foreach (var k in CalculatedItems[dfIx].Index)
+                {
+                    var val = CalculatedItems[dfIx][k.Key];
+                }
             }
 
             if (function == eSubTotalFunctions.None)
@@ -579,16 +611,18 @@ namespace OfficeOpenXml.Table.PivotTable
             }
             else
             {
-                var subTotalKey = $"{functionFieldIx},{dfIx},{function}";
+                var subTotalKey = functionFieldIx + "," + dfIx + "," + function;
                 if (CalculatedFieldRowColumnSubTotals[subTotalKey].TryGetValue(key, out var value))
                 {
                     return value;
                 }
             }
+
             if (ExistsValueInTable(key, dfIx))
             {
                 return 0D;
             }
+
             return ErrorValues.RefError;
         }
 

--- a/src/EPPlus/Table/PivotTable/PivotTableCacheInternal.cs
+++ b/src/EPPlus/Table/PivotTable/PivotTableCacheInternal.cs
@@ -477,19 +477,25 @@ namespace OfficeOpenXml.Table.PivotTable
                 //Update data field index
                 foreach (var df in pt.DataFields)
                 {
-                    var ix = movedFields.IndexOf(df.Index);
-                    if(ix<0)
+                    // BUGGFIX: Kontrollera om det underliggande fältet finns i den nya fields-listan
+                    // istället för att kolla om df.Index finns i movedFields
+                    if (df.Field == null || !fields.Any(x => x.Name.Equals(df.Field.Name, StringComparison.InvariantCultureIgnoreCase)))
                     {
                         rmDfFields.Add(df);
                     }
-                    else if (df.Index != df.Field.Index)
+                    else
                     {
-                        df.Index = df.Field.Index;
+                        // Uppdatera index om fältet har flyttats
+                        var newField = fields.FirstOrDefault(x => x.Name.Equals(df.Field.Name, StringComparison.InvariantCultureIgnoreCase));
+                        if (newField != null && df.Index != newField.Index)
+                        {
+                            df.Index = newField.Index;
+                        }
                     }
                 }
 
                 rmDfFields.ForEach(df => { df.Field.IsDataField = false; pt.DataFields.Remove(df); });
-                if(pt.DataFields.Count==0)
+                if (pt.DataFields.Count == 0)
                 {
                     pt.DeleteNode("d:dataFields");
                 }

--- a/src/EPPlus/Table/PivotTable/PivotTableCacheInternal.cs
+++ b/src/EPPlus/Table/PivotTable/PivotTableCacheInternal.cs
@@ -477,15 +477,15 @@ namespace OfficeOpenXml.Table.PivotTable
                 //Update data field index
                 foreach (var df in pt.DataFields)
                 {
-                    // BUGGFIX: Kontrollera om det underliggande fältet finns i den nya fields-listan
-                    // istället för att kolla om df.Index finns i movedFields
+                    // Check if the underlying field still exists in the updated fields list
+                    // by matching field names (case-insensitive)
                     if (df.Field == null || !fields.Any(x => x.Name.Equals(df.Field.Name, StringComparison.InvariantCultureIgnoreCase)))
                     {
                         rmDfFields.Add(df);
                     }
                     else
                     {
-                        // Uppdatera index om fältet har flyttats
+                        // Update the data field's index if the underlying field was moved
                         var newField = fields.FirstOrDefault(x => x.Name.Equals(df.Field.Name, StringComparison.InvariantCultureIgnoreCase));
                         if (newField != null && df.Index != newField.Index)
                         {

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/GetPivotData/GetPivotDataTests_CaluclatedFields2.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/GetPivotData/GetPivotDataTests_CaluclatedFields2.cs
@@ -1,0 +1,338 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Engineering;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Text;
+using OfficeOpenXml.Table.PivotTable;
+using OfficeOpenXml.Table.PivotTable.Calculation;
+using System;
+using System.Collections.Generic;
+
+namespace EPPlus.Core.Tests.Table.PivotTable
+{
+    [TestClass]
+    public class GetPivotDataTests_CalculatedFields2
+    {
+        private ExcelPackage _package;
+        private ExcelWorksheet _dataWs;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _package = new ExcelPackage();
+            _dataWs = _package.Workbook.Worksheets.Add("Data");
+
+            // Headers
+            _dataWs.Cells["A1"].Value = "Department";
+            _dataWs.Cells["B1"].Value = "Basic Pay";
+            _dataWs.Cells["C1"].Value = "Overtime";
+            _dataWs.Cells["D1"].Value = "Bonus";
+
+            // Sales department
+            _dataWs.Cells["A2"].Value = "Sales";
+            _dataWs.Cells["B2"].Value = 5000d;
+            _dataWs.Cells["C2"].Value = 500d;
+            _dataWs.Cells["D2"].Value = 1000d;
+
+            _dataWs.Cells["A3"].Value = "Sales";
+            _dataWs.Cells["B3"].Value = 6000d;
+            _dataWs.Cells["C3"].Value = 600d;
+            _dataWs.Cells["D3"].Value = 1200d;
+
+            // IT department
+            _dataWs.Cells["A4"].Value = "IT";
+            _dataWs.Cells["B4"].Value = 7000d;
+            _dataWs.Cells["C4"].Value = 300d;
+            _dataWs.Cells["D4"].Value = 800d;
+
+            _dataWs.Cells["A5"].Value = "IT";
+            _dataWs.Cells["B5"].Value = 7500d;
+            _dataWs.Cells["C5"].Value = 400d;
+            _dataWs.Cells["D5"].Value = 900d;
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _package?.Dispose();
+        }
+
+        [TestMethod]
+        public void GetPivotData_CalculatedField_ShouldReturnCorrectValue()
+        {
+            // Arrange
+            var ws = _package.Workbook.Worksheets.Add("Pivot");
+            var pt = ws.PivotTables.Add(ws.Cells["A1"], _dataWs.Cells["A1:D5"], "TestPivot");
+
+            pt.RowFields.Add(pt.Fields["Department"]);
+
+            pt.Fields.AddCalculatedField("Total Comp", "'Basic Pay'+'Overtime'+'Bonus'");
+            var df = pt.DataFields.Add(pt.Fields["Total Comp"]);
+            df.Function = DataFieldFunctions.Sum;
+            df.Name = "Sum of Total Comp";  // <-- Lägg till detta!
+
+            // Act
+            pt.Calculate(refreshCache: true);
+
+            var criteria = new List<PivotDataFieldItemSelection>
+            {
+                new PivotDataFieldItemSelection("Department", "Sales")
+            };
+
+            var result = pt.GetPivotData("Sum of Total Comp", criteria);
+
+            // Assert
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsFalse(result is ExcelErrorValue,
+                $"GetPivotData should not return #REF! error, got: {result}");
+
+            // Sales: (5000+500+1000) + (6000+600+1200) = 14300
+            Assert.AreEqual(14300d, (double)result, 0.001,
+                "Calculated field value for Sales should be 14300");
+        }
+
+        [TestMethod]
+        public void GetPivotData_CalculatedField_GrandTotal_ShouldWork()
+        {
+            // Arrange
+            var ws = _package.Workbook.Worksheets.Add("Pivot");
+            var pt = ws.PivotTables.Add(ws.Cells["A1"], _dataWs.Cells["A1:D5"], "TestPivot");
+
+            pt.RowFields.Add(pt.Fields["Department"]);
+            pt.Fields.AddCalculatedField("All Pay", "'Basic Pay'+'Overtime'+'Bonus'");
+            var df = pt.DataFields.Add(pt.Fields["All Pay"]);
+            df.Function = DataFieldFunctions.Sum;
+            df.Name = "Sum of All Pay";  // <-- Lägg till detta
+
+            // Act
+            pt.Calculate(refreshCache: true);
+            var grandTotal = pt.GetPivotData("Sum of All Pay");
+
+            // Assert
+            Assert.IsNotNull(grandTotal);
+            Assert.IsFalse(grandTotal is ExcelErrorValue,
+                string.Format("Grand total should not return error, got: {0}", grandTotal));
+
+            // Total: Sales(14300) + IT(16900) = 31200
+            Assert.AreEqual(31200d, (double)grandTotal, 0.001);
+        }
+
+        [TestMethod]
+        public void GetPivotData_MultipleCalculatedFields_ShouldWorkIndependently()
+        {
+            // Arrange
+            var ws = _package.Workbook.Worksheets.Add("Pivot");
+            var pt = ws.PivotTables.Add(ws.Cells["A1"], _dataWs.Cells["A1:D5"], "TestPivot");
+
+            pt.RowFields.Add(pt.Fields["Department"]);
+
+            pt.Fields.AddCalculatedField("Base Plus OT", "'Basic Pay'+'Overtime'");
+            pt.Fields.AddCalculatedField("Total Comp", "'Basic Pay'+'Overtime'+'Bonus'");
+
+            var df1 = pt.DataFields.Add(pt.Fields["Base Plus OT"]);
+            df1.Function = DataFieldFunctions.Sum;
+            df1.Name = "Sum of Base Plus OT";  // <-- Lägg till detta
+
+            var df2 = pt.DataFields.Add(pt.Fields["Total Comp"]);
+            df2.Function = DataFieldFunctions.Sum;
+            df2.Name = "Sum of Total Comp";  // <-- Lägg till detta
+
+            // Act
+            pt.Calculate(refreshCache: true);
+
+            var criteriaIT = new List<PivotDataFieldItemSelection>
+            {
+                new PivotDataFieldItemSelection("Department", "IT")
+            };
+
+            var result1 = pt.GetPivotData("Sum of Base Plus OT", criteriaIT);
+            var result2 = pt.GetPivotData("Sum of Total Comp", criteriaIT);
+
+            // Assert
+            Assert.IsFalse(result1 is ExcelErrorValue);
+            Assert.IsFalse(result2 is ExcelErrorValue);
+
+            // IT Base + OT: (7000+300) + (7500+400) = 15200
+            Assert.AreEqual(15200d, (double)result1, 0.001);
+
+            // IT Total: (7000+300+800) + (7500+400+900) = 16900
+            Assert.AreEqual(16900d, (double)result2, 0.001);
+        }
+
+        [TestMethod]
+        public void GetPivotData_CalculatedField_CalculatedItems_ShouldBePopulated()
+        {
+            // Arrange
+            var ws = _package.Workbook.Worksheets.Add("Pivot");
+            var pt = ws.PivotTables.Add(ws.Cells["A1"], _dataWs.Cells["A1:D5"], "TestPivot");
+
+            pt.RowFields.Add(pt.Fields["Department"]);
+            pt.Fields.AddCalculatedField("Sum Total", "'Basic Pay'+'Overtime'");
+            var df = pt.DataFields.Add(pt.Fields["Sum Total"]);
+            df.Function = DataFieldFunctions.Sum;
+            df.Name = "Sum of Sum Total";  // <-- Lägg till detta
+
+            // Act
+            pt.Calculate(refreshCache: true);
+
+            // Assert
+            Assert.IsTrue(pt.IsCalculated, "Pivot table should be marked as calculated");
+            Assert.IsNotNull(pt.CalculatedItems, "CalculatedItems should not be null");
+
+            var dfIndex = pt.DataFields.IndexOf(df);
+            Assert.IsTrue(dfIndex >= 0, "DataField should be in collection");
+            Assert.IsTrue(dfIndex < pt.CalculatedItems.Count,
+                "Should have CalculatedItems entry for this index");
+
+            var store = pt.CalculatedItems[dfIndex];
+            Assert.IsNotNull(store, "Store should not be null");
+            Assert.IsTrue(store.Count > 0,
+                "CalculatedItems store should be populated (this was empty before the fix)");
+        }
+
+        [TestMethod]
+        public void GetPivotData_CalculatedFieldMixedWithRegular_ShouldWork()
+        {
+            // Arrange
+            var ws = _package.Workbook.Worksheets.Add("Pivot");
+            var pt = ws.PivotTables.Add(ws.Cells["A1"], _dataWs.Cells["A1:D5"], "TestPivot");
+
+            pt.RowFields.Add(pt.Fields["Department"]);
+
+            // Add regular data field first
+            var dfBasic = pt.DataFields.Add(pt.Fields["Basic Pay"]);
+            dfBasic.Function = DataFieldFunctions.Sum;
+            dfBasic.Name = "Sum of Basic Pay";  // <-- Lägg till detta
+
+            // Add calculated field
+            pt.Fields.AddCalculatedField("Total", "'Basic Pay'+'Overtime'+'Bonus'");
+            var dfCalc = pt.DataFields.Add(pt.Fields["Total"]);
+            dfCalc.Function = DataFieldFunctions.Sum;
+            dfCalc.Name = "Sum of Total";  // <-- Lägg till detta
+
+            // Act
+            pt.Calculate(refreshCache: true);
+
+            var criteriaSales = new List<PivotDataFieldItemSelection>
+            {
+                new PivotDataFieldItemSelection("Department", "Sales")
+            };
+
+            var basicResult = pt.GetPivotData("Sum of Basic Pay", criteriaSales);
+            var calcResult = pt.GetPivotData("Sum of Total", criteriaSales);
+
+            // Assert
+            Assert.IsFalse(basicResult is ExcelErrorValue, "Regular field should work");
+            Assert.IsFalse(calcResult is ExcelErrorValue, "Calculated field should work");
+
+            Assert.AreEqual(11000d, (double)basicResult, 0.001); // 5000 + 6000
+            Assert.AreEqual(14300d, (double)calcResult, 0.001);
+        }
+
+        [TestMethod]
+        public void GetPivotData_CalculatedFieldWithComplexFormula_ShouldWork()
+        {
+            // Arrange
+            var ws = _package.Workbook.Worksheets.Add("Pivot");
+            var pt = ws.PivotTables.Add(ws.Cells["A1"], _dataWs.Cells["A1:D5"], "TestPivot");
+
+            pt.RowFields.Add(pt.Fields["Department"]);
+
+            // Complex formula with multiple operations
+            pt.Fields.AddCalculatedField("Complex Calc",
+                "'Basic Pay' * 2 + 'Overtime' - 'Bonus'");
+            var df = pt.DataFields.Add(pt.Fields["Complex Calc"]);
+            df.Function = DataFieldFunctions.Sum;
+            df.Name = "Sum of Complex Calc";  // <-- Lägg till detta!
+
+            // Act
+            pt.Calculate(refreshCache: true);
+
+            var criteriaIT = new List<PivotDataFieldItemSelection>
+            {
+                new PivotDataFieldItemSelection("Department", "IT")
+            };
+
+            var result = pt.GetPivotData("Sum of Complex Calc", criteriaIT);
+
+            // Assert
+            Assert.IsFalse(result is ExcelErrorValue);
+
+            // IT: (7000*2+300-800) + (7500*2+400-900) 
+            //   = (14000+300-800) + (15000+400-900)
+            //   = 13500 + 14500 = 28000
+            Assert.AreEqual(28000d, (double)result, 0.001);
+        }
+
+        [TestMethod]
+        public void GetPivotData_CalculatedFieldOnlyWithFormula_NoRegularFields()
+        {
+            // Arrange
+            var ws = _package.Workbook.Worksheets.Add("Pivot");
+            var pt = ws.PivotTables.Add(ws.Cells["A1"], _dataWs.Cells["A1:D5"], "TestPivot");
+
+            pt.RowFields.Add(pt.Fields["Department"]);
+
+            // Only add calculated field, no regular data fields
+            pt.Fields.AddCalculatedField("Only Calc", "'Basic Pay'+'Overtime'");
+            var df = pt.DataFields.Add(pt.Fields["Only Calc"]);
+            df.Function = DataFieldFunctions.Sum;
+            df.Name = "Sum of Only Calc";  // <-- Lägg till detta
+
+            // Act
+            pt.Calculate(refreshCache: true);
+
+            var criteriaIT = new List<PivotDataFieldItemSelection>
+            {
+                new PivotDataFieldItemSelection("Department", "IT")
+            };
+
+            var result = pt.GetPivotData("Sum of Only Calc", criteriaIT);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsFalse(result is ExcelErrorValue,
+                "Should work even when pivot has only calculated fields");
+
+            // IT: (7000+300) + (7500+400) = 15200
+            Assert.AreEqual(15200d, (double)result, 0.001);
+        }
+
+        [TestMethod]
+        public void GetPivotData_CalculatedField_DifferentDepartments()
+        {
+            // Arrange
+            var ws = _package.Workbook.Worksheets.Add("Pivot");
+            var pt = ws.PivotTables.Add(ws.Cells["A1"], _dataWs.Cells["A1:D5"], "TestPivot");
+
+            pt.RowFields.Add(pt.Fields["Department"]);
+            pt.Fields.AddCalculatedField("Total Pay", "'Basic Pay'+'Overtime'+'Bonus'");
+            var df = pt.DataFields.Add(pt.Fields["Total Pay"]);
+            df.Function = DataFieldFunctions.Sum;
+            df.Name = "Sum of Total Pay";  // <-- Lägg till detta
+
+            // Act
+            pt.Calculate(refreshCache: true);
+
+            var criteriaSales = new List<PivotDataFieldItemSelection>
+            {
+                new PivotDataFieldItemSelection("Department", "Sales")
+            };
+
+            var criteriaIT = new List<PivotDataFieldItemSelection>
+            {
+                new PivotDataFieldItemSelection("Department", "IT")
+            };
+
+            var salesResult = pt.GetPivotData("Sum of Total Pay", criteriaSales);
+            var itResult = pt.GetPivotData("Sum of Total Pay", criteriaIT);
+
+            // Assert
+            Assert.IsFalse(salesResult is ExcelErrorValue);
+            Assert.IsFalse(itResult is ExcelErrorValue);
+
+            // Sales: 14300, IT: 16900
+            Assert.AreEqual(14300d, (double)salesResult, 0.001);
+            Assert.AreEqual(16900d, (double)itResult, 0.001);
+        }
+    }
+}

--- a/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/GetPivotData/GetPivotDataTests_CaluclatedFields2.cs
+++ b/src/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/GetPivotData/GetPivotDataTests_CaluclatedFields2.cs
@@ -1,10 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
-using OfficeOpenXml.FormulaParsing.Excel.Functions.Engineering;
-using OfficeOpenXml.FormulaParsing.Excel.Functions.Text;
 using OfficeOpenXml.Table.PivotTable;
 using OfficeOpenXml.Table.PivotTable.Calculation;
-using System;
 using System.Collections.Generic;
 
 namespace EPPlus.Core.Tests.Table.PivotTable
@@ -68,7 +65,7 @@ namespace EPPlus.Core.Tests.Table.PivotTable
             pt.Fields.AddCalculatedField("Total Comp", "'Basic Pay'+'Overtime'+'Bonus'");
             var df = pt.DataFields.Add(pt.Fields["Total Comp"]);
             df.Function = DataFieldFunctions.Sum;
-            df.Name = "Sum of Total Comp";  // <-- Lägg till detta!
+            df.Name = "Sum of Total Comp"; 
 
             // Act
             pt.Calculate(refreshCache: true);
@@ -101,7 +98,7 @@ namespace EPPlus.Core.Tests.Table.PivotTable
             pt.Fields.AddCalculatedField("All Pay", "'Basic Pay'+'Overtime'+'Bonus'");
             var df = pt.DataFields.Add(pt.Fields["All Pay"]);
             df.Function = DataFieldFunctions.Sum;
-            df.Name = "Sum of All Pay";  // <-- Lägg till detta
+            df.Name = "Sum of All Pay";
 
             // Act
             pt.Calculate(refreshCache: true);
@@ -130,11 +127,11 @@ namespace EPPlus.Core.Tests.Table.PivotTable
 
             var df1 = pt.DataFields.Add(pt.Fields["Base Plus OT"]);
             df1.Function = DataFieldFunctions.Sum;
-            df1.Name = "Sum of Base Plus OT";  // <-- Lägg till detta
+            df1.Name = "Sum of Base Plus OT";
 
             var df2 = pt.DataFields.Add(pt.Fields["Total Comp"]);
             df2.Function = DataFieldFunctions.Sum;
-            df2.Name = "Sum of Total Comp";  // <-- Lägg till detta
+            df2.Name = "Sum of Total Comp";
 
             // Act
             pt.Calculate(refreshCache: true);
@@ -169,7 +166,7 @@ namespace EPPlus.Core.Tests.Table.PivotTable
             pt.Fields.AddCalculatedField("Sum Total", "'Basic Pay'+'Overtime'");
             var df = pt.DataFields.Add(pt.Fields["Sum Total"]);
             df.Function = DataFieldFunctions.Sum;
-            df.Name = "Sum of Sum Total";  // <-- Lägg till detta
+            df.Name = "Sum of Sum Total";
 
             // Act
             pt.Calculate(refreshCache: true);
@@ -201,13 +198,13 @@ namespace EPPlus.Core.Tests.Table.PivotTable
             // Add regular data field first
             var dfBasic = pt.DataFields.Add(pt.Fields["Basic Pay"]);
             dfBasic.Function = DataFieldFunctions.Sum;
-            dfBasic.Name = "Sum of Basic Pay";  // <-- Lägg till detta
+            dfBasic.Name = "Sum of Basic Pay";
 
             // Add calculated field
             pt.Fields.AddCalculatedField("Total", "'Basic Pay'+'Overtime'+'Bonus'");
             var dfCalc = pt.DataFields.Add(pt.Fields["Total"]);
             dfCalc.Function = DataFieldFunctions.Sum;
-            dfCalc.Name = "Sum of Total";  // <-- Lägg till detta
+            dfCalc.Name = "Sum of Total";
 
             // Act
             pt.Calculate(refreshCache: true);
@@ -242,7 +239,7 @@ namespace EPPlus.Core.Tests.Table.PivotTable
                 "'Basic Pay' * 2 + 'Overtime' - 'Bonus'");
             var df = pt.DataFields.Add(pt.Fields["Complex Calc"]);
             df.Function = DataFieldFunctions.Sum;
-            df.Name = "Sum of Complex Calc";  // <-- Lägg till detta!
+            df.Name = "Sum of Complex Calc";
 
             // Act
             pt.Calculate(refreshCache: true);
@@ -276,7 +273,7 @@ namespace EPPlus.Core.Tests.Table.PivotTable
             pt.Fields.AddCalculatedField("Only Calc", "'Basic Pay'+'Overtime'");
             var df = pt.DataFields.Add(pt.Fields["Only Calc"]);
             df.Function = DataFieldFunctions.Sum;
-            df.Name = "Sum of Only Calc";  // <-- Lägg till detta
+            df.Name = "Sum of Only Calc";
 
             // Act
             pt.Calculate(refreshCache: true);
@@ -308,7 +305,7 @@ namespace EPPlus.Core.Tests.Table.PivotTable
             pt.Fields.AddCalculatedField("Total Pay", "'Basic Pay'+'Overtime'+'Bonus'");
             var df = pt.DataFields.Add(pt.Fields["Total Pay"]);
             df.Function = DataFieldFunctions.Sum;
-            df.Name = "Sum of Total Pay";  // <-- Lägg till detta
+            df.Name = "Sum of Total Pay";
 
             // Act
             pt.Calculate(refreshCache: true);


### PR DESCRIPTION
### Problem
When a pivot table contains calculated fields (fields defined by formulas in the pivot cache, e.g., `'Basic Pay'+'Overtime'+'Bonus'`), these fields were not properly computed during pivot table calculation. This caused `GETPIVOTDATA` to return `#REF!` for any data field that referenced a calculated field.

### Root Cause
The calculation logic had two issues:

1. **Wrong field collection**: `GetCalcOrder()` searched for calculated fields in `ExcelPivotTable.Fields`, which only contains source data columns. Calculated fields exist as cache fields (`ExcelPivotTableCacheField`) with indices beyond the source data range and were therefore never found. This resulted in:
   - `GetCalcOrder()` returning an empty list
   - `CalculateFormulaFields()` never executing
   - `CalculatedItems` remaining empty for calculated data fields

2. **Wrong index lookup**: `GetSumCalcItems()` used `ds.Index` (the field's index in the field collection) instead of `DataFields.IndexOf(ds)` (the data field's position in the data fields collection) when retrieving from `CalculatedItems`. This caused incorrect data to be referenced when building calculated field formulas that depended on regular data fields.

### Solution

**PivotTableColumnCalculation.cs:**
- Changed `GetCalcOrder()` to iterate over cache fields (`_tbl.CacheDefinition._cacheReference.Fields`) instead of pivot table fields
- Updated to collect cache field indices that are actually used as data fields with formulas
- Modified `CalculateFormulaFields()` to work directly with cache fields and their indices
- Enhanced key collection to gather all unique keys across all referenced source fields to ensure no data combinations are missed

**PivotTableCalculation.cs:**
- Fixed `GetSumCalcItems()` to use `pivotTable.DataFields.IndexOf(ds)` instead of `ds.Index` when accessing `CalculatedItems`

### Testing
Added comprehensive unit tests covering:
- Basic calculated field with `GETPIVOTDATA`
- Grand totals for calculated fields  
- Multiple calculated fields working independently
- Calculated fields mixed with regular data fields
- Complex formulas with multiple operations
- Pivot tables containing only calculated fields
- Different filter criteria returning different calculated values