### PR TITLE
Bug/s1019 Inserting rows or Columns when named range is on MAX row or column resulted in nullref

### DIFF
--- a/src/EPPlus/ExcelAddressBase.cs
+++ b/src/EPPlus/ExcelAddressBase.cs
@@ -1333,8 +1333,9 @@ namespace OfficeOpenXml
             var toCol = GetColumn((setFixed && _toColFixed ? _toCol : _toCol + cols), setRefOnMinMax);
             if (col <= _fromCol)
             {
-                var fromCol = GetColumn((setFixed && _fromColFixed ? _fromCol : _fromCol + cols), setRefOnMinMax);
-                return new ExcelAddressBase(_fromRow, fromCol, _toRow, toCol, _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed, WorkSheetName, _address);
+                var fromCol = setFixed && _fromColFixed ? _fromCol : _fromCol + cols;
+                if (fromCol > ExcelPackage.MaxColumns) return null;
+                return new ExcelAddressBase(_fromRow, GetColumn(fromCol, setRefOnMinMax), _toRow, toCol, _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed, WorkSheetName, _address);
             }
             else
             {

--- a/src/EPPlus/ExcelNamedRange.cs
+++ b/src/EPPlus/ExcelNamedRange.cs
@@ -38,6 +38,8 @@ namespace OfficeOpenXml
             /// </summary>
             RelativeTableAddress = 2
         }
+
+        internal bool SetCommentWarningWhenOverMax = false;
         ExcelWorksheet _sheet;
         /// <summary>
         /// A named range

--- a/src/EPPlus/ExcelNamedRange.cs
+++ b/src/EPPlus/ExcelNamedRange.cs
@@ -39,7 +39,6 @@ namespace OfficeOpenXml
             RelativeTableAddress = 2
         }
 
-        internal bool SetCommentWarningWhenOverMax = false;
         ExcelWorksheet _sheet;
         /// <summary>
         /// A named range

--- a/src/EPPlus/ExcelNamedRangeCollection.cs
+++ b/src/EPPlus/ExcelNamedRangeCollection.cs
@@ -189,6 +189,10 @@ namespace OfficeOpenXml
                 if (rows > 0 && address._toCol<=upperLimit && address._fromCol>=lowerLimint && address.Rows < ExcelPackage.MaxRows)
                 {
                     address = address.AddRow(rowFrom, rows, false);
+                    if(address == null && new ExcelAddressBase(namedRange.Address)._fromRow == 1048576)
+                    {
+                        throw new InvalidOperationException("Cannot insert row over Max Rows");
+                    }
                 }
                 if(cols > 0 && colFrom > 0 && address._toRow <= upperLimit && address._fromRow >= lowerLimint && address.Columns < ExcelPackage.MaxColumns)
                 {

--- a/src/EPPlus/ExcelNamedRangeCollection.cs
+++ b/src/EPPlus/ExcelNamedRangeCollection.cs
@@ -179,26 +179,78 @@ namespace OfficeOpenXml
             Insert(rowFrom, colFrom, rows, cols, n => true, lowerLimint, upperLimit);
         }
 
