### PR TITLE
Fixed nullcheck for i1653 if _cells are null

### DIFF
--- a/src/EPPlus/Style/RichText/ExcelRichTextCollection.cs
+++ b/src/EPPlus/Style/RichText/ExcelRichTextCollection.cs
@@ -160,9 +160,13 @@ namespace OfficeOpenXml.Style
             //If just a note we can't clear formulas on the cell itself.
             if (_isComment == false)
             {
-                //We MUST clear formulas before setting richtext
-                //To ensure calculate does not create missmatch between formula and richtext.
-                _cells.ClearFormulas();
+                //We can't clear formulas if no cells exist
+                if(_cells != null)
+                {
+                    //We MUST clear formulas before setting richtext
+                    //To ensure calculate does not create missmatch between formula and richtext.
+                    _cells.ClearFormulas();
+                }
             }
 
             var rt = new ExcelRichText(text, this);


### PR DESCRIPTION
Shared Strings may have _cells == null
This is normally not an issue but new richtext checks cells to clear formulas.
Since this is shared strings there are no cells (or therefore formulas in cells) to clear.
Thus there was a crash.

Fixed with a nullcheck.