### PR TITLE
Feature/memory range dimension

### DIFF
--- a/src/EPPlus/FormulaParsing/DependencyChain/ArrayFormulaOutput.cs
+++ b/src/EPPlus/FormulaParsing/DependencyChain/ArrayFormulaOutput.cs
@@ -10,17 +10,18 @@
  *************************************************************************************************
   05/14/2024         EPPlus Software AB       Initial release EPPlus 7
  *************************************************************************************************/
-using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
 using OfficeOpenXml.Core.CellStore;
+using OfficeOpenXml.Filter;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
+using OfficeOpenXml.FormulaParsing.FormulaExpressions;
+using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
+using OfficeOpenXml.FormulaParsing.Ranges;
+using OfficeOpenXml.Utils;
+using OfficeOpenXml.Utils.TypeConversion;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
-using OfficeOpenXml.Filter;
-using OfficeOpenXml.FormulaParsing.FormulaExpressions;
-using OfficeOpenXml.Utils;
-using OfficeOpenXml.Utils.TypeConversion;
 
 namespace OfficeOpenXml.FormulaParsing
 {
@@ -37,7 +38,14 @@ namespace OfficeOpenXml.FormulaParsing
             var rows = sf.EndRow - sf.StartRow + 1;
             var cols = sf.EndCol - sf.StartCol + 1;
             var wsIx = ws.IndexInList;
-            for (int r = 0; r < rows; r++)
+
+            // Determine physical boundary and default value for virtual rows
+            var virtualImr = array as InMemoryRange;
+            var hasVirtual = virtualImr != null && virtualImr.HasVirtualRows;
+            var physicalRowLimit = hasVirtual ? Math.Min(rows, virtualImr.PhysicalRows) : rows;
+
+            // Phase 1: Physical rows - read actual cell values via GetOffset
+            for (int r = 0; r < physicalRowLimit; r++)
             {
                 for (int c = 0; c < cols; c++)
                 {
@@ -46,9 +54,8 @@ namespace OfficeOpenXml.FormulaParsing
                     if (r < nr && c < nc)
                     {
                         var val = array.GetOffset(r, c);
-                        if(ConvertUtil.IsNumeric(val) && val is double dbl &&  dbl == 0d)
+                        if (ConvertUtil.IsNumeric(val) && val is double dbl && dbl == 0d)
                         {
-                            // avoid -0
                             val = 0d;
                         }
                         ws.SetValueInner(row, col, val ?? 0D);
@@ -58,7 +65,35 @@ namespace OfficeOpenXml.FormulaParsing
                         ws.SetValueInner(row, col, ErrorValues.NAError);
                     }
                     var id = ExcelCellBase.GetCellId(wsIx, row, col);
-                    depChain.processedCells.Add(id);    
+                    depChain.processedCells.Add(id);
+                }
+            }
+
+            // Phase 2: Virtual rows - write pre-computed default value directly
+            if (hasVirtual && physicalRowLimit < rows)
+            {
+                var defaultVal = virtualImr.VirtualDefaultValue ?? 0D;
+                if (ConvertUtil.IsNumeric(defaultVal) && defaultVal is double dblDefault && dblDefault == 0d)
+                {
+                    defaultVal = 0d;
+                }
+                for (int r = physicalRowLimit; r < rows; r++)
+                {
+                    for (int c = 0; c < cols; c++)
+                    {
+                        var row = sr + r;
+                        var col = sc + c;
+                        if (r < nr && c < nc)
+                        {
+                            ws.SetValueInner(row, col, defaultVal);
+                        }
+                        else
+                        {
+                            ws.SetValueInner(row, col, ErrorValues.NAError);
+                        }
+                        var id = ExcelCellBase.GetCellId(wsIx, row, col);
+                        depChain.processedCells.Add(id);
+                    }
                 }
             }
 
@@ -74,7 +109,7 @@ namespace OfficeOpenXml.FormulaParsing
                 {
                     if (r == startRow && c == startColumn) continue;
                     object f = -1;
-                    if (fIx!=-1 && ws._formulas.Exists(r, c, ref f) && f != null)
+                    if (fIx != -1 && ws._formulas.Exists(r, c, ref f) && f != null)
                     {
                         if (f is int intfIx && intfIx == fIx)
                         {
@@ -87,7 +122,7 @@ namespace OfficeOpenXml.FormulaParsing
                     else
                     {
                         var v = ws.GetValueInner(r, c);
-                        if(v!=null)
+                        if (v != null)
                         {
                             rowOff = r - startRow;
                             colOff = c - startColumn;
@@ -98,7 +133,7 @@ namespace OfficeOpenXml.FormulaParsing
             }
             rowOff = colOff = 0;
             return false;
-        }   
+        }
         internal static SimpleAddress[] FillDynamicArrayFromRangeInfo(RpnFormula f, IRangeInfo array, RangeHashset rd, RpnOptimizedDependencyChain depChain)
         {
             var nr = array.Size.NumberOfRows;
@@ -107,13 +142,13 @@ namespace OfficeOpenXml.FormulaParsing
             var startRow = f._row;
             var startCol = f._column;
             var wsIx = ws.IndexInList;
-            
+
             f._flags |= FormulaFlags.IsDynamic;
             var md = depChain._parsingContext.Package.Workbook.Metadata;
             //d.GetDynamicArrayIndex(out int cm);
             md.GetDynamicArrayId(out uint cm);
             var metaData = f._ws._metadataStore.GetValue(startRow, startCol);
-            metaData.cm= cm;
+            metaData.cm = cm;
 
             f._ws._metadataStore.SetValue(f._row, f._column, metaData);
 
@@ -134,7 +169,7 @@ namespace OfficeOpenXml.FormulaParsing
                 }
             }
             SimpleAddress[] dirtyRange;
-            if(f._arrayIndex==-1)
+            if (f._arrayIndex == -1)
             {
                 var endRow = startRow + array.Size.NumberOfRows - 1;
                 var endCol = f._column + array.Size.NumberOfCols - 1;
@@ -151,7 +186,7 @@ namespace OfficeOpenXml.FormulaParsing
                 CleanupSharedFormulaValues(f, ws, sf, endRow, endCol);
                 sf.EndRow = endRow;
                 sf.EndCol = endCol;
-                
+
             }
             FillArrayFromRangeInfo(f, array, rd, depChain);
             return dirtyRange;
@@ -212,10 +247,10 @@ namespace OfficeOpenXml.FormulaParsing
             }
         }
 
-        private static SimpleAddress[] GetDirtyRange(int fromRow, int fromCol, int toRow, int toCol, int prevToRow=0, int prevToCol=0)
+        private static SimpleAddress[] GetDirtyRange(int fromRow, int fromCol, int toRow, int toCol, int prevToRow = 0, int prevToCol = 0)
         {
-            if(prevToRow == 0) prevToRow = fromRow;
-            if(prevToCol == 0) prevToCol = fromCol;
+            if (prevToRow == 0) prevToRow = fromRow;
+            if (prevToCol == 0) prevToCol = fromCol;
             if (prevToRow == toRow && prevToCol == toCol)
             {
                 return new SimpleAddress[0];
@@ -226,15 +261,15 @@ namespace OfficeOpenXml.FormulaParsing
                 {
                     new SimpleAddress(fromRow, Math.Min(prevToCol+1, toCol+1), Math.Min(prevToRow, toRow), Math.Max(prevToCol, toCol)),
                     new SimpleAddress(Math.Min(prevToRow + 1, toRow + 1), fromCol, Math.Max(prevToRow, toRow), Math.Max(prevToCol, toCol))
-                };            
+                };
             }
-            else if(prevToRow != toRow)
+            else if (prevToRow != toRow)
             {
-                return new SimpleAddress[] { new SimpleAddress(Math.Min(prevToRow+1, toRow), fromCol, Math.Max(prevToRow, toRow), Math.Max(prevToCol,toCol)) };
-            }            
+                return new SimpleAddress[] { new SimpleAddress(Math.Min(prevToRow + 1, toRow), fromCol, Math.Max(prevToRow, toRow), Math.Max(prevToCol, toCol)) };
+            }
             else
             {
-                return new SimpleAddress[] { new SimpleAddress(fromRow, Math.Min(prevToCol+1, toCol), Math.Max(prevToRow, toRow), Math.Max(prevToCol, toCol)) };
+                return new SimpleAddress[] { new SimpleAddress(fromRow, Math.Min(prevToCol + 1, toCol), Math.Max(prevToRow, toRow), Math.Max(prevToCol, toCol)) };
             }
         }
 