-        internal void Insert(int rowFrom, int colFrom, int rows, int cols, Func<ExcelNamedRange, bool> filter, int lowerLimint = 0, int upperLimit=int.MaxValue)
+        internal void Insert(int rowFrom, int colFrom, int rows, int cols, Func<ExcelNamedRange, bool> filter, int lowerLimit = 0, int upperLimit=int.MaxValue)
         {
             var namedRanges = this._list.Where(filter);
             foreach(var namedRange in namedRanges)
             {
                 if (namedRange._fromRow <= 0) continue;
                 var address = new ExcelAddressBase(namedRange.Address);
-                if (rows > 0 && address._toCol<=upperLimit && address._fromCol>=lowerLimint && address.Rows < ExcelPackage.MaxRows)
+                if (rows > 0 && address._toCol<=upperLimit && address._fromCol>=lowerLimit && address.Rows < ExcelPackage.MaxRows)
                 {
-                    address = address.AddRow(rowFrom, rows, false);
-                    if(address == null && new ExcelAddressBase(namedRange.Address)._fromRow == 1048576)
+                    if(address._toRow + rows > ExcelPackage.MaxRows)
                     {
-                        throw new InvalidOperationException("Cannot insert row over Max Rows");
+                        if (address._fromRowFixed == false)
+                        {
+                            //if relative the address should remain as is
+                        }
+                        else if (address._fromRowFixed | address._toRowFixed)
+                        {
+                            //This may look strange at a glance but appears to be how excel does it despite absolute refs
+                            address = address.AddRow(rowFrom, rows, false, false);
+                        }
+                        else
+                        {
+                            //If over MaxRows this results in null
+                            address = address.AddRow(rowFrom, rows, false);
+                        }
+                    }
+                    else
+                    {
+                        //If over MaxRows this results in null
+                        address = address.AddRow(rowFrom, rows, false);
                     }
                 }
-                if(cols > 0 && colFrom > 0 && address._toRow <= upperLimit && address._fromRow >= lowerLimint && address.Columns < ExcelPackage.MaxColumns)
+                if(cols > 0 && colFrom > 0 && address._toRow <= upperLimit && address._fromRow >= lowerLimit && address.Columns < ExcelPackage.MaxColumns)
                 {
-                    address = address.AddColumn(colFrom, cols, false,false);
+                    if (address._toCol + cols > ExcelPackage.MaxColumns)
+                    {
+                        if (address._toColFixed == false && address._fromColFixed == false)
+                        {
+                            //if relative the address should remain as is
+                        }
+                        else if (address._fromColFixed | address._toColFixed)
+                        {
+                            //This may look strange at a glance but appears to be how excel does it despite absolute refs
+                            address = address.AddColumn(colFrom, cols, false, false);
+                        }
+                        else
+                        {
+                            address = address.AddColumn(colFrom, cols, false);
+                        }
+                    }
+                    else
+                    {
+                        //If over MaxRows this results in null
+                        address = address.AddColumn(colFrom, cols, false, false);
+                    }
                 }
-                namedRange.Address = address.Address;
+
+                if(address == null)
+                {
+                    namedRange.Address = $"{namedRange.WorkSheetName}!{ExcelErrorValue.Values.Ref}";
+
+                    if(namedRange.SetCommentWarningWhenOverMax)
+                    {
+                        namedRange.NameComment += $"\n This namedRange was set to #REF! by Insert with input \n" +
+                        $"rowFrom: {rowFrom}, colfrom:{colFrom}, rows:{rows}, cols: {cols}.\n" +
+                        $"MaxRows are {ExcelPackage.MaxRows}, MaxColumns are: {ExcelPackage.MaxColumns}";
+                    }
+                }
+                else
+                {
+                    namedRange.Address = address.Address;
+                }
             }
         }
         internal void Delete(int rowFrom, int colFrom, int rows, int cols, int lowerLimint = 0, int upperLimit = int.MaxValue)

--- a/src/EPPlus/ExcelNamedRangeCollection.cs
+++ b/src/EPPlus/ExcelNamedRangeCollection.cs
@@ -239,13 +239,6 @@ namespace OfficeOpenXml
                 if(address == null)
                 {
                     namedRange.Address = $"{namedRange.WorkSheetName}!{ExcelErrorValue.Values.Ref}";
-
-                    if(namedRange.SetCommentWarningWhenOverMax)
-                    {
-                        namedRange.NameComment += $"\n This namedRange was set to #REF! by Insert with input \n" +
-                        $"rowFrom: {rowFrom}, colfrom:{colFrom}, rows:{rows}, cols: {cols}.\n" +
-                        $"MaxRows are {ExcelPackage.MaxRows}, MaxColumns are: {ExcelPackage.MaxColumns}";
-                    }
                 }
                 else
                 {

--- a/src/EPPlusTest/Core/Range/Insert/RangeInsertTests.cs
+++ b/src/EPPlusTest/Core/Range/Insert/RangeInsertTests.cs
@@ -1526,5 +1526,163 @@ namespace EPPlusTest.Core.Range.Insert
                 SaveAndCleanup(p);
             }
         }
