### PR TITLE
Fix: Honor CompareOptions and Culture in RangeSortOptions

### DIFF
--- a/src/EPPlus/Sorting/Internal/EPPlusSortComparerBase.cs
+++ b/src/EPPlus/Sorting/Internal/EPPlusSortComparerBase.cs
@@ -76,7 +76,7 @@ namespace OfficeOpenXml.Sorting.Internal
             {
                 var s1 = x1 == null ? "" : x1.ToString();
                 var s2 = y1 == null ? "" : y1.ToString();
-                ret = string.Compare(s1, s2, StringComparison.CurrentCulture);
+                ret = string.Compare(s1, s2, Culture ?? CultureInfo.CurrentCulture, CompOptions);
             }
             else
             {

--- a/src/EPPlusTest/Sorting/SortCaseSensitivityTests.cs
+++ b/src/EPPlusTest/Sorting/SortCaseSensitivityTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using OfficeOpenXml.Sorting;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace EPPlusTest.Sorting
+{
+    [TestClass]
+    public class SortCaseSensitivityTests : TestBase
+    {
+        [TestMethod]
+        public void ShouldRespectCaseSensitivity()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("SortTest");
+                
+                // Data: APPLE then apple
+                sheet.Cells["A1"].Value = "APPLE";
+                sheet.Cells["A2"].Value = "apple";
+
+                // 1. Case-Insensitive Sort (Should preserve original order APPLE, apple)
+                var options = RangeSortOptions.Create();
+                options.CompareOptions = CompareOptions.IgnoreCase;
+                options.SortBy.Column(0);
+                sheet.Cells["A1:A2"].Sort(options);
+
+                Assert.AreEqual("APPLE", sheet.Cells["A1"].Text, "Insensitive sort failed to preserve order");
+                Assert.AreEqual("apple", sheet.Cells["A2"].Text);
+
+                // 2. Case-Sensitive Sort (Should flip to apple, APPLE because a < A in linguistic sort)
+                options = RangeSortOptions.Create();
+                options.CompareOptions = CompareOptions.None; // linguistic sensitive
+                options.SortBy.Column(0);
+                sheet.Cells["A1:A2"].Sort(options);
+
+                Assert.AreEqual("apple", sheet.Cells["A1"].Text, "Sensitive sort failed to flip order");
+                Assert.AreEqual("APPLE", sheet.Cells["A2"].Text);
+            }
+        }
+
+        [TestMethod]
+        public void ShouldRespectOrdinalCaseSensitivity()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var sheet = package.Workbook.Worksheets.Add("SortTestOrdinal");
+                
+                // Data: apple then APPLE
+                sheet.Cells["A1"].Value = "apple";
+                sheet.Cells["A2"].Value = "APPLE";
+
+                // Ordinal Sort (Binary): A (65) < a (97). So APPLE should be first.
+                var options = RangeSortOptions.Create();
+                options.CompareOptions = CompareOptions.Ordinal;
+                options.SortBy.Column(0);
+                sheet.Cells["A1:A2"].Sort(options);
+
+                Assert.AreEqual("APPLE", sheet.Cells["A1"].Text, "Ordinal sort failed to put uppercase first");
+                Assert.AreEqual("apple", sheet.Cells["A2"].Text);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR fixes an issue where range sorting in EPPlus 8 failed to respect the `CompareOptions` set in `RangeSortOptions`. The internal comparison logic was hard-coded to use `StringComparison.CurrentCulture`, which prevented users from performing true case-sensitive (Ordinal/Binary) sorts or using specific linguistic rules.

### Changes
- Modified `OfficeOpenXml.Sorting.Internal.EPPlusSortComparerBase` to use the `Culture` and `CompOptions` properties during string comparisons instead of a hard-coded value.
- Updated the comparison logic to fallback to `CultureInfo.CurrentCulture` only if no specific culture is provided.

### Verification
Added a new test class `EPPlusTest.Sorting.SortCaseSensitivityTests` with the following test cases:
- `ShouldRespectCaseSensitivity`: Verifies that linguistic case-sensitive sorting (a < A) works as expected.
- `ShouldRespectOrdinalCaseSensitivity`: Verifies that binary/ordinal sorting (A < a) correctly positions uppercase letters first.

All tests passed for both .NET 8.0 and .NET 4.8.1 targets.