### PR TITLE
Fix culture-specific DateTime in PowerQuery metadata

### DIFF
--- a/src/EPPlus/Data/PowerQuery/ExcelPowerQueryMetaDataEntry.cs
+++ b/src/EPPlus/Data/PowerQuery/ExcelPowerQueryMetaDataEntry.cs
@@ -153,11 +153,11 @@ namespace OfficeOpenXml.Data.Connection
             }
             if (Value is int i)
             {
-                return "l" + i.ToString();
+                return "l" + i.ToString(CultureInfo.InvariantCulture);
             }
             if (Value is DateTime dt)
             {
-                return "d" + dt.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ");
+                return "d" + dt.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture);
             }
             if (Value is bool b)
             {
@@ -165,11 +165,11 @@ namespace OfficeOpenXml.Data.Connection
             }
             if (Value is double d)
             {
-                return "f" + d.ToString();
+                return "f" + d.ToString(CultureInfo.InvariantCulture);
             }
             else
             {
-                return "s" + Value.ToString(); //You shoul never end up here.
+                return "s" + Value.ToString(); //You should never end up here.
             }
         }
         /// <summary>

--- a/src/EPPlusTest/Data/ConnectionTests.cs
+++ b/src/EPPlusTest/Data/ConnectionTests.cs
@@ -3,7 +3,9 @@ using OfficeOpenXml;
 using OfficeOpenXml.Data.Connection;
 using System;
 using System.Data.Common;
+using System.Globalization;
 using System.Text;
+using System.Threading;
 using System.Xml;
 
 namespace EPPlusTest.Data
@@ -193,10 +195,26 @@ namespace EPPlusTest.Data
                 SaveAndCleanup(p);
             }
         }
+        
         [TestMethod]
-        public void AddPivotTableWithConnection()
+        public void GetValueAsText_DateTime_ShouldUseInvariantCulture()
         {
+            var cc = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("fi-FI");
+                var entry = new ExcelPowerQueryMetaDataEntry("FillLastUpdated",
+                    new DateTime(2026, 2, 19, 8, 15, 36, DateTimeKind.Utc));
+                var result = entry.GetValueAsText(CultureInfo.GetCultureInfo("fi-FI"));
+                Assert.IsTrue(result.Contains(":"),
+                    $"Expected colon as time separator but got: {result}");
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = cc;
+            }
         }
+
         [ClassCleanup]
         public static void Cleanup()
         {

--- a/src/EPPlusTest/Issues/PackageIssues.cs
+++ b/src/EPPlusTest/Issues/PackageIssues.cs
@@ -1,6 +1,10 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
+using System;
+using System.ComponentModel;
 using System.Drawing;
+using System.IO;
+using System.Linq;
 
 namespace EPPlusTest.Issues
 {
@@ -160,6 +164,27 @@ namespace EPPlusTest.Issues
             package.Workbook.CalculateAllPivotTables();
 
             SaveAndCleanup(package);
+        }
+
+        [TestMethod]
+        public void sc1012()
+        {
+            string path = @"C:\\epplusTest\\Workbooks\\import_template_simple.xlsx";
+
+            Stream excelFile = new MemoryStream(System.IO.File.ReadAllBytes(path));
+
+            using (ExcelPackage pck = new ExcelPackage(excelFile))
+            {
+                ExcelWorksheet sheetSap = pck.Workbook.Worksheets.Where(pr => string.Equals(pr.Name, "SAP data", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault();
+                sheetSap.Cells[1, 1].Value = "Test";
+
+                pck.Save();
+                pck.Stream.Seek(0, SeekOrigin.Begin);
+                byte[] buffer = new byte[pck.Stream.Length];
+                pck.Stream.Read(buffer, 0, (int)pck.Stream.Length);
+                File.WriteAllBytes(@"c:\temp\error_report.xlsx", buffer);
+
+            }
         }
     }
 }

--- a/src/EPPlusTest/Issues/PackageIssues.cs
+++ b/src/EPPlusTest/Issues/PackageIssues.cs
@@ -3,8 +3,10 @@ using OfficeOpenXml;
 using System;
 using System.ComponentModel;
 using System.Drawing;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 namespace EPPlusTest.Issues
 {
@@ -164,27 +166,6 @@ namespace EPPlusTest.Issues
             package.Workbook.CalculateAllPivotTables();
 
             SaveAndCleanup(package);
-        }
-
-        [TestMethod]
-        public void sc1012()
-        {
-            string path = @"C:\\epplusTest\\Workbooks\\import_template_simple.xlsx";
-
-            Stream excelFile = new MemoryStream(System.IO.File.ReadAllBytes(path));
-
-            using (ExcelPackage pck = new ExcelPackage(excelFile))
-            {
-                ExcelWorksheet sheetSap = pck.Workbook.Worksheets.Where(pr => string.Equals(pr.Name, "SAP data", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault();
-                sheetSap.Cells[1, 1].Value = "Test";
-
-                pck.Save();
-                pck.Stream.Seek(0, SeekOrigin.Begin);
-                byte[] buffer = new byte[pck.Stream.Length];
-                pck.Stream.Read(buffer, 0, (int)pck.Stream.Length);
-                File.WriteAllBytes(@"c:\temp\error_report.xlsx", buffer);
-
-            }
         }
     }
 }


### PR DESCRIPTION
See #2295 

Added `CultureInfo.InvariantCulture` to `ExcelPowerQueryMetaDataEntry.GetValueAsText `method.