+
+        #region NamedRange insert Max row/col tests
+        [TestMethod]
+        public void InsertRowRangeMaxRelativeMultipleLines()
+        {
+            using (var p = OpenPackage("namedRangeMaxRelativeLargerRange.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("ANamedRange");
+
+                string rangeString = "A1048570:A1048576";
+
+                //Add relative reference to max row
+                var namedRange = ws.Names.Add("EndNamedRangeA", ws.Cells[rangeString], true);
+
+                //Insert row somewhere above max row
+                ws.InsertRow(347, 1, 346);
+
+                //address should remain unchanged
+                Assert.AreEqual(rangeString, namedRange.Address);
+                SaveAndCleanup(p);
+            }
+        }
+
+        [TestMethod]
+        public void InsertRowRangeMaxAbsoluteMultipleLines()
+        {
+            using (var p = OpenPackage("namedRangeMaxAbsoluteLargerRange.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("ANamedRange");
+
+                //Add absolute reference to max row
+                var namedRange = ws.Names.Add("EndNamedRangeA", ws.Cells["A1048570:A1048576"]);
+
+                //Insert row somewhere above max row
+                ws.InsertRow(347, 1, 346);
+
+                //from row should be added to by one
+                Assert.AreEqual("$A$1048571:$A$1048576", namedRange.Address);
+                SaveAndCleanup(p);
+            }
+        }
+
+        [TestMethod]
+        public void InsertRowNamedRangeMaxAbsolute()
+        {
+            using (var p = OpenPackage("namedRangeMaxAbsolute.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("ANamedRange");
+
+                //Add absolute reference to max row
+                var namedRange = ws.Names.Add("EndNamedRangeA", ws.Cells["A1048576"]);
+
+                //Insert row somewhere above max row
+                ws.InsertRow(347, 1, 346);
+
+                Assert.AreEqual($"ANamedRange!{ExcelErrorValue.Values.Ref}", namedRange.Address);
+                Assert.AreEqual(null, namedRange.Value);
+            }
+        }
+
+        [TestMethod]
+        public void InsertRowNamedRangeMaxRelative()
+        {
+            using (var p = OpenPackage("namedRangeMaxRelative.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("ANamedRange");
+
+                var relativeRange = ws.Names.Add("EndNamedRangeB", ws.Cells["B1048576"], true);
+
+                //Insert row somewhere above max row
+                ws.InsertRow(347, 1, 346);
+
+                Assert.AreEqual("B1048576", relativeRange.Address);
+                SaveAndCleanup(p);
+            }
+        }
+
+        //Column tests start
+
+        [TestMethod]
+        public void InsertColNamedRangeMaxAbsolute()
+        {
+            using (var p = OpenPackage("namedRangeMaxColAbsolute.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("colNamedRange");
+
+                var maxCols = ExcelPackage.MaxColumns;
+
+                //Add absolute reference to max col
+                var namedRange = ws.Names.Add("EndNamedRangeMaxCols", ws.Cells[3, maxCols]);
+
+                //Insert col somewhere left of max col
+                ws.InsertColumn(347, 1, 346);
+
+                Assert.AreEqual($"colNamedRange!{ExcelErrorValue.Values.Ref}", namedRange.Address);
+                Assert.AreEqual(null, namedRange.Value);
+            }
+        }
+
+        [TestMethod]
+        public void InsertColNamedRangeMaxRelative()
+        {
+            using (var p = OpenPackage("namedRangeMaxColRelative.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("colNamedRange");
+
+                var maxCols = ExcelPackage.MaxColumns;
+
+                //Add absolute reference to max col
+                var namedRange = ws.Names.Add("EndNamedRangeMaxCols", ws.Cells[3, maxCols], true);
+
+                //Insert col somewhere left of max col
+                ws.InsertColumn(347, 1, 346);
+
+                Assert.AreEqual("XFD3", namedRange.Address);
+            }
+        }
+
+        [TestMethod]
+        public void InsertColRangeMaxRelativeMultipleLines()
+        {
+            using (var p = OpenPackage("namedRangeMaxColRelativeLargerRange.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("ANamedRange");
+
+                string rangeString = "XFB3:XFD3";
+
+                //Add relative reference to max row
+                var namedRange = ws.Names.Add("EndNamedRangeA", ws.Cells[rangeString], true);
+
+                //Insert col somewhere left of max col
+                ws.InsertColumn(347, 1, 346);
+
+                //address should remain unchanged
+                Assert.AreEqual(rangeString, namedRange.Address);
+            }
+        }
+
+        [TestMethod]
+        public void InsertColRangeMaxAbsoluteMultipleLines()
+        {
+            using (var p = OpenPackage("namedRangeMaxColAbsoluteLargerRange.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("ANamedRange");
+
+                string rangeString = "XFB3:XFD3";
+
+                //Add relative reference to max row
+                var namedRange = ws.Names.Add("EndNamedRangeA", ws.Cells[rangeString]);
+
+                //Insert col somewhere left of max col
+                ws.InsertColumn(347, 1, 346);
+
+                //address should remain unchanged
+                Assert.AreEqual("$XFC$3:$XFD$3", namedRange.Address);
+            }
+        }
+        #endregion
     }
 }

--- a/src/EPPlusTest/WorkSheetTests.cs
+++ b/src/EPPlusTest/WorkSheetTests.cs
@@ -2758,27 +2758,7 @@ namespace EPPlusTest
 
                 var adress = namedRange.Address;
 
-                namedRange.SetAddress("披露附注!D7152", p.Workbook, ws.Name);
-
                 ws.InsertRow(347, 1, 346);
-                SaveAndCleanup(p);
-            }
-        }
-
-
-        [TestMethod]
-        public void InsertRowIssue2()
-        {
-            using (var p = OpenPackage("namedRangeWs.xlsx", true))
-            {
-                var ws = p.Workbook.Worksheets.Add("ANamedRange");
-
-                //var namedRange = ws.Names.Add("EndNamedRangeA", ws.Cells["A1048576"]);
-                var namedRange2 = ws.Names.Add("EndNamedRangeB", ws.Cells["B1048576"], true);
-
-                //On Insert relative references stay on the last row Absolute ones become #!REF
-                ws.InsertRow(347, 1, 346);
-
                 SaveAndCleanup(p);
             }
         }

--- a/src/EPPlusTest/WorkSheetTests.cs
+++ b/src/EPPlusTest/WorkSheetTests.cs
@@ -2747,5 +2747,40 @@ namespace EPPlusTest
 
             return wks.Cells[$"{originalTemplateRow}:{originalTemplateRow + insertCount}"];
         }
+
+        [TestMethod]
+        public void InsertRowIssue()
+        {
+            using (var p = OpenTemplatePackage("s1019.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets.GetByName("披露附注");
+                var namedRange = ws.Names["上一行"];
+
+                var adress = namedRange.Address;
+
+                namedRange.SetAddress("披露附注!D7152", p.Workbook, ws.Name);
+
+                ws.InsertRow(347, 1, 346);
+                SaveAndCleanup(p);
+            }
+        }
+
+
+        [TestMethod]
+        public void InsertRowIssue2()
+        {
+            using (var p = OpenPackage("namedRangeWs.xlsx", true))
+            {
+                var ws = p.Workbook.Worksheets.Add("ANamedRange");
+
+                //var namedRange = ws.Names.Add("EndNamedRangeA", ws.Cells["A1048576"]);
+                var namedRange2 = ws.Names.Add("EndNamedRangeB", ws.Cells["B1048576"], true);
+
+                //On Insert relative references stay on the last row Absolute ones become #!REF
+                ws.InsertRow(347, 1, 346);
+
+                SaveAndCleanup(p);
+            }
+        }
     }
 }


### PR DESCRIPTION
When inserting rows or columns and having a namedRange on the maxRow or maxColumn Epplus crashed with a nullref exception.

This fix makes Epplus consistent with Excel for these cases. Specifically the behaviour is now:
Absolute References that are a singular cell on the maxRow/maxColumn become "#REF!" errors
Relative References are unaffected
Absolute ranges with a from row NOT on the max row/column but the toRow/toCol adress is now move the Absolute Reference of the fromRow by one as Excel does. for example:

We have a named range Sheet1!$XFB$3:$XFD$3
Insert column is performed on column XEU
the named range changes to  Sheet1!$XFC$3:$XFD$3

Epplus is now consistent with Excel on this.