--- a/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupUtils/XlookupScanner.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupUtils/XlookupScanner.cs
@@ -150,16 +150,28 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.LookupUtils
             return -1;
         }
 
+
         private int GetMaxItemsRow(IRangeInfo lookupRange)
         {
+            var adjusted = lookupRange.GetAddressDimensionAdjusted(0);
+            if (adjusted != null)
+            {
+                return adjusted.ToRow - adjusted.FromRow + 1;
+            }
             if (lookupRange.Address.ToRow > lookupRange.Dimension.ToRow)
             {
                 return lookupRange.Dimension.ToRow - lookupRange.Address.FromRow + 1;
-            }            
+            }
             return _lookupRange.Size.NumberOfRows;
         }
+
         private int GetMaxItemsColumns(IRangeInfo lookupRange)
         {
+            var adjusted = lookupRange.GetAddressDimensionAdjusted(0);
+            if (adjusted != null)
+            {
+                return adjusted.ToCol - adjusted.FromCol + 1;
+            }
             if (lookupRange.Address.ToCol > lookupRange.Dimension.ToCol)
             {
                 return lookupRange.Dimension.ToCol - lookupRange.Address.FromCol + 1;

--- a/src/EPPlus/FormulaParsing/Excel/Operators/RangeOperationsOperator.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Operators/RangeOperationsOperator.cs
@@ -10,16 +10,11 @@
  *************************************************************************************************
   05/30/2022         EPPlus Software AB       EPPlus 6.1
  *************************************************************************************************/
-using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
-using OfficeOpenXml.FormulaParsing.Excel.Functions.Text;
 using OfficeOpenXml.FormulaParsing.FormulaExpressions;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
 using OfficeOpenXml.FormulaParsing.Ranges;
-using OfficeOpenXml.Utils;
 using OfficeOpenXml.Utils.TypeConversion;
 using System;
-using System.Globalization;
-using System.Linq;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Operators
 {
@@ -42,18 +37,30 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
         internal static InMemoryRange Negate(IRangeInfo ri)
         {
             InMemoryRange imr;
-            if(ri.IsInMemoryRange==false)
+            if (ri.IsInMemoryRange == false)
             {
-                imr = new InMemoryRange(ri.Size);
+                var physicalRows = RangeHelper.GetPhysicalRows(ri);
+                var logicalRows = ri.Size.NumberOfRows;
+                if (physicalRows < logicalRows)
+                {
+                    imr = new InMemoryRange(
+                        new RangeDefinition(physicalRows, ri.Size.NumberOfCols),
+                        logicalRows);
+                }
+                else
+                {
+                    imr = new InMemoryRange(ri.Size);
+                }
             }
             else
             {
                 imr = (InMemoryRange)ri;
             }
 
+            int rows = imr.PhysicalRows;
             for (int c = 0; c < ri.Size.NumberOfCols; c++)
             {
-                for (int r = 0; r < ri.Size.NumberOfRows; r++)
+                for (int r = 0; r < rows; r++)
                 {
                     var d = ConvertUtil.GetValueDouble(ri.GetOffset(r, c), false, true);
 
@@ -67,20 +74,62 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
                     }
                 }
             }
+
+            if (imr.HasVirtualRows)
+            {
+                // Compute the negation of an empty cell: -(0) = 0
+                // Use the upstream default if one exists, otherwise null (= 0)
+                var srcDefault = imr.VirtualDefaultValue;
+                if (srcDefault == null)
+                {
+                    srcDefault = 0d;
+                }
+                var d = ConvertUtil.GetValueDouble(srcDefault, false, false);
+                if (double.IsNaN(d))
+                {
+                    imr.VirtualDefaultValue = ErrorValues.ValueError;
+                }
+                else
+                {
+                    imr.VirtualDefaultValue = d == 0d ? 0d : -d;
+                }
+            }
+
             return imr;
         }
+
         private static InMemoryRange CreateRange(IRangeInfo l, IRangeInfo r, FormulaRangeAddress address)
         {
             var width = Math.Max(l.Size.NumberOfCols, r.Size.NumberOfCols);
-            var height = Math.Max(l.Size.NumberOfRows, r.Size.NumberOfRows);
-            var rangeDef = new RangeDefinition(height, width);
-            if(address != null)
+
+            int logicalHeight = Math.Max(l.Size.NumberOfRows, r.Size.NumberOfRows);
+            int physicalHeight = Math.Max(
+                RangeHelper.GetPhysicalRows(l),
+                RangeHelper.GetPhysicalRows(r));
+
+            if (physicalHeight >= logicalHeight)
             {
-                return new InMemoryRange(address, rangeDef);
+                // No virtual rows needed - existing behavior
+                var rangeDef = new RangeDefinition(logicalHeight, width);
+                if (address != null)
+                {
+                    return new InMemoryRange(address, rangeDef);
+                }
+                else
+                {
+                    return new InMemoryRange(rangeDef);
+                }
+            }
+
+            // Virtual range: small backing array, large logical size
+            var physicalDef = new RangeDefinition(physicalHeight, width);
+            if (address != null)
+            {
+                return new InMemoryRange(address, physicalDef, logicalHeight);
             }
             else
             {
-                return new InMemoryRange(rangeDef);
+                return new InMemoryRange(physicalDef, logicalHeight);
             }
         }
 
@@ -105,7 +154,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
         {
             var res = ApplyOperator(leftVal, rightVal, op, out bool error, context);
             var resultValue = res.ResultValue;
-            if(!(resultValue is bool) && ConvertUtil.IsNumeric(resultValue) && res.ResultNumeric == 0d)
+            if (!(resultValue is bool) && ConvertUtil.IsNumeric(resultValue) && res.ResultNumeric == 0d)
             {
                 // avoid -0 results.
                 resultValue = 0d;
@@ -115,7 +164,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
 
         private static bool ShouldUseSingleRow(RangeDefinition lSize, RangeDefinition rSize)
         {
-            if((lSize.NumberOfRows == 1 || rSize.NumberOfRows == 1) && lSize.NumberOfCols == rSize.NumberOfCols)
+            if ((lSize.NumberOfRows == 1 || rSize.NumberOfRows == 1) && lSize.NumberOfCols == rSize.NumberOfCols)
             {
                 return true;
             }
@@ -143,11 +192,11 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
 
         private static bool AddressIsNotAvailable(RangeDefinition lSize, RangeDefinition rSize, int row, int col)
         {
-            if(row >= lSize.NumberOfRows || row >=rSize.NumberOfRows)
+            if (row >= lSize.NumberOfRows || row >= rSize.NumberOfRows)
             {
                 return true;
             }
-            else if(col >= lSize.NumberOfCols || col >= rSize.NumberOfCols)
+            else if (col >= lSize.NumberOfCols || col >= rSize.NumberOfCols)
             {
                 return true;
             }
@@ -193,22 +242,48 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
             catch
             {
                 throw;
-            }           
+            }
         }
 
-        public static InMemoryRange ApplySingleValueRight(CompileResult left, CompileResult right, Operators op, ParsingContext context)
+        private static void SetVirtualDefault(
+            InMemoryRange resultRange,
+            CompileResult nullLeft,
+            CompileResult nullRight,
+            Operators op,
+            ParsingContext context)
+        {
+            if (!resultRange.HasVirtualRows) return;
+
+            var res = ApplyOperator(nullLeft, nullRight, op, out bool error, context);
+            if (error)
+            {
+                resultRange.VirtualDefaultValue = ExcelErrorValue.Create(eErrorType.Value);
+            }
+            else
+            {
+                var resultValue = res.ResultValue;
+                if (!(resultValue is bool) && ConvertUtil.IsNumeric(resultValue) && res.ResultNumeric == 0d)
+                {
+                    resultValue = 0d;
+                }
+                resultRange.VirtualDefaultValue = resultValue;
+            }
+        }
+
+        public static InMemoryRange ApplySingleValueRight(
+            CompileResult left, CompileResult right, Operators op, ParsingContext context)
         {
             var lr = left.Result as IRangeInfo;
-            if(lr == null && left.Result is FormulaRangeAddress fra)
+            if (lr == null && left.Result is FormulaRangeAddress fra)
             {
                 lr = context.ExcelDataProvider.GetRange(fra);
             }
-            else if(left.Address != null && left.Result is not InMemoryRange)
+            else if (left.Address != null && left.Result is not InMemoryRange)
             {
                 lr = context.ExcelDataProvider.GetRange(left.Address);
             }
             var resultRange = CreateRange(lr, InMemoryRange.Empty, lr.Address);
-            for (var row = 0; row < resultRange.Size.NumberOfRows; row++)
+            for (var row = 0; row < resultRange.PhysicalRows; row++)
             {
                 for (var col = 0; col < resultRange.Size.NumberOfCols; col++)
                 {
@@ -217,10 +292,16 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
                     SetValue(op, resultRange, row, col, lcr, right, context);
                 }
             }
+
+            // Compute default for virtual rows: null op scalar
+            SetVirtualDefault(resultRange,
+                CompileResultFactory.Create(null), right, op, context);
+
             return resultRange;
         }
 
-        public static InMemoryRange ApplySingleValueLeft(CompileResult left, CompileResult right, Operators op, ParsingContext context)
+        public static InMemoryRange ApplySingleValueLeft(
+            CompileResult left, CompileResult right, Operators op, ParsingContext context)
         {
             var rr = right.Result as IRangeInfo;
             if (rr == null && right.Result is FormulaRangeAddress fra)
@@ -232,7 +313,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
                 rr = context.ExcelDataProvider.GetRange(right.Address);
             }
             var resultRange = CreateRange(InMemoryRange.Empty, rr, rr.Address);
-            for (var row = 0; row < resultRange.Size.NumberOfRows; row++)
+            for (var row = 0; row < resultRange.PhysicalRows; row++)
             {
                 for (var col = 0; col < resultRange.Size.NumberOfCols; col++)
                 {
@@ -242,18 +323,83 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
                     SetValue(op, resultRange, row, col, left, rcr, context);
                 }
             }
+
+            // Compute default for virtual rows: scalar op null
+            SetVirtualDefault(resultRange,
+                left, CompileResultFactory.Create(null), op, context);
+
             return resultRange;
+        }
+
+        private static void SetVirtualDefaultForRanges(
+              InMemoryRange resultRange,
+              IRangeInfo lr,
+              IRangeInfo rr,
+              bool shouldUseSingleRow,
+              bool shouldUseSingleCell,
+              bool singleRowSingleCol,
+              Operators op,
+              ParsingContext context)
+        {
+            if (!resultRange.HasVirtualRows) return;
+
+            CompileResult virtualLeft, virtualRight;
+            if (shouldUseSingleRow)
+            {
+                if (lr.Size.NumberOfRows == 1)
+                {
+                    virtualLeft = CompileResultFactory.Create(GetCellValue(lr, 0, 0));
+                    virtualRight = CompileResultFactory.Create(null);
+                }
+                else
+                {
+                    virtualLeft = CompileResultFactory.Create(null);
+                    virtualRight = CompileResultFactory.Create(GetCellValue(rr, 0, 0));
+                }
+            }
+            else if (shouldUseSingleCell)
+            {
+                if (lr.Size.NumberOfCols == 1 && lr.Size.NumberOfRows == 1)
+                {
+                    virtualLeft = CompileResultFactory.Create(GetCellValue(lr, 0, 0));
+                    virtualRight = CompileResultFactory.Create(null);
+                }
+                else
+                {
+                    virtualLeft = CompileResultFactory.Create(null);
+                    virtualRight = CompileResultFactory.Create(GetCellValue(rr, 0, 0));
+                }
+            }
+            else if (singleRowSingleCol)
+            {
+                if (lr.Size.NumberOfRows == 1)
+                {
+                    virtualLeft = CompileResultFactory.Create(GetCellValue(lr, 0, 0));
+                    virtualRight = CompileResultFactory.Create(null);
+                }
+                else
+                {
+                    virtualLeft = CompileResultFactory.Create(null);
+                    virtualRight = CompileResultFactory.Create(GetCellValue(rr, 0, 0));
+                }
+            }
+            else
+            {
+                virtualLeft = CompileResultFactory.Create(null);
+                virtualRight = CompileResultFactory.Create(null);
+            }
+            SetVirtualDefault(resultRange, virtualLeft, virtualRight, op, context);
         }
 
         private static InMemoryRange ApplyRanges(CompileResult left, CompileResult right, Operators op, ParsingContext context, FormulaRangeAddress intersectAddress)
         {
             var lr = left.Result as IRangeInfo;
             var rr = right.Result as IRangeInfo;
-            if(lr == null && left.Result is FormulaRangeAddress fral)
+            if (lr == null && left.Result is FormulaRangeAddress fral)
             {
                 lr = new RangeInfo(fral);
             }
-            if(rr == null && right.Result is FormulaRangeAddress frar)
+            if (rr == null && right.Result is FormulaRangeAddress frar)
             {
                 rr = new RangeInfo(frar);
             }
@@ -263,7 +409,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
             var shouldUseSingleRow = ShouldUseSingleRow(lr.Size, rr.Size);
             var shouldUseSingleCell = ShouldUseSingleCell(lr.Size, rr.Size);
             var singleRowSingleCol = SingleRowSingleCol(lr.Size, rr.Size);
-            for (var row = 0; row < resultRange.Size.NumberOfRows; row++)
+            for (var row = 0; row < resultRange.PhysicalRows; row++)
             {
                 for (var col = 0; col < resultRange.Size.NumberOfCols; col++)
                 {
@@ -339,6 +485,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
                     }
                 }
             }
+
+            SetVirtualDefaultForRanges(resultRange, lr, rr,
+                shouldUseSingleRow, shouldUseSingleCell, singleRowSingleCol,
+                op, context);
 
             return resultRange;
         }

--- a/src/EPPlus/FormulaParsing/ExcelUtilities/RangeFlattener.cs
+++ b/src/EPPlus/FormulaParsing/ExcelUtilities/RangeFlattener.cs
@@ -10,13 +10,10 @@
  *************************************************************************************************
   21/06/2023         EPPlus Software AB       Initial release EPPlus 7
  *************************************************************************************************/
+using OfficeOpenXml.FormulaParsing.Ranges;
 using OfficeOpenXml.Utils.TypeConversion;
-using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
-using OfficeOpenXml.Utils;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OfficeOpenXml.FormulaParsing.ExcelUtilities
 {
@@ -32,8 +29,9 @@ namespace OfficeOpenXml.FormulaParsing.ExcelUtilities
         public static List<double?> FlattenRange(IRangeInfo r1, bool addNullifEmpty = true)
         {
             var result = new List<double?>();
+            int rows = RangeHelper.GetPhysicalRows(r1);
 
-            for (var row = 0; row < r1.Size.NumberOfRows; row++)
+            for (var row = 0; row < rows; row++)
             {
                 for (var column = 0; column < r1.Size.NumberOfCols; column++)
                 {
@@ -67,7 +65,8 @@ namespace OfficeOpenXml.FormulaParsing.ExcelUtilities
             return result;
         }
         /// <summary>
-        /// Produces two lists based on the supplied ranges. The lists will contain all data from positions where both ranges has numeric values. 
+        /// Produces two lists based on the supplied ranges.
+        /// The lists will contain all data from positions where both ranges has numeric values. 
         /// </summary>
         /// <param name="r1">range 1</param>
         /// <param name="r2">range 2</param>

--- a/src/EPPlus/FormulaParsing/FormulaExpressions/FunctionCompilers/CustomArrayBehaviourCompiler.cs
+++ b/src/EPPlus/FormulaParsing/FormulaExpressions/FunctionCompilers/CustomArrayBehaviourCompiler.cs
@@ -40,18 +40,18 @@ namespace OfficeOpenXml.FormulaParsing.FormulaExpressions.FunctionCompilers
         public override CompileResult Compile(IEnumerable<CompileResult> children, ParsingContext context)
         {
             var args = new List<FunctionArgument>();
-            
+
             if (!children.Any()) return new CompileResult(eErrorType.Value);
 
             var rangeArgs = new Dictionary<int, IRangeInfo>();
             var otherArgs = new Dictionary<int, CompileResult>();
-            for(var ix = 0; ix < children.Count(); ix++)
+            for (var ix = 0; ix < children.Count(); ix++)
             {
                 var cr = children.ElementAt(ix);
-                if(cr.DataType == DataType.ExcelRange && Function.ArrayBehaviourConfig.CanBeArrayArg(ix) && (cr.Result is IRangeInfo || cr.Result is FormulaRangeAddress))
+                if (cr.DataType == DataType.ExcelRange && Function.ArrayBehaviourConfig.CanBeArrayArg(ix) && (cr.Result is IRangeInfo || cr.Result is FormulaRangeAddress))
                 {
                     var range = cr.Result as IRangeInfo;
-                    if(range == null && cr.Result is FormulaRangeAddress fra)
+                    if (range == null && cr.Result is FormulaRangeAddress fra)
                     {
                         range = new RangeInfo(fra);
                     }
@@ -71,7 +71,7 @@ namespace OfficeOpenXml.FormulaParsing.FormulaExpressions.FunctionCompilers
                 }
                 else
                 {
-                    if(cr.DataType == DataType.ExcelRange)
+                    if (cr.DataType == DataType.ExcelRange)
                     {
                         cr = CompileResultFactory.Create(cr.Result);
                     }
@@ -79,55 +79,78 @@ namespace OfficeOpenXml.FormulaParsing.FormulaExpressions.FunctionCompilers
                 }
             }
 
-            if(rangeArgs.Count == 0)
+            if (rangeArgs.Count == 0)
             {
                 var defaultCompiler = new DefaultCompiler(Function);
                 return defaultCompiler.Compile(children, context);
             }
 
             short maxWidth = 0;
-            var maxHeight = 0;
-            foreach(var rangeArg in rangeArgs.Values)
+            var maxPhysicalHeight = 0;
+            var maxLogicalHeight = 0;
+            foreach (var rangeArg in rangeArgs.Values)
             {
-                if(rangeArg.Size.NumberOfCols > maxWidth)
+                if (rangeArg.Size.NumberOfCols > maxWidth)
                 {
                     maxWidth = rangeArg.Size.NumberOfCols;
                 }
-                if(rangeArg.Size.NumberOfRows > maxHeight) 
+
+                int physical = RangeHelper.GetPhysicalRows(rangeArg);
+                if (physical > maxPhysicalHeight)
                 {
-                    maxHeight= rangeArg.Size.NumberOfRows;
+                    maxPhysicalHeight = physical;
+                }
+                if (rangeArg.Size.NumberOfRows > maxLogicalHeight)
+                {
+                    maxLogicalHeight = rangeArg.Size.NumberOfRows;
                 }
             }
 
-            var resultRangeDef = new RangeDefinition(maxHeight, maxWidth);
             InMemoryRange resultRange;
-            if(rangeArgs.Count==1)
+            if (maxPhysicalHeight < maxLogicalHeight)
             {
-                resultRange = new InMemoryRange(rangeArgs.First().Value.Address, resultRangeDef);
+                var physicalDef = new RangeDefinition(maxPhysicalHeight, maxWidth);
+                if (rangeArgs.Count == 1)
+                {
+                    resultRange = new InMemoryRange(rangeArgs.First().Value.Address, physicalDef, maxLogicalHeight);
+                }
+                else
+                {
+                    resultRange = new InMemoryRange(physicalDef, maxLogicalHeight);
+                }
             }
             else
             {
-               resultRange = new InMemoryRange(resultRangeDef);
+                var rangeDef = new RangeDefinition(maxLogicalHeight, maxWidth);
+                if (rangeArgs.Count == 1)
+                {
+                    resultRange = new InMemoryRange(rangeArgs.First().Value.Address, rangeDef);
+                }
+                else
+                {
+                    resultRange = new InMemoryRange(rangeDef);
+                }
             }
+
             var nArgs = children.Count();
-            for(var row = 0; row < resultRange.Size.NumberOfRows; row++)
+            for (var row = 0; row < resultRange.PhysicalRows; row++)
             {
-                for(var col = 0; col < resultRange.Size.NumberOfCols; col++)
+                for (var col = 0; col < resultRange.Size.NumberOfCols; col++)
                 {
                     bool isError = false;
                     var argList = new List<FunctionArgument>();
-                    for(var argIx = 0; argIx < nArgs; argIx++)
+                    for (var argIx = 0; argIx < nArgs; argIx++)
                     {
-                        if(rangeArgs.ContainsKey(argIx))
+                        if (rangeArgs.ContainsKey(argIx))
                         {
                             var range = rangeArgs[argIx];
                             var r = row;
                             var c = col;
-                            if(range.Size.NumberOfCols == 1 && range.Size.NumberOfRows == resultRange.Size.NumberOfRows)
+                            if (range.Size.NumberOfCols == 1 && range.Size.NumberOfRows == resultRange.Size.NumberOfRows)
                             {
                                 c = 0;
                             }
-                            if(range.Size.NumberOfRows == 1 && range.Size.NumberOfCols == resultRange.Size.NumberOfCols)
+                            if (range.Size.NumberOfRows == 1 && range.Size.NumberOfCols == resultRange.Size.NumberOfCols)
                             {
                                 r = 0;
                             }
@@ -149,12 +172,12 @@ namespace OfficeOpenXml.FormulaParsing.FormulaExpressions.FunctionCompilers
                                     continue;
                                 }
                             }
-                            
+
                         }
                         else
                         {
                             var arg = otherArgs[argIx];
-                            if(arg.DataType == DataType.LambdaCalculation)
+                            if (arg.DataType == DataType.LambdaCalculation)
                             {
                                 var calculator = arg.ResultValue as LambdaCalculator;
                                 calculator.BeginCalculation();

--- a/src/EPPlus/FormulaParsing/LexicalAnalysis/FormulaAddress.cs
+++ b/src/EPPlus/FormulaParsing/LexicalAnalysis/FormulaAddress.cs
@@ -708,16 +708,15 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
         /// </summary>
         /// <param name="package">The <see cref="ExcelPackage"/> that contains the address</param>
         /// <returns></returns>
+
         public bool HasFormulas(ExcelPackage package)
         {
             if (_hasFormulas.HasValue) return _hasFormulas.Value;
-
             if (package == null || WorksheetIx < 0)
             {
                 _hasFormulas = false;
                 return false;
             }
-
             var ws = package.Workbook.GetWorksheetByIndexInList(WorksheetIx);
             if (ws == null)
             {
@@ -725,10 +724,30 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
                 return false;
             }
 
-            // Check if range contains formulas
-            for (var row = FromRow; row <= ToRow; row++)
+            // Clamp to worksheet dimension to avoid iterating 1M rows
+            // for full column references
+            var dim = ws.Dimension;
+            var fromRow = FromRow;
+            var toRow = ToRow;
+            var fromCol = FromCol;
+            var toCol = ToCol;
+            if (dim != null)
             {
-                for (var col = FromCol; col <= ToCol; col++)
+                fromRow = Math.Max(fromRow, dim._fromRow);
+                toRow = Math.Min(toRow, dim._toRow);
+                fromCol = Math.Max(fromCol, dim._fromCol);
+                toCol = Math.Min(toCol, dim._toCol);
+            }
+            else
+            {
+                // No dimension means no data, hence no formulas
+                _hasFormulas = false;
+                return false;
+            }
+
+            for (var row = fromRow; row <= toRow; row++)
+            {
+                for (var col = fromCol; col <= toCol; col++)
                 {
                     if (ws._formulas.GetValue(row, col) != null)
                     {
@@ -737,7 +756,6 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
                     }
                 }
             }
-
             _hasFormulas = false;
             return false;
         }

--- a/src/EPPlus/FormulaParsing/Ranges/InMemoryRange.cs
+++ b/src/EPPlus/FormulaParsing/Ranges/InMemoryRange.cs
@@ -36,8 +36,6 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
             _physicalRows = rangeDef.NumberOfRows;
             Size = rangeDef;
             _address = new FormulaRangeAddress() { FromRow = 0, FromCol = 0, ToRow = rangeDef.NumberOfRows - 1, ToCol = rangeDef.NumberOfCols - 1 };
-            Debug.Assert(_physicalRows >= 0);
-            Debug.Assert(_physicalRows <= Size.NumberOfRows);
         }
         /// <summary>
         /// The constructor
@@ -55,8 +53,6 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
             _cells = new ICellInfo[rangeDef.NumberOfRows, rangeDef.NumberOfCols];
             _physicalRows = rangeDef.NumberOfRows;
             Size = rangeDef;
-            Debug.Assert(_physicalRows >= 0);
-            Debug.Assert(_physicalRows <= Size.NumberOfRows);
         }
 
         /// <summary>
@@ -76,8 +72,6 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
             _physicalRows = physicalDef.NumberOfRows;
             _cells = new ICellInfo[physicalDef.NumberOfRows, physicalDef.NumberOfCols];
             Size = new RangeDefinition(logicalRows, physicalDef.NumberOfCols);
-            Debug.Assert(_physicalRows >= 0);
-            Debug.Assert(_physicalRows <= Size.NumberOfRows);
         }
 
         /// <summary>
@@ -98,8 +92,6 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
                 ToRow = logicalRows - 1,
                 ToCol = physicalDef.NumberOfCols - 1
             };
-            Debug.Assert(_physicalRows >= 0);
-            Debug.Assert(_physicalRows <= Size.NumberOfRows);
         }
 
         /// <summary>
@@ -119,8 +111,6 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
                 }
             }
             _address = new FormulaRangeAddress() { FromRow = 0, FromCol = 0, ToRow = Size.NumberOfRows - 1, ToCol = Size.NumberOfCols - 1 };
-            Debug.Assert(_physicalRows >= 0);
-            Debug.Assert(_physicalRows <= Size.NumberOfRows);
         }
 
         /// <summary>
@@ -141,8 +131,6 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
                 }
             }
             _address = new FormulaRangeAddress() { FromRow = 0, FromCol = 0, ToRow = Size.NumberOfRows - 1, ToCol = Size.NumberOfCols - 1 };
