### PR TITLE
Allow AppVersion in OfficeProperties to be set to null. #2393.

### DIFF
--- a/src/EPPlus/OfficeProperties.cs
+++ b/src/EPPlus/OfficeProperties.cs
@@ -293,6 +293,14 @@ namespace OfficeOpenXml
             get { return _extendedHelper.GetXmlNodeString(AppVersionPath); }
             set 
             {
+                if (value == null)
+                {                    
+                    if(_extendedHelper.TopNode != null)
+                    {
+                        _extendedHelper.DeleteNode(AppVersionPath);
+                    }
+                    return;
+                }                    
                 var versions = value.Split('.');
                 if(versions.Length!=2 || versions.Any(x=>!x.IsInt()))
                 {

--- a/src/EPPlusTest/OfficePropertiesTests.cs
+++ b/src/EPPlusTest/OfficePropertiesTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.DateAndTime;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -57,6 +58,20 @@ namespace EPPlusTest
 
             p.Dispose();
             p2.Dispose();
+        }
+
+        [TestMethod]
+        public void AppVersion_SetToNull_RemovesNodeWithoutThrowing()
+        {
+            using var package = new ExcelPackage();
+            var props = package.Workbook.Properties;
+            var s = package.Workbook.Worksheets.Add("TestSheet");
+            s.Cells["A1"].Value = "Hej";
+            props.AppVersion = "16.0300";
+            Assert.AreEqual("16.0300", props.AppVersion);
+            
+            props.AppVersion = null;
+            Assert.IsTrue(string.IsNullOrEmpty(props.AppVersion)); 
         }
     }
 }


### PR DESCRIPTION
Before submitting this pull request I have...
- [x] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [x] ensured that the functionality I have added/changed is covered by new unit tests.
- [x] merged the target branch into the PR branch and resolved any merge conflicts
- [x] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).
