### PR TITLE
Added fix for #2350

### DIFF
--- a/src/EPPlus/Core/Worksheet/WorksheetCopyHelper.cs
+++ b/src/EPPlus/Core/Worksheet/WorksheetCopyHelper.cs
@@ -200,6 +200,7 @@ namespace OfficeOpenXml.Core.Worksheet
             }
         }
 
+
         private static void CloneCellsAndStyles(ExcelWorksheet Copy, ExcelWorksheet added)
         {
             bool sameWorkbook = (Copy.Workbook == added.Workbook);

--- a/src/EPPlus/DataValidation/ExcelDataValidationInt.cs
+++ b/src/EPPlus/DataValidation/ExcelDataValidationInt.cs
@@ -59,6 +59,7 @@ namespace OfficeOpenXml.DataValidation
         internal ExcelDataValidationInt(ExcelDataValidationInt copy, ExcelWorksheet ws) 
             : base(copy, ws)
         {
+            _isTextLength = copy.ValidationType.Type == eDataValidationType.TextLength;
             Formula = copy.Formula;
             Formula2 = copy.Formula2;
         }

--- a/src/EPPlusTest/Issues/CopyIssues.cs
+++ b/src/EPPlusTest/Issues/CopyIssues.cs
@@ -131,6 +131,22 @@ namespace EPPlusTest.Issues
                 SaveAndCleanup(p);
             }
         }
+
+        [TestMethod]
+        public void i2350()
+        {
+            using (var p =OpenTemplatePackage("i2350.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets[0];
+
+                using(var p2 = OpenPackage("i2350Output.xlsx", true))
+                {
+                    p2.Workbook.Worksheets.Add("test", ws);
+                    SaveAndCleanup(p2);
+                }
+            }
+        }
+
         //One cell/range can be copied to multiple comma-separated ranges
         [TestMethod]
         public void i1656PasteSpecial_Formulas_OneToMany()


### PR DESCRIPTION
Fix for #2350 

_isTextLength variable was not being copied. 
Likely it was missed since its identical with IntDataValidation until applied.