### PR TITLE
Fix NotSupportedException when deleting ExcelChartsheet

### DIFF
--- a/src/EPPlus/ExcelWorksheets.cs
+++ b/src/EPPlus/ExcelWorksheets.cs
@@ -470,15 +470,18 @@ namespace OfficeOpenXml
                 worksheet.Drawings.ClearDrawings();
             }
 
-            //Remove all comments
-            if (!(worksheet is ExcelChartsheet) && worksheet.Comments.Count > 0)
+            if (!(worksheet is ExcelChartsheet))
             {
-                worksheet.Comments.Clear();
-            }
+                //Remove all comments
+                if (worksheet.Comments.Count > 0)
+                {
+                    worksheet.Comments.Clear();
+                }
 
-            while(worksheet.PivotTables.Count>0)
-            {
-                worksheet.PivotTables.Delete(worksheet.PivotTables[0]);
+                while (worksheet.PivotTables.Count > 0)
+                {
+                    worksheet.PivotTables.Delete(worksheet.PivotTables[0]);
+                }
             }
             //Delete any parts still with relations to the Worksheet.
             DeleteRelationsAndParts(worksheet.Part);

--- a/src/EPPlusTest/Issues/ChartSheetDeleteTests.cs
+++ b/src/EPPlusTest/Issues/ChartSheetDeleteTests.cs
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Required Notice: Copyright (C) EPPlus Software AB. 
+ * https://epplussoftware.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *******************************************************************************/
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using OfficeOpenXml.Drawing.Chart;
+
+namespace EPPlusTest.Issues
+{
+    [TestClass]
+    public class ChartSheetDeleteTests
+    {
+        [TestMethod]
+        public void DeleteChartSheetShouldNotThrowNotSupportedException()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var ws = package.Workbook.Worksheets.Add("Data");
+                var chartSheet = package.Workbook.Worksheets.AddChart("ChartSheet", eChartType.ColumnClustered);
+                
+                // This call previously threw NotSupportedException because it tried to access chartSheet.PivotTables
+                package.Workbook.Worksheets.Delete(chartSheet);
+                
+                Assert.AreEqual(1, package.Workbook.Worksheets.Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a type guard to ExcelWorksheets.Delete() to prevent it from attempting to access the PivotTables collection on ExcelChartsheet objects. This aligns the behavior with the existing guard for Comments found earlier in the same method.

  Changes:
   * Modified src/EPPlus/ExcelWorksheets.cs to wrap PivotTable cleanup in a !(worksheet is ExcelChartsheet) check.
   * Added src/EPPlusTest/Issues/ChartSheetDeleteTests.cs to verify the fix.