### PR TITLE
Fix off-by-one in InsertAndShift resize condition (#2291)

### DIFF
--- a/src/EPPlus/Core/ChangableDictionary.cs
+++ b/src/EPPlus/Core/ChangableDictionary.cs
@@ -66,7 +66,7 @@ namespace OfficeOpenXml.Core
                 pos = ~pos;
             }
 
-            if (pos + 1 >= _index[0].Length - 1)
+            if (_count >= _index[0].Length - 1)
             {
                 Array.Resize(ref _index[0], _index[0].Length << 1);
                 Array.Resize(ref _index[1], _index[1].Length << 1);

--- a/src/EPPlusTest/Issues/WorksheetIssues.cs
+++ b/src/EPPlusTest/Issues/WorksheetIssues.cs
@@ -4,6 +4,7 @@ using OfficeOpenXml.Core;
 using OfficeOpenXml.Drawing;
 using OfficeOpenXml.Drawing.Chart;
 using OfficeOpenXml.FormulaParsing;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Information;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Logical;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.RichData;
@@ -1110,6 +1111,23 @@ namespace EPPlusTest.Issues
             
             var d3 = ws.Cells["D3"].Text;
             Assert.AreEqual("Negative 4000,000", d3);
+        }
+
+        [TestMethod]
+        public void InsertAndShift_ShouldNotThrow_WhenArrayIsFull()
+        {
+            using var package = new ExcelPackage();
+            var sheet = package.Workbook.Worksheets.Add("Sheet1");
+
+            // Fill 7 columns with formatting to trigger the boundary condition
+            for (int col = 1; col <= 7; col++)
+            {
+                sheet.Column(col).Width = 15;
+            }
+
+            // These two inserts should not throw ArgumentException
+            sheet.InsertColumn(3, 1);
+            sheet.InsertColumn(5, 1);
         }
 
     }


### PR DESCRIPTION
Fixed a bug in` ChangeableDictionary.InsertAndShift` where the array resize condition was checking `pos + 1 >= Length - 1` instead of `_count >= Length - 1`. This caused an `ArgumentException` when calling `InsertColumn` on xlsx files where the number of defined columns was at the array boundary.

This PR also includes a unit test that replicated the issue and verifies the fix.