-            Debug.Assert(_physicalRows >= 0);
-            Debug.Assert(_physicalRows <= Size.NumberOfRows);
         }
 
         /// <summary>

--- a/src/EPPlus/FormulaParsing/Ranges/InMemoryRange.cs
+++ b/src/EPPlus/FormulaParsing/Ranges/InMemoryRange.cs
@@ -25,6 +25,7 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
     [DebuggerDisplay("{Size}")]
     public class InMemoryRange : IRangeInfo
     {
+
         /// <summary>
         /// The constructor
         /// </summary>
@@ -32,24 +33,75 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         public InMemoryRange(RangeDefinition rangeDef)
         {
             _cells = new ICellInfo[rangeDef.NumberOfRows, rangeDef.NumberOfCols];
+            _physicalRows = rangeDef.NumberOfRows;
             Size = rangeDef;
             _address = new FormulaRangeAddress() { FromRow = 0, FromCol = 0, ToRow = rangeDef.NumberOfRows - 1, ToCol = rangeDef.NumberOfCols - 1 };
+            Debug.Assert(_physicalRows >= 0);
+            Debug.Assert(_physicalRows <= Size.NumberOfRows);
         }
         /// <summary>
         /// The constructor
         /// </summary>
-        /// <param name="address">The worksheet address that should be used for this range. Will be used for implicit intersection.</param>
+        /// <param name="address">The worksheet address that should be used for this range.
+        /// Will be used for implicit intersection.</param>
         /// <param name="rangeDef">Defines the size of the range</param>
         public InMemoryRange(FormulaRangeAddress address, RangeDefinition rangeDef)
         {
-            if (address?._context != null)
+            if (address != null && address._context != null)
             {
                 _ws = address._context.Package.Workbook.GetWorksheetByIndexInList(address._context.CurrentCell.WorksheetIx);
             }
             _address = address;
             _cells = new ICellInfo[rangeDef.NumberOfRows, rangeDef.NumberOfCols];
+            _physicalRows = rangeDef.NumberOfRows;
             Size = rangeDef;
+            Debug.Assert(_physicalRows >= 0);
+            Debug.Assert(_physicalRows <= Size.NumberOfRows);
         }
+
+        /// <summary>
+        /// Constructor for a virtual range with a small physical backing array but large logical size.
+        /// Rows beyond <paramref name="physicalDef"/>.NumberOfRows are virtual and return null.
+        /// </summary>
+        /// <param name="address">The worksheet address for implicit intersection.</param>
+        /// <param name="physicalDef">Defines the physical (backed) size of the range.</param>
+        /// <param name="logicalRows">The full logical row count (e.g. 1048576 for a full column).</param>
+        internal InMemoryRange(FormulaRangeAddress address, RangeDefinition physicalDef, int logicalRows)
+        {
+            if (address != null && address._context != null)
+            {
+                _ws = address._context.Package.Workbook.GetWorksheetByIndexInList(address._context.CurrentCell.WorksheetIx);
+            }
+            _address = address;
+            _physicalRows = physicalDef.NumberOfRows;
+            _cells = new ICellInfo[physicalDef.NumberOfRows, physicalDef.NumberOfCols];
+            Size = new RangeDefinition(logicalRows, physicalDef.NumberOfCols);
+            Debug.Assert(_physicalRows >= 0);
+            Debug.Assert(_physicalRows <= Size.NumberOfRows);
+        }
+
+        /// <summary>
+        /// Constructor for a virtual range without an address.
+        /// Rows beyond <paramref name="physicalDef"/>.NumberOfRows are virtual and return null.
+        /// </summary>
+        /// <param name="physicalDef">Defines the physical (backed) size of the range.</param>
+        /// <param name="logicalRows">The full logical row count.</param>
+        internal InMemoryRange(RangeDefinition physicalDef, int logicalRows)
+        {
+            _physicalRows = physicalDef.NumberOfRows;
+            _cells = new ICellInfo[physicalDef.NumberOfRows, physicalDef.NumberOfCols];
+            Size = new RangeDefinition(logicalRows, physicalDef.NumberOfCols);
+            _address = new FormulaRangeAddress()
+            {
+                FromRow = 0,
+                FromCol = 0,
+                ToRow = logicalRows - 1,
+                ToCol = physicalDef.NumberOfCols - 1
+            };
+            Debug.Assert(_physicalRows >= 0);
+            Debug.Assert(_physicalRows <= Size.NumberOfRows);
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -57,6 +109,7 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         public InMemoryRange(List<List<object>> range)
         {
             Size = new RangeDefinition(range.Count, (short)range[0].Count);
+            _physicalRows = Size.NumberOfRows;
             _cells = new ICellInfo[Size.NumberOfRows, Size.NumberOfCols];
             for (int c = 0; c < Size.NumberOfCols; c++)
             {
@@ -66,15 +119,19 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
                 }
             }
             _address = new FormulaRangeAddress() { FromRow = 0, FromCol = 0, ToRow = Size.NumberOfRows - 1, ToCol = Size.NumberOfCols - 1 };
+            Debug.Assert(_physicalRows >= 0);
+            Debug.Assert(_physicalRows <= Size.NumberOfRows);
         }
 
         /// <summary>
         /// Constructor
         /// </summary>
-        /// <param name="ri">Another <see cref="IRangeInfo"/> used as clone for this range. The address of the supplied range will not be copied.</param>
+        /// <param name="ri">Another <see cref="IRangeInfo"/> used as clone for this range.
+        /// The address of the supplied range will not be copied.</param>
         public InMemoryRange(IRangeInfo ri)
         {
             Size = ri.Size;
+            _physicalRows = Size.NumberOfRows;
             _cells = new ICellInfo[Size.NumberOfRows, Size.NumberOfCols];
             for (int c = 0; c < Size.NumberOfCols; c++)
             {
@@ -84,6 +141,8 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
                 }
             }
             _address = new FormulaRangeAddress() { FromRow = 0, FromCol = 0, ToRow = Size.NumberOfRows - 1, ToCol = Size.NumberOfCols - 1 };
+            Debug.Assert(_physicalRows >= 0);
+            Debug.Assert(_physicalRows <= Size.NumberOfRows);
         }
 
         /// <summary>
