### PR TITLE
Fix KeyNotFoundException / ArgumentException on drawing rename and removal

### DIFF
--- a/src/EPPlus/Drawing/ExcelDrawing.cs
+++ b/src/EPPlus/Drawing/ExcelDrawing.cs
@@ -21,6 +21,7 @@ using OfficeOpenXml.Utils.EnumUtils;
 using OfficeOpenXml.Utils.FileUtils;
 using OfficeOpenXml.Utils.XML;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -332,6 +333,18 @@ namespace OfficeOpenXml.Drawing
                 try
                 {
                     if (_nvPrPath == "") throw new NotImplementedException();
+                    string oldName = GetXmlNodeString(_nvPrPath + "/@name");
+                    // Only perform dictionary synchronization if the name has actually changed
+                    if (!string.IsNullOrEmpty(oldName) && !oldName.Equals(value, StringComparison.Ordinal))
+                    {
+                        // Validate name uniqueness in both worksheet and parent-group drawing collections.
+                        // All checks must pass before any dictionaries are updated, preventing partial desynchronization.
+                        ValidateNameUniquenessInCollections(value);
+
+                        // All uniqueness checks successfully passed! Safe to update name-lookup dictionaries.
+                        UpdateNameInDictionaries(oldName, value);
+                    }
+
                     SetXmlNodeString(_nvPrPath + "/@name", value);
                     if (this is ExcelSlicer<ExcelTableSlicerCache> ts)
                     {
@@ -343,6 +356,10 @@ namespace OfficeOpenXml.Drawing
                         SetXmlNodeString(_nvPrPath + "/../../a:graphic/a:graphicData/sle:slicer/@name", value);
                         pts.SlicerName = value;
                     }
+                }
+                catch (ArgumentException)
+                {
+                    throw;
                 }
                 catch
                 {
@@ -2496,6 +2513,43 @@ namespace OfficeOpenXml.Drawing
             //Copy Blip Fill
             WorksheetCopyHelper.CopyBlipFillDrawing(worksheet, worksheet._drawings.Part, worksheet._drawings.DrawingXml, this, sourceShape.Fill, worksheet._drawings.Part.Uri);
             return drawNode;
+        }
+
+        private void ValidateNameUniqueness(Dictionary<string, int> drawingNames, IEnumerable<ExcelDrawing> collection, string name)
+        {
+            if (drawingNames?.ContainsKey(name) == true)
+            {
+                int index = drawingNames[name];
+                var drawing = collection?.ElementAtOrDefault(index);
+
+                if (drawing != null && drawing != this)
+                {
+                    string collectionDescription = collection is ExcelDrawingsGroup ? "the group drawings collection" : "drawings collection";
+                    throw new ArgumentException($"Name '{name}' already exists in {collectionDescription}.");
+                }
+            }
+        }
+
+        private void ValidateNameUniquenessInCollections(string name)
+        {
+            ValidateNameUniqueness(_drawings?._drawingNames, _drawings?._drawingsList, name);
+            ValidateNameUniqueness(_parent?.Drawings?._drawingNames, _parent?.Drawings, name);
+        }
+
+        private void UpdateNameInDictionary(Dictionary<string, int> drawingNames, string oldName, string newName)
+        {
+            if (drawingNames?.ContainsKey(oldName) == true)
+            {
+                int index = drawingNames[oldName];
+                drawingNames.Remove(oldName);
+                drawingNames[newName] = index;
+            }
+        }
+
+        private void UpdateNameInDictionaries(string oldName, string newName)
+        {
+            UpdateNameInDictionary(_drawings?._drawingNames, oldName, newName);
+            UpdateNameInDictionary(_parent?.Drawings?._drawingNames, oldName, newName);
         }
 
         internal ExcelAddressBase GetAddress()

--- a/src/EPPlus/Drawing/ExcelGroupShape.cs
+++ b/src/EPPlus/Drawing/ExcelGroupShape.cs
@@ -38,7 +38,7 @@ namespace OfficeOpenXml.Drawing
             _parent = parent;
             _nsm = nsm;
             _topNode = topNode;
-            _drawingNames = new Dictionary<string, int>();
+            _drawingNames = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             _drawingsCollectionType = drawingsCollectionType;
             AddDrawings();
         }
@@ -298,7 +298,21 @@ namespace OfficeOpenXml.Drawing
         public void Remove(ExcelDrawing drawing)
         {
             CheckNotDisposed();
-            _groupDrawings.Remove(drawing);
+            // Find the 0-based list index of the drawing within this group
+            int index = _groupDrawings.IndexOf(drawing);
+            if (index < 0) return;
+
+            // Remove the drawing from the list and its entry from the lookup dictionary
+            _groupDrawings.RemoveAt(index);
+            _drawingNames.Remove(drawing.Name);
+            
+            // Re-index all remaining drawings after the removed index in the group's name-to-index lookup.
+            // When an element is removed, all subsequent elements shift down, so we update their mapped indices accordingly.
+            for (int i = index; i < _groupDrawings.Count; i++)
+            {
+                _drawingNames[_groupDrawings[i].Name] = i;
+            }
+
             AdjustXmlAndMoveFromGroup(drawing);
             var ix = _parent._drawings._drawingsList.IndexOf(_parent);
             _parent._drawings._drawingsList.Insert(ix, drawing);

--- a/src/EPPlusTest/Drawing/DrawingTest.cs
+++ b/src/EPPlusTest/Drawing/DrawingTest.cs
@@ -1218,5 +1218,62 @@ namespace EPPlusTest
                 SaveAndCleanup(package);
             }
         }
