### PR TITLE
Fix: add case-insensitive enum parsing to Chart Axis TickMark getters

### DIFF
--- a/src/EPPlus/Drawing/Chart/ExcelChartAxisStandard.cs
+++ b/src/EPPlus/Drawing/Chart/ExcelChartAxisStandard.cs
@@ -75,7 +75,7 @@ namespace OfficeOpenXml.Drawing.Chart
                 {
                     try
                     {
-                        return (eAxisTickMark)Enum.Parse(typeof(eAxisTickMark), v);
+                        return (eAxisTickMark)Enum.Parse(typeof(eAxisTickMark), v, true /* ignoreCase */);
                     }
                     catch
                     {
@@ -105,7 +105,7 @@ namespace OfficeOpenXml.Drawing.Chart
                 {
                     try
                     {
-                        return (eAxisTickMark)Enum.Parse(typeof(eAxisTickMark), v);
+                        return (eAxisTickMark)Enum.Parse(typeof(eAxisTickMark), v, true /* ignoreCase */);
                     }
                     catch
                     {

--- a/src/EPPlusTest/Issues/ChartIssues.cs
+++ b/src/EPPlusTest/Issues/ChartIssues.cs
@@ -459,5 +459,39 @@ namespace EPPlusTest.Issues
             }
         }
 
+        [TestMethod]
+        public void ChartAxisTickMarkCaseSensitivity()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var ws = package.Workbook.Worksheets.Add("Sheet1");
+                var chart = ws.Drawings.AddChart("chart1", eChartType.ColumnClustered);
+
+                // Fetch Category and Value axes
+                var catAxis = chart.Axis[0];
+                var valAxis = chart.Axis[1];
+
+                // 1. Verify MajorTickMark Case-Insensitive Parsing
+                valAxis.MajorTickMark = eAxisTickMark.In;
+                Assert.AreEqual(eAxisTickMark.In, valAxis.MajorTickMark, "MajorTickMark should be parsed back as 'In' instead of defaulting to 'Cross'.");
+
+                valAxis.MajorTickMark = eAxisTickMark.Out;
+                Assert.AreEqual(eAxisTickMark.Out, valAxis.MajorTickMark, "MajorTickMark should be parsed back as 'Out'.");
+
+                valAxis.MajorTickMark = eAxisTickMark.None;
+                Assert.AreEqual(eAxisTickMark.None, valAxis.MajorTickMark, "MajorTickMark should be parsed back as 'None'.");
+
+                // 2. Verify MinorTickMark Case-Insensitive Parsing
+                valAxis.MinorTickMark = eAxisTickMark.In;
+                Assert.AreEqual(eAxisTickMark.In, valAxis.MinorTickMark, "MinorTickMark should be parsed back as 'In'.");
+
+                valAxis.MinorTickMark = eAxisTickMark.Out;
+                Assert.AreEqual(eAxisTickMark.Out, valAxis.MinorTickMark, "MinorTickMark should be parsed back as 'Out'.");
+
+                valAxis.MinorTickMark = eAxisTickMark.None;
+                Assert.AreEqual(eAxisTickMark.None, valAxis.MinorTickMark, "MinorTickMark should be parsed back as 'None'.");
+            }
+        }
+
     }
 }


### PR DESCRIPTION
### Summary of Changes
This PR resolves a case-sensitivity enum parsing bug inside `ExcelChartAxisStandard` where setting `MajorTickMark` or `MinorTickMark` wrote lowercased strings to XML (e.g. `"in"`, `"out"`), but reading them back failed because `Enum.Parse` was called case-sensitively against the capitalized enum members (`In`, `Out`).

Passing `true` as the third parameter of `Enum.Parse` enables case-insensitive parsing, bringing `MajorTickMark` and `MinorTickMark` into alignment with other chart axis properties.

### Related Issues
Closes #2369

### Details of Changes
- **`src/EPPlus/Drawing/Chart/ExcelChartAxisStandard.cs`**:
  - Updated `MajorTickMark` getter to use `Enum.Parse(typeof(eAxisTickMark), v, true)`.
  - Updated `MinorTickMark` getter to use `Enum.Parse(typeof(eAxisTickMark), v, true)`.

- **`src/EPPlusTest/Issues/ChartIssues.cs`**:
  - Added MSUnit test case `ChartAxisTickMarkCaseSensitivity` to verify that both `MajorTickMark` and `MinorTickMark` can be assigned and read back correctly for all valid enum states (`In`, `Out`, `None`).

### Verification & Testing
- Ran `dotnet test src/EPPlusTest/EPPlus.Test.csproj --filter Name=ChartAxisTickMarkCaseSensitivity`
- Verified successful execution under **.NET 8.0** and **.NET Framework 4.8.1** (total: 2; failed: 0; succeeded: 2).