@@ -101,6 +160,8 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         private readonly ICellInfo[,] _cells;
         private int _colIx = -1;
         private int _rowIndex = 0;
+        private readonly int _physicalRows;
+        private object _virtualDefaultValue;  // null means "no default" (backward compat)
 
         private static InMemoryRange _empty = new InMemoryRange(new RangeDefinition(0, 0));
 
@@ -110,6 +171,35 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         public static InMemoryRange Empty => _empty;
 
         /// <summary>
+        /// Number of rows backed by the physical cell array.
+        /// For non-virtual ranges this equals Size.NumberOfRows.
+        /// </summary>
+        internal int PhysicalRows
+        {
+            get { return _physicalRows; }
+        }
+
+
+        /// <summary>
+        /// The value returned for rows beyond PhysicalRows.
+        /// When null (default), virtual rows return null.
+        /// When set, virtual rows return this value instead.
+        /// </summary>
+        internal object VirtualDefaultValue
+        {
+            get { return _virtualDefaultValue; }
+            set { _virtualDefaultValue = value; }
+        }
+
+        /// <summary>
+        /// True if the range has virtual (unstored) rows beyond PhysicalRows.
+        /// </summary>
+        internal bool HasVirtualRows
+        {
+            get { return Size.NumberOfRows > _physicalRows; }
+        }
+
+        /// <summary>
         /// Sets the value for a cell.
         /// </summary>
         /// <param name="row">The row</param>
