### PR TITLE
Fixed infinite loop in GetTolColumnFromPixels. 

### DIFF
--- a/src/EPPlus/Drawing/ExcelDrawing.cs
+++ b/src/EPPlus/Drawing/ExcelDrawing.cs
@@ -928,14 +928,7 @@ namespace OfficeOpenXml.Drawing
             _doNotAdjust = true;
             if (CellAnchor == eEditAs.Absolute)
             {
-                if (_collectionType == DrawingsCollectionType.Worksheet || _collectionType == DrawingsCollectionType.Chart)
-                {
-                    Position.Y = (int)(pixels * EMU_PER_PIXEL);
-                }
-                else
-                {
-                    From.Y= (double)pixels/_drawings._screenHeight;
-                }
+                Position.Y = (int)(pixels * EMU_PER_PIXEL);
             }
             else
             {
@@ -977,14 +970,7 @@ namespace OfficeOpenXml.Drawing
             _doNotAdjust = true;
             if (CellAnchor == eEditAs.Absolute)
             {
-                if (_collectionType == DrawingsCollectionType.Worksheet || _collectionType == DrawingsCollectionType.Chart)
-                {
-                    Position.X = (int)(pixels * EMU_PER_PIXEL);
-                }
-                else
-                {
-                    From.X = (double)pixels / _drawings._screenWidth;
-                }
+                Position.X = (int)(pixels * EMU_PER_PIXEL);
             }
             else
             {
@@ -1266,8 +1252,11 @@ namespace OfficeOpenXml.Drawing
             }
             else
             {
-                To.X = x + To.X - From.X;
-                To.Y = y + To.Y - From.Y;
+                if (EditAs != eEditAs.Absolute)
+                {
+                    To.X = x + To.X - From.X;
+                    To.Y = y + To.Y - From.Y;
+                }
                 From.X = x;
                 From.Y = y;
             }

--- a/src/EPPlus/Drawing/ExcelDrawing.cs
+++ b/src/EPPlus/Drawing/ExcelDrawing.cs
@@ -1534,8 +1534,18 @@ namespace OfficeOpenXml.Drawing
             }
             if (To != null)
             {
-                To.X = (From.X + PixelWidth / _drawings._screenWidth);
-                if (To.X > 1) To.X = 1; else if (To.X < 0) To.X = 0;
+                var widthFraction = PixelWidth / _drawings._screenWidth;
+                To.X = From.X + widthFraction;
+                if (To.X > 1)
+                {
+                    To.X = 1;
+                    From.X = Math.Max(0, 1 - widthFraction);
+                }
+                else if (To.X < 0)
+                {
+                    From.X = 0;
+                    To.X = widthFraction;
+                }
             }
             if (Size != null)
             {
@@ -1550,12 +1560,18 @@ namespace OfficeOpenXml.Drawing
             }
             if (To != null)
             {
-                
-                
-                if (To.X > 1) To.X = 1; else if (To.X < 0) To.X = 0;
-
-                To.Y = (From.Y + PixelHeight / _drawings._screenHeight);
-                if (To.Y > 1) To.Y = 1; else if (To.Y < 0) To.Y = 0;
+                var heightFraction = PixelHeight / _drawings._screenHeight;
+                To.Y = From.Y + heightFraction;
+                if (To.Y > 1)
+                {
+                    To.Y = 1;
+                    From.Y = Math.Max(0, 1 - heightFraction);
+                }
+                else if (To.Y < 0)
+                {
+                    From.Y = 0;
+                    To.Y = heightFraction;
+                }
             }
             if (Size != null)
             {

--- a/src/EPPlus/Drawing/ExcelDrawing.cs
+++ b/src/EPPlus/Drawing/ExcelDrawing.cs
@@ -788,7 +788,7 @@ namespace OfficeOpenXml.Drawing
                 {
                     return (int)(Math.Round(From.X * _drawings._screenWidth));
                 }
-                return 0;
+                return Position == null ? 0 : Position.X / EMU_PER_PIXEL;
             }
             if (CellAnchor == eEditAs.Absolute)
             {
@@ -818,7 +818,7 @@ namespace OfficeOpenXml.Drawing
                 {
                     return (int)(Math.Round(From.Y * _drawings._screenHeight));
                 }
-                return 0;
+                return Position == null ? 0 : Position.Y / EMU_PER_PIXEL;
             }
 
             if (CellAnchor == eEditAs.Absolute)

