### PR TITLE
Fix IndexOutOfRangeException in LoadFromText when text file has more columns than specified DataTypes

### DIFF
--- a/src/EPPlus/LoadFunctions/LoadFromTextBase.cs
+++ b/src/EPPlus/LoadFunctions/LoadFromTextBase.cs
@@ -62,16 +62,18 @@ namespace OfficeOpenXml.LoadFunctions
 
         protected object ConvertData(T Format, eDataTypes[] dataType, string v, int col, bool isText)
         {
-            if (isText && (dataType == null || dataType.Length < col))
+            bool isOutOfBounds = dataType == null || col >= dataType.Length;
+
+            if (isOutOfBounds)
             {
-                return string.IsNullOrEmpty(v) ? null : v;
+                if (isText)
+                {
+                    return string.IsNullOrEmpty(v) ? null : v;
+                }
+                return ConvertData(Format, eDataTypes.Unknown, v, col, isText);
             }
-            else
-            {
-                if(dataType == null || dataType.Length < col)
-                    return ConvertData(Format, eDataTypes.Unknown, v, col, isText);
-                return ConvertData(Format, dataType[col], v, col, isText);
-            }
+
+            return ConvertData(Format, dataType[col], v, col, isText);
         }
 
         protected object ConvertData(T Format, eDataTypes? dataType, string v, int col, bool isText)

--- a/src/EPPlusTest/LoadFunctions/LoadFromTextTests.cs
+++ b/src/EPPlusTest/LoadFunctions/LoadFromTextTests.cs
@@ -467,5 +467,21 @@ namespace EPPlusTest.LoadFunctions
             }
         }
 
+        [TestMethod]
+        public void ShouldLoadCsvFormatWithTrailingColumns()
+        {
+            // This test verifies that importing a text/CSV file with more columns than specified in DataTypes does not crash.
+            // Previously, an off-by-one bounds check (dataType.Length < col) allowed the loop to attempt accessing dataType[col]
+            // when 'col' was equal to 'dataType.Length', resulting in a System.IndexOutOfRangeException.
+            // With the fix (col >= dataType.Length), trailing columns beyond the DataTypes array are gracefully imported as Unknown (General).
+            AddLine("a;2;extra");
+            _format.Delimiter = ';';
+            _format.DataTypes = new eDataTypes[] { eDataTypes.String, eDataTypes.Number };
+            _worksheet.Cells["A1"].LoadFromText(_lines.ToString(), _format);
+            Assert.AreEqual("a", _worksheet.Cells["A1"].Value);
+            Assert.AreEqual(2d, _worksheet.Cells["B1"].Value);
+            Assert.AreEqual("extra", _worksheet.Cells["C1"].Value);
+        }
+
     }
 }


### PR DESCRIPTION
## Description
This pull request resolves a `System.IndexOutOfRangeException` that occurs during `ExcelRangeBase.LoadFromText` execution when importing text or CSV files.

### Root Cause
In `src/EPPlus/LoadFunctions/LoadFromTextBase.cs`, the `ConvertData` method checks if the current column index `col` is out of bounds for the `dataType` array:
```csharp
if (isText && (dataType == null || dataType.Length < col))
{
    return string.IsNullOrEmpty(v) ? null : v;
}
else
{
    if(dataType == null || dataType.Length < col)
        return ConvertData(Format, eDataTypes.Unknown, v, col, isText);
    return ConvertData(Format, dataType[col], v, col, isText);
}
```
The bounds checks use `dataType.Length < col`. Because `col` is a 0-based column index, when `col` is equal to `dataType.Length`, it is already out of bounds. The off-by-one check allowed execution to bypass the guard and attempt to access `dataType[col]`, resulting in a `System.IndexOutOfRangeException`.

### Solution
Simplified and corrected the bounds checking logic in `src/EPPlus/LoadFunctions/LoadFromTextBase.cs`'s `ConvertData` method. Introduced a clean boolean flag `isOutOfBounds` checking `col >= dataType.Length` and cleanly structured the branches:
```csharp
protected object ConvertData(T Format, eDataTypes[] dataType, string v, int col, bool isText)
{
    bool isOutOfBounds = dataType == null || col >= dataType.Length;

    if (isOutOfBounds)
    {
        if (isText)
        {
            return string.IsNullOrEmpty(v) ? null : v;
        }
        return ConvertData(Format, eDataTypes.Unknown, v, col, isText);
    }

    return ConvertData(Format, dataType[col], v, col, isText);
}
```
This ensures that any trailing columns beyond the length of the specified `DataTypes` array are handled gracefully and default to `eDataTypes.Unknown` (General) rather than causing a crash.

## Unit Tests
Added a new unit test `ShouldLoadCsvFormatWithTrailingColumns` to `src/EPPlusTest/LoadFunctions/LoadFromTextTests.cs` to verify the fix and explain the historical issue with clear comments:
```csharp
[TestMethod]
public void ShouldLoadCsvFormatWithTrailingColumns()
{
    // This test verifies that importing a text/CSV file with more columns than specified in DataTypes does not crash.
    // Previously, an off-by-one bounds check (dataType.Length < col) allowed the loop to attempt accessing dataType[col]
    // when 'col' was equal to 'dataType.Length', resulting in a System.IndexOutOfRangeException.
    // With the fix (col >= dataType.Length), trailing columns beyond the DataTypes array are gracefully imported as Unknown (General).
    AddLine("a;2;extra");
    _format.Delimiter = ';';
    _format.DataTypes = new eDataTypes[] { eDataTypes.String, eDataTypes.Number };
    _worksheet.Cells["A1"].LoadFromText(_lines.ToString(), _format);
    Assert.AreEqual("a", _worksheet.Cells["A1"].Value);
    Assert.AreEqual(2d, _worksheet.Cells["B1"].Value);
    Assert.AreEqual("extra", _worksheet.Cells["C1"].Value);
}
```
This test runs and passes successfully on both `.NET 8.0` and `.NET Framework 4.6.2` targets.