@@ -117,6 +207,7 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         /// <param name="val">The value to set</param>
         public void SetValue(int row, int col, object val)
         {
+            if (row >= _physicalRows) return;
             var c = new InMemoryCellInfo(val);
             _cells[row, col] = c;
         }
@@ -129,6 +220,7 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         /// <param name="cell">The cell</param>
         public void SetCell(int row, int col, ICellInfo cell)
         {
+            if (row >= _physicalRows) return;
             _cells[row, col] = cell;
         }
         /// <summary>
@@ -165,7 +257,7 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         public FormulaRangeAddress Dimension
         {
             get
-            {        
+            {
                 return _address;
             }
         }
@@ -190,7 +282,7 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         /// <summary>
         /// The addresses for the range, if more than one.
         /// </summary>
-        public FormulaRangeAddress[] Addresses => [_address];
+        public FormulaRangeAddress[] Addresses => new FormulaRangeAddress[] { _address };
 
         /// <summary>
         /// Dispose
@@ -226,12 +318,10 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         /// <returns>The value of the cell</returns>
         public object GetOffset(int rowOffset, int colOffset)
         {
+            if (rowOffset >= _physicalRows)
+                return _virtualDefaultValue;  // was: return null;
             var c = _cells[rowOffset, colOffset];
-            if (c == null)
-            {
-                return null;
-            }
-            return c.Value;
+            return c == null ? null : c.Value;
         }
 
         /// <summary>
@@ -242,23 +332,43 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         /// <param name="rowOffsetEnd">The ending row offset from the top-left cell.</param>
         /// <param name="colOffsetStart">The ending column offset from the top-left cell</param>
         /// <returns>The value of the cell</returns>
-        public IRangeInfo GetOffset(int rowOffsetStart, int colOffsetStart, int rowOffsetEnd, int colOffsetEnd)
+        public IRangeInfo GetOffset(int rowOffsetStart, int colOffsetStart,
+                             int rowOffsetEnd, int colOffsetEnd)
         {
-            var nRows = Math.Abs(rowOffsetEnd - rowOffsetStart);
-            var nCols = (short)Math.Abs(colOffsetEnd- colOffsetStart);
-            nRows++;
-            nCols++;
-            var rangeDef = new RangeDefinition(nRows, nCols);
-            var result = new InMemoryRange(rangeDef);
-            var rowIx = 0;
-            for(var row = rowOffsetStart; row <= rowOffsetEnd; row++)
+            var logicalRows = rowOffsetEnd - rowOffsetStart + 1;
+            var nCols = (short)(colOffsetEnd - colOffsetStart + 1);
+
+            if (rowOffsetStart >= _physicalRows)
+            {
+                var emptyRange = new InMemoryRange(new RangeDefinition(0, nCols), logicalRows);
+                emptyRange._virtualDefaultValue = _virtualDefaultValue;  // propagate
+                return emptyRange;
+            }
+
+            var physicalEnd = Math.Min(rowOffsetEnd, _physicalRows - 1);
+            var physicalRows = physicalEnd - rowOffsetStart + 1;
+
+            InMemoryRange result;
+            if (physicalRows < logicalRows)
+            {
+                result = new InMemoryRange(new RangeDefinition(physicalRows, nCols), logicalRows);
+                result._virtualDefaultValue = _virtualDefaultValue;  // propagate
+            }
+            else
+            {
+                result = new InMemoryRange(new RangeDefinition(physicalRows, nCols));
+            }
+
+            for (var row = rowOffsetStart; row <= physicalEnd; row++)
             {
                 var colIx = 0;
                 for (var col = colOffsetStart; col <= colOffsetEnd; col++)
                 {
-                    result.SetValue(rowIx, colIx++, _cells[row, col].Value);
+                    var cell = _cells[row, col];
+                    var val = cell != null ? cell.Value : null;
+                    result.SetValue(row - rowOffsetStart, colIx, val);
+                    colIx++;
                 }
-                rowIx++;
             }
             return result;
         }
@@ -280,20 +390,12 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         /// <returns></returns>
         public object GetValue(int row, int col)
         {
-            if (_address == null)
-            { 
-                var c = _cells[row, col];
-                if (c == null) return null;
-                return c.Value;
-
-
-            }
-            else
-            {
-                var c = _cells[row-_address.FromRow, col-Address.FromCol];
-                if (c == null) return null;
-                return c.Value;
-            }
+            int r = _address == null ? row : row - _address.FromRow;
+            if (r >= _physicalRows) return _virtualDefaultValue;
+            int c = _address == null ? col : col - _address.FromCol;
+            var cell = _cells[r, c];
+            if (cell == null) return null;
+            return cell.Value;
         }
         /// <summary>
         /// Get cell
@@ -303,6 +405,13 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         /// <returns></returns>
         public ICellInfo GetCell(int row, int col)
         {
+            if (row >= _physicalRows)
+            {
+                // Return a virtual cell with the default value if set
+                if (_virtualDefaultValue != null)
+                    return new InMemoryCellInfo(_virtualDefaultValue);
+                return null;
+            }
             var c = _cells[row, col];
             if (c == null) return null;
             return c;
@@ -320,7 +429,7 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
             }
             _colIx = 0;
             _rowIndex++;
-            if (_rowIndex >= Size.NumberOfRows) return false;
+            if (_rowIndex >= _physicalRows) return false;
             return true;
         }
         /// <summary>
