### PR TITLE
Fix exception when updating drawing hyperlinks and fix ignored tooltips

### DIFF
--- a/src/EPPlus/Drawing/ExcelDrawing.cs
+++ b/src/EPPlus/Drawing/ExcelDrawing.cs
@@ -527,7 +527,7 @@ namespace OfficeOpenXml.Drawing
                     DeleteNode(_hyperLinkPath);
                     if (HypRel != null)
                     {
-                        _drawings._package.ZipPackage.DeletePart(UriHelper.ResolvePartUri(HypRel.SourceUri, HypRel.TargetUri));
+                        _drawings.Part.DeleteRelationship(HypRel.Id);
                     }
                 }
 
@@ -542,7 +542,7 @@ namespace OfficeOpenXml.Drawing
                         HypRel = _drawings.Part.CreateRelationship(value, Packaging.TargetMode.External, ExcelPackage.schemaHyperlink);
                     }
                     SetXmlNodeString(_hyperLinkPath + "/@r:id", HypRel.Id);
-                    if (Hyperlink is ExcelHyperLink excelLink)
+                    if (value is ExcelHyperLink excelLink)
                     {
                         SetXmlNodeString(_hyperLinkPath + "/@tooltip", excelLink.ToolTip);
                     }

--- a/src/EPPlusTest/HyperlinkTest.cs
+++ b/src/EPPlusTest/HyperlinkTest.cs
@@ -102,5 +102,49 @@ namespace EPPlusTest
             }
         }
 
+        [TestMethod]
+        public void DrawingHyperlinkUpdate_ShouldNotThrowException()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var ws = package.Workbook.Worksheets.Add("Sheet1");
+                
+                // Add a drawing (shape)
+                var shape = ws.Drawings.AddShape("MyShape", eShapeStyle.Rect);
+                
+                // 1. Assign initial external URL hyperlink
+                var initialUrl = new ExcelHyperLink("https://epplussoftware.com") { ToolTip = "Initial ToolTip" };
+                shape.Hyperlink = initialUrl;
+                
+                Assert.IsNotNull(shape.Hyperlink);
+                
+                // 2. Re-assign to a new external URL hyperlink (this would crash without the fix)
+                var updatedUrl = new ExcelHyperLink("https://github.com/EPPlusSoftware/EPPlus") { ToolTip = "Updated ToolTip" };
+                shape.Hyperlink = updatedUrl;
+                
+                Assert.AreEqual("https://github.com/EPPlusSoftware/EPPlus", shape.Hyperlink.OriginalString);
+                
+                // 3. Re-assign to an internal sheet reference (this would also crash without the fix)
+                var internalLink = new ExcelHyperLink("Sheet1!A10", "Go to A10") { ToolTip = "Internal ToolTip" };
+                shape.Hyperlink = internalLink;
+                
+                Assert.AreEqual("Sheet1!A10", ((ExcelHyperLink)shape.Hyperlink).ReferenceAddress);
+
+                // 4. Save and read back to verify XML and tooltip are correct
+                package.Save();
+
+                using (var readPackage = new ExcelPackage(package.Stream))
+                {
+                    var readWs = readPackage.Workbook.Worksheets["Sheet1"];
+                    var readShape = readWs.Drawings["MyShape"];
+                    
+                    var readLink = (ExcelHyperLink)readShape.Hyperlink;
+                    Assert.IsNotNull(readLink);
+                    Assert.AreEqual("Sheet1!A10", readLink.ReferenceAddress);
+                    Assert.AreEqual("Internal ToolTip", readLink.ToolTip);
+                }
+            }
+        }
+
     }
 }


### PR DESCRIPTION
### Summary
This PR fixes two bugs in `ExcelDrawing.cs` when working with hyperlinks on drawings (shapes, pictures, etc.):
1. An exception (`NullReferenceException` or `InvalidOperationException`) when changing an existing hyperlink to a new one.
2. Tooltips not being saved when assigning a new hyperlink with a tooltip.

### What was wrong?

1. **The Exception**:
   When you changed a drawing's hyperlink, the setter tried to delete the old link using `ZipPackage.DeletePart(...)`. However, drawing hyperlinks are just XML relationships (`.rels`), not actual physical files inside the ZIP package. This caused an exception:
   * If the old link was a worksheet reference, it threw a `NullReferenceException` (because the target URI is null).
   * If the old link was an external web URL, it threw `InvalidOperationException: Part does not exist`.

2. **The Tooltip Bug**:
   When writing the tooltip to the drawing's XML, the code checked `if (Hyperlink is ExcelHyperLink excelLink)`. At this point, the backing field hadn't been updated yet, so `Hyperlink` returned the *old* hyperlink instead of the new one. This meant any new tooltip you set was ignored.

### How this PR fixes it

1. **For the Exception**: Changed the code to delete the relationship from the drawing part instead of trying to delete a zip package part:
   ```csharp
   _drawings.Part.DeleteRelationship(HypRel.Id);
   ```
2. **For the Tooltip**: Changed the check to use the incoming `value` instead of the old `Hyperlink` property:
   ```csharp
   if (value is ExcelHyperLink excelLink)
   ```

### Added Tests
Added a unit test `DrawingHyperlinkUpdate_ShouldNotThrowException` in `HyperlinkTest.cs` that:
- Assigns an initial external link.
- Updates it to a new external link.
- Updates it to an internal sheet reference.
- Saves the file and reads it back to make sure the tooltip and hyperlink are correct.