### PR TITLE
Fix negation bug for numeric strings

### DIFF
--- a/src/EPPlus/FormulaParsing/Excel/Operators/RangeOperationsOperator.cs
+++ b/src/EPPlus/FormulaParsing/Excel/Operators/RangeOperationsOperator.cs
@@ -62,7 +62,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
             {
                 for (int r = 0; r < rows; r++)
                 {
-                    var d = ConvertUtil.GetValueDouble(ri.GetOffset(r, c), false, true);
+                    var d = ConvertUtil.GetValueDouble(ri.GetOffset(r, c), false, true, true);
 
                     if (double.IsNaN(d))
                     {

--- a/src/EPPlus/FormulaParsing/FormulaExpressions/CompileResults/CompileResult.cs
+++ b/src/EPPlus/FormulaParsing/FormulaExpressions/CompileResults/CompileResult.cs
@@ -126,7 +126,7 @@ namespace OfficeOpenXml.FormulaParsing.FormulaExpressions
                 return new CompileResult(RangeOperationsOperator.Negate(ri), DataType.ExcelRange);
             }
 
-            else if (IsNumeric)
+            else if (IsNumeric || IsNumericString)
             {
                 return new CompileResult(ResultNumeric * -1, DataType.Decimal);
             }

--- a/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
+++ b/src/EPPlusTest/Issues/FormulaCalculationIssues.cs
@@ -1497,7 +1497,37 @@ namespace EPPlusTest.Issues
             }
             SwitchBackToCurrentCulture();
         }
-  
+
+        [TestMethod]
+        public void s1023()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var s = package.Workbook.Worksheets.Add("s1023");
+                s.Cells["A1"].Formula = "IF(LEFT(B1,1) = \"1\", -D1, D1)";
+                s.Cells["B1"].Value = 111;
+                s.Cells["C1"].Value = 50;
+                s.Cells["D1"].Formula = "UNIQUE(FILTER(B: B & C:C, B: B & C:C<>\"\"))";
+                s.Workbook.Calculate();
+
+                Assert.AreEqual(-11150d, s.Cells["A1"].Value);
+                Assert.AreEqual("11150", s.Cells["D1"].Value);
+            }
+        }
+
+        [TestMethod]
+        public void s1023NegNumericString()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var s = package.Workbook.Worksheets.Add("s1023");
+                s.Cells["A1"].Formula = "-D1";
+                s.Cells["D1"].Value = "11150";
+                s.Cells["A1"].Calculate();
+
+                Assert.AreEqual(-11150d, s.Cells["A1"].Value);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixed bug in FormulaParsing where negating a numeric string resulted in a VALUE error.

Before submitting this pull request I have...
- [x] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [X] ensured that the functionality I have added/changed is covered by new unit tests.
- [X] merged the target branch into the PR branch and resolved any merge conflicts
- [x] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).