@@ -341,15 +450,26 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
 
         internal static InMemoryRange CloneRange(IRangeInfo ri)
         {
-            var ret = new InMemoryRange(ri.Size);
-            for(int r=0;r < ri.Size.NumberOfRows;r++)
+            var isVirtual = ri is InMemoryRange && ((InMemoryRange)ri).HasVirtualRows;
+            int physRows = isVirtual ? ((InMemoryRange)ri).PhysicalRows : ri.Size.NumberOfRows;
+
+            var ret = isVirtual
+                ? new InMemoryRange(new RangeDefinition(physRows, ri.Size.NumberOfCols),
+                                    ri.Size.NumberOfRows)
+                : new InMemoryRange(ri.Size);
+
+            if (isVirtual)
             {
-                for (int c = 0; c < ri.Size.NumberOfCols;c++)
-                {
-                    ret.SetValue(r,c,ri.GetOffset(r,c));
-                }
+                ret._virtualDefaultValue = ((InMemoryRange)ri)._virtualDefaultValue;
             }
 
+            for (int r = 0; r < physRows; r++)
+            {
+                for (int c = 0; c < ri.Size.NumberOfCols; c++)
+                {
+                    ret.SetValue(r, c, ri.GetOffset(r, c));
+                }
+            }
             return ret;
         }
 