+        [TestMethod]
+        public void DrawingNameChangeAndRemovalTest()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var ws = package.Workbook.Worksheets.Add("RenameTest");
+                
+                // Add a drawing (shape)
+                var shape = ws.Drawings.AddShape("InitialName", eShapeStyle.Rect);
+                Assert.AreEqual("InitialName", shape.Name);
+                Assert.IsTrue(ws.Drawings._drawingNames.ContainsKey("InitialName"));
+                
+                // Rename drawing
+                shape.Name = "RenamedName";
+                Assert.AreEqual("RenamedName", shape.Name);
+                
+                // Verify the internal dictionary was updated
+                Assert.IsFalse(ws.Drawings._drawingNames.ContainsKey("InitialName"), "Old name key should be removed from dictionary");
+                Assert.IsTrue(ws.Drawings._drawingNames.ContainsKey("RenamedName"), "New name key should be added to dictionary");
+                
+                // Test removing by shape object reference
+                ws.Drawings.Remove(shape);
+                Assert.AreEqual(0, ws.Drawings.Count, "Drawing should be removed successfully");
+                Assert.IsFalse(ws.Drawings._drawingNames.ContainsKey("RenamedName"), "Dictionary should no longer contain renamed name");
+            }
+        }
+
+        [TestMethod]
+        public void GroupedDrawingNameChangeAndRemovalTest()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var ws = package.Workbook.Worksheets.Add("GroupRenameTest");
+                
+                var shape1 = ws.Drawings.AddShape("Shape1", eShapeStyle.Rect);
+                var shape2 = ws.Drawings.AddShape("Shape2", eShapeStyle.Rect);
+                
+                // Group shapes using public EPPlus API
+                var group = shape1.Group(shape2);
+                
+                Assert.AreEqual("Shape1", shape1.Name);
+                Assert.IsTrue(group.Drawings._drawingNames.ContainsKey("Shape1"));
+                
+                // Rename grouped shape
+                shape1.Name = "GroupedShape1Renamed";
+                Assert.AreEqual("GroupedShape1Renamed", shape1.Name);
+                
+                // Verify the internal group dictionary was updated
+                Assert.IsFalse(group.Drawings._drawingNames.ContainsKey("Shape1"), "Old name key should be removed from group dictionary");
+                Assert.IsTrue(group.Drawings._drawingNames.ContainsKey("GroupedShape1Renamed"), "New name key should be added to group dictionary");
+                
+                // Test removing grouped shape
+                group.Drawings.Remove(shape1);
+                Assert.AreEqual(1, group.Drawings.Count, "One shape should be left in group");
+                Assert.IsFalse(group.Drawings._drawingNames.ContainsKey("GroupedShape1Renamed"), "Group dictionary should no longer contain removed name");
+            }
+        }
     }
 }


### PR DESCRIPTION
### Problem
1. **Drawing Renaming**: Renaming an `ExcelDrawing` updated the underlying XML but failed to synchronize the change with the parent's `_drawingNames` lookup dictionary. This caused subsequent lookups and `Remove()` calls on renamed drawings to fail with a `KeyNotFoundException`.
2. **Group Shape Removal**: `ExcelDrawingsGroup.Remove()` removed drawings from the internal list but did not clean up their entries from the `_drawingNames` dictionary or re-index the remaining shapes, causing index desynchronization.
3. **Case Sensitivity**: The `_drawingNames` dictionary in `ExcelDrawingsGroup` was case-sensitive, unlike the worksheet-level dictionary which is case-insensitive, resulting in inconsistent behavior.

### Solution
- **Synchronized Renaming**: Updated the `ExcelDrawing.Name` setter to validate uniqueness across both worksheet and group-level collections first, then update both lookup dictionaries.
- **Group Shape Re-indexing**: Fixed `ExcelDrawingsGroup.Remove` to remove the shape's name from `_drawingNames` and re-index the shifted indices of the remaining drawings in the group.
- **Case-Insensitive Group Lookup**: Initialized `_drawingNames` in `ExcelDrawingsGroup` with `StringComparer.OrdinalIgnoreCase` to align with worksheet-level drawing lookups.

### Testing
Added unit tests in `DrawingTest.cs` to verify renaming and removal behavior for both standard and grouped drawings:
- `DrawingNameChangeAndRemovalTest`
- `GroupedDrawingNameChangeAndRemovalTest`