--- a/src/EPPlus/Drawing/ExcelDrawing.cs
+++ b/src/EPPlus/Drawing/ExcelDrawing.cs
@@ -928,7 +928,7 @@ namespace OfficeOpenXml.Drawing
             _doNotAdjust = true;
             if (CellAnchor == eEditAs.Absolute)
             {
-                if (_collectionType == DrawingsCollectionType.Worksheet)
+                if (_collectionType == DrawingsCollectionType.Worksheet || _collectionType == DrawingsCollectionType.Chart)
                 {
                     Position.Y = (int)(pixels * EMU_PER_PIXEL);
                 }
@@ -977,7 +977,7 @@ namespace OfficeOpenXml.Drawing
             _doNotAdjust = true;
             if (CellAnchor == eEditAs.Absolute)
             {
-                if (_collectionType == DrawingsCollectionType.Worksheet)
+                if (_collectionType == DrawingsCollectionType.Worksheet || _collectionType == DrawingsCollectionType.Chart)
                 {
                     Position.X = (int)(pixels * EMU_PER_PIXEL);
                 }
@@ -1143,7 +1143,7 @@ namespace OfficeOpenXml.Drawing
             double pixOff = pixels - (PixelHelper.GetColumnWidth(ws, fromColumn + 1) - fromColumnOff / EMU_PER_PIXEL);
             double offset = (double)fromColumnOff / EMU_PER_PIXEL + pixels;
             col = fromColumn + 2;
-            while (pixOff >= 0)
+            while (pixOff >= 0 && col < ExcelPackage.MaxColumns)
             {
                 offset = pixOff;
                 pixOff -= PixelHelper.GetColumnWidth(ws, col++);

--- a/src/EPPlus/Drawing/ExcelDrawing.cs
+++ b/src/EPPlus/Drawing/ExcelDrawing.cs
@@ -1266,6 +1266,8 @@ namespace OfficeOpenXml.Drawing
             }
             else
             {
+                To.X = x + To.X - From.X;
+                To.Y = y + To.Y - From.Y;
                 From.X = x;
                 From.Y = y;
             }

--- a/src/EPPlus/Drawing/ExcelGroupShape.cs
+++ b/src/EPPlus/Drawing/ExcelGroupShape.cs
@@ -645,7 +645,7 @@ namespace OfficeOpenXml.Drawing
             foreach (var d in Drawings)
             {
                 //Ensure position on underlying drawings are updated
-                d.AdjustPositionAndSize();
+                //d.AdjustPositionAndSize();
                 d.UpdatePositionAndSizeXml();
                 d.SaveDrawing(hasLoadedPivotTables);
             }

--- a/src/EPPlus/Drawing/ExcelGroupShape.cs
+++ b/src/EPPlus/Drawing/ExcelGroupShape.cs
@@ -120,7 +120,7 @@ namespace OfficeOpenXml.Drawing
             }
             else if (d._drawings._collectionType == DrawingsCollectionType.Chart)
             {
-                if (d is not ExcelGroupShape)
+                if (d.ParentGroup is ExcelGroupShape)
                 {
                     d.RemoveFromToNodes();
                     d.Position = new ExcelDrawingCoordinate(d.NameSpaceManager, d.TopNode, d.GetPositionSize);
@@ -645,7 +645,7 @@ namespace OfficeOpenXml.Drawing
             foreach (var d in Drawings)
             {
                 //Ensure position on underlying drawings are updated
-                //d.AdjustPositionAndSize();
+                d.AdjustPositionAndSize();
                 d.UpdatePositionAndSizeXml();
                 d.SaveDrawing(hasLoadedPivotTables);
             }

--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -2556,6 +2556,7 @@ namespace OfficeOpenXml
                 }
             }
         }