@@ -357,7 +477,7 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         {
             var rows = values.GetUpperBound(0) + 1;
             var ir = new InMemoryRange(rows, 1);
-            for(int r=0;r < rows;r++)
+            for (int r = 0; r < rows; r++)
             {
                 ir.SetValue(r, 0, values[r]);
             }
@@ -365,12 +485,26 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         }
 
         /// <summary>
-        /// Get the address adjusted inside the dimension of the worksheet. Not applicable on InMemoryRange's, as no addresses us used.
+        /// Get the address adjusted inside the dimension of the worksheet.
+        /// Not applicable on InMemoryRange's, as no addresses us used.
         /// </summary>
         /// <param name="index">Not applicable on InMemoryRange's.</param>
         /// <returns>The address.</returns>
         public FormulaRangeAddress GetAddressDimensionAdjusted(int index)
         {
+            if (index > 0) return null;
+
+            if (HasVirtualRows)
+            {
+                // Return address clamped to physical rows
+                return new FormulaRangeAddress()
+                {
+                    FromRow = _address.FromRow,
+                    FromCol = _address.FromCol,
+                    ToRow = _address.FromRow + _physicalRows - 1,
+                    ToCol = _address.ToCol
+                };
+            }
             return _address;
         }
 
@@ -378,7 +512,7 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
         {
             var sb = new StringBuilder();
             sb.Append("{");
-            for (var row = 0; row < Size.NumberOfRows; row++)
+            for (var row = 0; row < _physicalRows; row++)
             {
                 for (var col = 0; col < Size.NumberOfCols; col++)
                 {
@@ -389,7 +523,7 @@ namespace OfficeOpenXml.FormulaParsing.Ranges
                         sb.Append(",");
                     }
                 }
-                if(row < Size.NumberOfRows - 1)
+                if (row < _physicalRows - 1)
                 {
                     sb.Append(";");
                 }

--- a/src/EPPlus/FormulaParsing/Ranges/RangeHelper.cs
+++ b/src/EPPlus/FormulaParsing/Ranges/RangeHelper.cs
@@ -1,0 +1,48 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  03/03/2026         EPPlus Software AB           Virtual InMemoryRange support
+ *************************************************************************************************/
+
+namespace OfficeOpenXml.FormulaParsing.Ranges
+{
+    /// <summary>
+    /// Helper methods for working with range physical/logical size.
+    /// </summary>
+    internal static class RangeHelper
+    {
+        /// <summary>
+        /// Returns the effective number of data rows for a range.
+        /// For virtual InMemoryRanges: the physical row count.
+        /// For worksheet-backed ranges: constrained by worksheet dimension.
+        /// For other ranges: Size.NumberOfRows.
+        /// </summary>
+        internal static int GetPhysicalRows(IRangeInfo range)
+        {
+            if (range is InMemoryRange imr)
+                return imr.PhysicalRows;
+
+            if (!range.IsInMemoryRange && range.Worksheet?.Dimension != null)
+            {
+                var adjusted = range.GetAddressDimensionAdjusted(0);
+                if (adjusted != null)
+                {
+                    // If the adjusted address is invalid (no column overlap),
+                    // the range column has no data at all
+                    if (adjusted.FromCol > adjusted.ToCol || adjusted.FromRow > adjusted.ToRow)
+                        return 0;
+                    return adjusted.ToRow - adjusted.FromRow + 1;
+                }
+            }
+
+            return range.Size.NumberOfRows;
+        }
+    }
+}

--- a/src/EPPlusTest/FormulaParsing/EntireColumnTests.cs
+++ b/src/EPPlusTest/FormulaParsing/EntireColumnTests.cs
@@ -1,0 +1,233 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace EPPlusTest.FormulaParsing
+{
+    [TestClass]
+    public class EntireColumnTests
+    {
+        private ExcelPackage _package;
+        private ExcelWorkbook _workbook;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _package = new ExcelPackage();
+            _workbook = _package.Workbook;
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _package.Dispose();
+        }
+
+        [TestMethod]
+        public void FullColumnRefPlusScalar_EmptyColumn_ShouldReturnOneInFirstAndLastRow()
+        {
+            // Arrange
+            var ws = _workbook.Worksheets.Add("Sheet1");
+            // Column B is entirely empty/blank
+            ws.Cells["C1"].Formula = "B:B+1";
+
+            // Act
+            ws.Calculate();
+
+            // Assert - first row of spill result
+            Assert.AreEqual(1d, ws.Cells["C1"].Value,
+                "First row should be 0 + 1 = 1");
+            var lastRow = ws.Dimension != null ? ws.Dimension.End.Row : 1;
+            Assert.AreEqual(ExcelPackage.MaxRows, ws.Dimension.End.Row,
+                "Spill should extend to the last row of the worksheet");
+            Assert.AreEqual(1d, ws.Cells["C" + lastRow].Value,
+                "Last row of spill should be 0 + 1 = 1");
+        }
+
+        [TestMethod]
+        public void FullColumnRefPlusScalar_WithData_PhysicalRowsCalculatedAndVirtualRowsGetDefault()
+        {
+            // Arrange - B has data in rows 1-3, formula in C1
+            var ws = _workbook.Worksheets.Add("Sheet1");
+            ws.Cells["B1"].Value = 10d;
+            ws.Cells["B2"].Value = 20d;
+            ws.Cells["B3"].Value = 30d;
+            ws.Cells["C1"].Formula = "B:B+5";
+
+            // Act
+            ws.Calculate();
+
+            // Assert - physical rows get their actual calculated values
+            Assert.AreEqual(15d, ws.Cells["C1"].Value);
+            Assert.AreEqual(25d, ws.Cells["C2"].Value);
+            Assert.AreEqual(35d, ws.Cells["C3"].Value);
+            // Virtual rows beyond data: empty + 5 = 5
+            Assert.AreEqual(5d, ws.Cells["C4"].Value,
+                "First virtual row should be 0 + 5 = 5");
+            Assert.AreEqual(5d, ws.Cells["C" + ExcelPackage.MaxRows].Value,
+                "Last row should be 0 + 5 = 5");
+        }
+
+        [TestMethod]
+        public void FullColumnRefEqualsString_VirtualRowsShouldBeFalse()
+        {
+            // Arrange - comparison operator: A:A="Hello"
+            // Virtual rows are empty, empty != "Hello" => FALSE
+            var ws = _workbook.Worksheets.Add("Sheet1");
+            ws.Cells["A1"].Value = "Hello";
+            ws.Cells["A2"].Value = "World";
+            ws.Cells["A3"].Value = "Hello";
+            ws.Cells["B1"].Formula = "A:A=\"Hello\"";
+
+            // Act
+            ws.Calculate();
+
+            // Assert - physical rows
+            Assert.AreEqual(true, ws.Cells["B1"].Value);
+            Assert.AreEqual(false, ws.Cells["B2"].Value);
+            Assert.AreEqual(true, ws.Cells["B3"].Value);
+            // Virtual rows: empty = "Hello" => FALSE
+            Assert.AreEqual(false, ws.Cells["B4"].Value,
+                "Virtual row: empty = \"Hello\" should be FALSE");
+            Assert.AreEqual(false, ws.Cells["B" + ExcelPackage.MaxRows].Value,
+                "Last row should also be FALSE");
+        }
+
+        [TestMethod]
+        public void TwoFullColumnRefsMultiplied_VirtualRowsShouldBeZero()
+        {
+            // Arrange - (A:A=x) * (B:B=y) pattern used in MATCH criteria
+            var ws = _workbook.Worksheets.Add("Sheet1");
+            ws.Cells["A1"].Value = "Alpha";
+            ws.Cells["A2"].Value = "Beta";
+            ws.Cells["B1"].Value = "X";
+            ws.Cells["B2"].Value = "Y";
+            ws.Cells["C1"].Value = 100d;
+            ws.Cells["C2"].Value = 200d;
+
+            // MATCH(1, (A:A="Alpha")*(B:B="X"), 0) should find row 1
+            ws.Cells["E1"].Formula = "MATCH(1,(A:A=\"Alpha\")*(B:B=\"X\"),0)";
+            // INDEX to retrieve the value
+            ws.Cells["F1"].Formula = "INDEX(C:C,MATCH(1,(A:A=\"Alpha\")*(B:B=\"X\"),0))";
+
+            // Act
+            ws.Calculate();
+
+            // Assert
+            Assert.AreEqual(1, ws.Cells["E1"].Value,
+                "MATCH should find row 1");
+            Assert.AreEqual(100d, ws.Cells["F1"].Value,
+                "INDEX should return 100 for Alpha+X");
+        }
+
+        [TestMethod]
+        public void CrossSheetFullColumnRef_IndexMatch_ShouldWork()
+        {
+            // Arrange - the original problem pattern from the design doc
+            var dataWs = _workbook.Worksheets.Add("Data");
+            dataWs.Cells["A1"].Value = "Item1";
+            dataWs.Cells["A2"].Value = "Item2";
+            dataWs.Cells["A3"].Value = "Item1";
+            dataWs.Cells["B1"].Value = "Day Shift";
+            dataWs.Cells["B2"].Value = "Day Shift";
+            dataWs.Cells["B3"].Value = "Night Shift";
+            dataWs.Cells["C1"].Value = 50d;
+            dataWs.Cells["C2"].Value = 75d;
+            dataWs.Cells["C3"].Value = 90d;
+
+            var ws = _workbook.Worksheets.Add("Formulas");
+            ws.Cells["A1"].Value = "Item1";
+            ws.Cells["B1"].Formula =
+                "IFERROR(INDEX(Data!$C:$C,MATCH(1,(Data!$A:$A=A1)*(Data!$B:$B=\"Day Shift\"),0)),\"-\")";
+            // Also test a lookup that should NOT match
+            ws.Cells["A2"].Value = "NoMatch";
+            ws.Cells["B2"].Formula =
+                "IFERROR(INDEX(Data!$C:$C,MATCH(1,(Data!$A:$A=A2)*(Data!$B:$B=\"Day Shift\"),0)),\"-\")";
+
+            // Act
+            _workbook.Calculate();
+
+            // Assert
+            Assert.AreEqual(50d, ws.Cells["B1"].Value,
+                "Should find Item1 + Day Shift => 50");
+            Assert.AreEqual("-", ws.Cells["B2"].Value,
+                "NoMatch should fall through to IFERROR => \"-\"");
+        }
+        [TestMethod]
+        public void ScalarDivideFullColumnRef_VirtualRowsShouldBeDivByZeroError()
+        {
+            // Arrange - 1/B:B where B has data in rows 1-2
+            // Virtual default: 1 / null = 1 / 0 = #DIV/0!
+            var ws = _workbook.Worksheets.Add("Sheet1");
+            ws.Cells["B1"].Value = 2d;
+            ws.Cells["B2"].Value = 4d;
+            ws.Cells["C1"].Formula = "1/B:B";
+
+            // Act
+            ws.Calculate();
+
+            // Assert - physical rows
+            Assert.AreEqual(0.5d, ws.Cells["C1"].Value);
+            Assert.AreEqual(0.25d, ws.Cells["C2"].Value);
+            // Virtual rows: 1 / 0 => #DIV/0!
+            var virtualVal = ws.Cells["C3"].Value;
+            Assert.IsInstanceOfType(virtualVal, typeof(ExcelErrorValue),
+                "Virtual row: 1/0 should produce an error");
+            Assert.AreEqual(eErrorType.Div0, ((ExcelErrorValue)virtualVal).Type,
+                "Error should be #DIV/0!");
+            // Last row should also be #DIV/0!
+            var lastVal = ws.Cells["C" + ExcelPackage.MaxRows].Value;
+            Assert.IsInstanceOfType(lastVal, typeof(ExcelErrorValue),
+                "Last row should also be #DIV/0!");
+        }
+
+        [TestMethod]
+        public void FullColumnRefConcat_VirtualRowsShouldConcatEmpty()
+        {
+            // Arrange - A:A&"!" via the Concat operator
+            // Virtual default: "" & "!" = "!"
+            var ws = _workbook.Worksheets.Add("Sheet1");
+            ws.Cells["A1"].Value = "Hello";
+            ws.Cells["A2"].Value = "World";
+            ws.Cells["B1"].Formula = "A:A&\"!\"";
+
+            // Act
+            ws.Calculate();
+
+            // Assert - physical rows
+            Assert.AreEqual("Hello!", ws.Cells["B1"].Value);
+            Assert.AreEqual("World!", ws.Cells["B2"].Value);
+            // Virtual rows: "" & "!" = "!"
+            Assert.AreEqual("!", ws.Cells["B3"].Value,
+                "Virtual row: empty & \"!\" should be \"!\"");
+            Assert.AreEqual("!", ws.Cells["B" + ExcelPackage.MaxRows].Value,
+                "Last row should also be \"!\"");
+        }
+
+        [TestMethod]
+        public void NegateFullColumnRef_VirtualRowsShouldBeZero()
+        {
+            // Arrange - negation: -A:A
+            // Virtual default: -(null) = -(0) = 0
+            var ws = _workbook.Worksheets.Add("Sheet1");
+            ws.Cells["A1"].Value = 5d;
+            ws.Cells["A2"].Value = -3d;
+            ws.Cells["B1"].Formula = "-A:A";
+
+            // Act
+            ws.Calculate();
+
+            // Assert - physical rows
+            Assert.AreEqual(-5d, ws.Cells["B1"].Value);
+            Assert.AreEqual(3d, ws.Cells["B2"].Value);
+            // Virtual rows: -(0) = 0
+            Assert.AreEqual(0d, ws.Cells["B3"].Value,
+                "Virtual row: -0 should be 0");
+            Assert.AreEqual(0d, ws.Cells["B" + ExcelPackage.MaxRows].Value,
+                "Last row should also be 0");
+        }
+    }
+}

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -3,6 +3,7 @@ using OfficeOpenXml;
 using OfficeOpenXml.FormulaParsing;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.MathFunctions;
 using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
