### PR TITLE
Please Add Timeline Slicer Support

### DIFF
--- a/docs/api/.manifest
+++ b/docs/api/.manifest
@@ -4052,6 +4052,7 @@
   "OfficeOpenXml.Drawing.Slicer.ExcelPivotTableSlicerCache": "OfficeOpenXml.Drawing.Slicer.ExcelPivotTableSlicerCache.yml",
   "OfficeOpenXml.Drawing.Slicer.ExcelPivotTableSlicerCache.Data": "OfficeOpenXml.Drawing.Slicer.ExcelPivotTableSlicerCache.yml",
   "OfficeOpenXml.Drawing.Slicer.ExcelPivotTableSlicerCache.PivotTables": "OfficeOpenXml.Drawing.Slicer.ExcelPivotTableSlicerCache.yml",
+  //Add ability to have timeline slicers.
   "OfficeOpenXml.Drawing.Slicer.ExcelPivotTableSlicerCache.SourceType": "OfficeOpenXml.Drawing.Slicer.ExcelPivotTableSlicerCache.yml",
   "OfficeOpenXml.Drawing.Slicer.ExcelPivotTableSlicerCacheTabularData": "OfficeOpenXml.Drawing.Slicer.ExcelPivotTableSlicerCacheTabularData.yml",
   "OfficeOpenXml.Drawing.Slicer.ExcelPivotTableSlicerCacheTabularData.CrossFilter": "OfficeOpenXml.Drawing.Slicer.ExcelPivotTableSlicerCacheTabularData.yml",

--- a/docs/api/OfficeOpenXml.Drawing.eDrawingType.yml
+++ b/docs/api/OfficeOpenXml.Drawing.eDrawingType.yml
@@ -188,6 +188,7 @@ items:
   name: Slicer
   nameWithType: eDrawingType.Slicer
   fullName: OfficeOpenXml.Drawing.eDrawingType.Slicer
+   # Excel has 2 types of Slicers with Pivot tables/charts, but only one is implemented on EPPlus.
   type: Field
   source:
     remote:


### PR DESCRIPTION
Before submitting this pull request I have...
- [x] read EPPlus Softwares [Contribution Guidlines](CONTRIBUTING.md)
- [x] ensured that the functionality I have added/changed is covered by new unit tests.
- [x] merged the target branch into the PR branch and resolved any merge conflicts
- [x] Run all the unit tests and ensured that they all are green (unless the purpose of the PR is to provide us with failing unit tests).

I am aware that currently EPPlus supports Pivot Tables, Pivot Charts, and Slicers. However, Excel has a couple kinds of slicers. One of these is already implemented in EPPlus, but I was wondering if the other could be as well. It's called a Timeline Slicer and it's essentially a slider bar for dates.
<img width="710" height="460" alt="Screenshot 2026-07-13 160544" src="https://github.com/user-attachments/assets/82e9d4fe-4215-4f6c-930e-f95e6b560ae4" />