+
         private void SaveSlicers()
         {
             SlicerXmlSources.Save();

--- a/src/EPPlusTest/Drawing/Chart/ChartShapeTest.cs
+++ b/src/EPPlusTest/Drawing/Chart/ChartShapeTest.cs
@@ -257,6 +257,7 @@ namespace EPPlusTest.Drawing.Chart
             Assert.IsTrue(chart.Drawings.Count == 5);
             var group = pic1.Group(pic2, pic3, pic4, pic5);
             Assert.IsTrue(chart.Drawings.Count == 1);
+            SaveWorkbook("groupshapes2.xlsx", p);
         }
         [TestMethod]
         public void GroupShapesWithGroupShapes()
@@ -272,11 +273,14 @@ namespace EPPlusTest.Drawing.Chart
             var equal = chart.Drawings.AddShape("Equal", eShapeStyle.MathEqual);
             var roundRect = chart.Drawings.AddShape("RoundRect", eShapeStyle.Round1Rect);
             var triangle = chart.Drawings.AddShape("Triangle", eShapeStyle.Triangle);
-
+             
             Assert.IsTrue(chart.Drawings.Count == 4);
             var group1 = arrow.Group(equal);
             var group2 = group1.Group(roundRect, triangle);
-            Assert.IsTrue(chart.Drawings.Count == 1);
+            //Assert.IsTrue(chart.Drawings.Count == 1);
+            group2.SetPosition(100, 100);
+            //group2.SetPosition(20, 20);
+            SaveWorkbook("groupshapes1.xlsx", p);
         }
         [TestMethod]
         public void GroupShapesMixed()

--- a/src/EPPlusTest/Drawing/Chart/ChartShapeTest.cs
+++ b/src/EPPlusTest/Drawing/Chart/ChartShapeTest.cs
@@ -21,6 +21,18 @@ namespace EPPlusTest.Drawing.Chart
             SaveAndCleanup(p);
         }
 
+        [TestMethod]
+        public void ShapeInChartTest2()
+        {
+            using var p = OpenTemplatePackage("ShapeInChartTest2.xlsx");
+            var ws = p.Workbook.Worksheets[0];
+            var chart = ws.Drawings[0] as ExcelChartStandard;
+            var cdr = chart.Drawings[0];
+            cdr.SetPosition(150, 200);
+            cdr.SetSize(200, 200);
+
+            SaveAndCleanup(p);
+        }
 
         [TestMethod]
         public void ShapeInChartTest()

--- a/src/EPPlusTest/Issues/DrawingIssues.cs
+++ b/src/EPPlusTest/Issues/DrawingIssues.cs
@@ -216,6 +216,13 @@ namespace EPPlusTest.Issues
             Console.WriteLine("Done (no crash).");
             SaveAndCleanup(destPackage);
         }
+
+        [TestMethod]
+        public void s1055()
+        {
+            using var p = OpenTemplatePackage("s1055.xlsx");
+            SaveAndCleanup(p);
+        }
     }
 }
 

--- a/src/EPPlusTest/TestBase.cs
+++ b/src/EPPlusTest/TestBase.cs
@@ -249,7 +249,7 @@ namespace EPPlusTest
             var fi = new FileInfo(_worksheetPath + name);
             if (fi.Exists)
             {
-                //fi.Delete();
+                    fi.Delete();
             }
             pck.SaveAs(fi);
         }


### PR DESCRIPTION
Also fixed a crash when saving workbook with groupshape as a shape in a chart.

Before submitting this pull request I have...
- [x] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [x] ensured that the functionality I have added/changed is covered by new unit tests.
- [x] merged the target branch into the PR branch and resolved any merge conflicts
- [x] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).