+using OfficeOpenXml.FormulaParsing.Logging;
 using OfficeOpenXml.Sorting;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
## Performance: Virtual InMemoryRange for full column references

Formulas using full column references (e.g. `$A:$A`, `B:B`) in dynamic array expressions caused severe performance degradation. EPPlus materialized 1,048,576 rows regardless of actual data, resulting in millions of unnecessary allocations and iterations.

### Changes

**Virtual InMemoryRange** — New concept separating physical size (backed by data) from logical size (full column). A `_virtualDefaultValue` field stores the pre-computed result for empty rows, avoiding per-cell allocation. Operators (`+`, `*`, `=`, `&`, etc.) compute the default once and propagate it through the chain.

**MATCH/XlookupScanner** — `GetMaxItemsRow` now uses `GetAddressDimensionAdjusted` to limit search to physical rows instead of iterating 1M rows.

**FormulaRangeAddress.HasFormulas** — Loop clamped to worksheet dimension, eliminating 1M iterations per SUMIFS/AVERAGEIFS call with full column references.

### Key files
- `InMemoryRange.cs` — Virtual rows, default value propagation
- `RangeOperationsOperator.cs` — `SetVirtualDefault`, `SetVirtualDefaultForRanges`
- `RangeHelper.cs` — `GetPhysicalRows`
- `XlookupScanner.cs` — Bounded search
- `FormulaRangeAddress.cs` — Bounded `HasFormulas`

### Result
Benchmark workbook: **10.8 minutes → 2.6 seconds** (~250x improvement). Full test suite (6200+ tests) green.

