### PR TITLE
#2431 Fix formula cfvo load error in ext icon sets

### DIFF
--- a/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
+++ b/src/EPPlus/ConditionalFormatting/ExcelConditionalFormattingCollection.cs
@@ -462,7 +462,12 @@ namespace OfficeOpenXml.ConditionalFormatting
                 iconArr[i].Type = types[i].ToEnum<eExcelConditionalFormattingValueObjectType>()
                     .GetValueOrDefault();
 
-                if(double.TryParse(values[i], out double result))
+                // A formula cfvo stores its expression in the @val attribute, even
+                // when that expression is a numeric constant. Only assign Value for
+                // the numeric-value types; otherwise route through Formula. This
+                // mirrors ReadIcon and the databar reader.
+                if(iconArr[i].Type != eExcelConditionalFormattingValueObjectType.Formula
+                    && double.TryParse(values[i], NumberStyles.Any, CultureInfo.InvariantCulture, out double result))
                 {
                     iconArr[i].Value = result;
                 }

--- a/src/EPPlusTest/Issues/ConditionalFormattingIssues.cs
+++ b/src/EPPlusTest/Issues/ConditionalFormattingIssues.cs
@@ -2,9 +2,11 @@
 using OfficeOpenXml;
 using OfficeOpenXml.ConditionalFormatting;
 using OfficeOpenXml.ConditionalFormatting.Contracts;
+using OfficeOpenXml.ConditionalFormatting.Rules;
 using OfficeOpenXml.Style;
 using System.Drawing;
 using System.Globalization;
+using System.IO;
 using System.Threading;
 
 namespace EPPlusTest.Issues
@@ -214,6 +216,89 @@ namespace EPPlusTest.Issues
 
                 var file = GetOutputFile("", "Cabinet_template_test_clean_ExcelOutput.xlsx");
                 package.SaveAs(file);
+            }
+        }
+
+        [TestMethod]
+        public void RoundTrip_ExtIconSetWithNumericFormulaCfvo_DoesNotThrow()
+        {
+            // Arrange - build an icon set that is written to the extLst
+            // (3Stars always goes to extLst) with a Formula-type threshold
+            // whose value is a numeric constant. Saving to a stream produces
+            // the exact same OOXML bytes as saving to a file.
+            var stream = new MemoryStream();
+
+            using (var package = new ExcelPackage())
+            {
+                var ws = package.Workbook.Worksheets.Add("Sheet1");
+
+                for (int row = 1; row <= 10; row++)
+                {
+                    ws.Cells[row, 1].Value = row;
+                }
+
+                var iconSet = ws.ConditionalFormatting.AddThreeIconSet(
+                    new ExcelAddress("A1:A10"),
+                    eExcelconditionalFormatting3IconsSetType.Stars);
+
+                // Third threshold: Formula type with a numeric constant.
+                iconSet.Icon3.Type = eExcelConditionalFormattingValueObjectType.Formula;
+                iconSet.Icon3.Formula = "67";
+
+                package.SaveAs(stream);
+            }
+
+            // Act & Assert - reloading must not throw (threw before the fix
+            // in ApplyIconSetExtValues).
+            stream.Position = 0;
+            using (var package = new ExcelPackage(stream))
+            {
+                var ws = package.Workbook.Worksheets[0];
+                var iconSet = (IExcelConditionalFormattingThreeIconSet<eExcelconditionalFormatting3IconsSetType>)
+                    ws.ConditionalFormatting[0];
+
+                Assert.AreEqual(eExcelConditionalFormattingValueObjectType.Formula, iconSet.Icon3.Type);
+                Assert.AreEqual("67", iconSet.Icon3.Formula);
+            }
+        }
+
+        [TestMethod]
+        public void RoundTrip_RegularIconSetWithNumericFormulaCfvo_DoesNotThrow()
+        {
+            // Arrange - a regular (non-ext) icon set with a Formula-type
+            // threshold whose value is a numeric constant. This exercises the
+            // ReadIcon path, which was already correct, guarding against a
+            // future regression there.
+            var stream = new MemoryStream();
+
+            using (var package = new ExcelPackage())
+            {
+                var ws = package.Workbook.Worksheets.Add("Sheet1");
+
+                for (int row = 1; row <= 10; row++)
+                {
+                    ws.Cells[row, 1].Value = row;
+                }
+
+                var iconSet = ws.ConditionalFormatting.AddThreeIconSet(
+                    new ExcelAddress("A1:A10"),
+                    eExcelconditionalFormatting3IconsSetType.Arrows);   // regular set, not extLst
+
+                iconSet.Icon3.Type = eExcelConditionalFormattingValueObjectType.Formula;
+                iconSet.Icon3.Formula = "67";
+
+                package.SaveAs(stream);
+            }
+
+            stream.Position = 0;
+            using (var package = new ExcelPackage(stream))
+            {
+                var ws = package.Workbook.Worksheets[0];
+                var iconSet = (IExcelConditionalFormattingThreeIconSet<eExcelconditionalFormatting3IconsSetType>)
+                    ws.ConditionalFormatting[0];
+
+                Assert.AreEqual(eExcelConditionalFormattingValueObjectType.Formula, iconSet.Icon3.Type);
+                Assert.AreEqual("67", iconSet.Icon3.Formula);
             }
         }
     }


### PR DESCRIPTION

## Summary

See #2431.

Loading a workbook with an icon set conditional formatting rule stored in `extLst` threw an `InvalidOperationException` when a threshold used `type="formula"` with a numeric constant value.

## Cause

Icon sets using extended sets (`3Stars`, `3Triangles`, `5Boxes`) or cross-sheet formulas are stored in `extLst` and read via `ApplyIconSetExtValues`. That reader routed any numeric value to the `Value` setter without checking the cfvo type, and the setter rejects `Value` when `Type == Formula`. The regular icon set reader (`ReadIcon`) and the databar reader already had this guard.

## Fix

Added a `Type != Formula` check in `ApplyIconSetExtValues` so formula thresholds are routed to the `Formula` property, matching the other two readers. Also switched the numeric parse to `InvariantCulture`, consistent with the databar reader and correct for the invariant XML format.

## Tests

Added round-trip tests that build an icon set in code, save to a stream, and reload:

- Ext icon set (`3Stars`) with a numeric formula cfvo — reproduces the exception without the fix, passes with it.
- Regular icon set — guards the `ReadIcon` path against regression.

Full conditional formatting regression suite passes.