### PR TITLE
fix: synchronize ColumnLookup when splitting multi-column ranges (#2471)

### DIFF
--- a/src/EPPlus/ExcelStyles.cs
+++ b/src/EPPlus/ExcelStyles.cs
@@ -766,6 +766,7 @@ namespace OfficeOpenXml
                 {
                     var newCol = ws.CopyColumn(column, address.End.Column + 1, column.ColumnMax);
                     column.ColumnMax = address.End.Column;
+                    ws.ColumnLookup.UpdateColumn(column.ColumnMin, column); // Sync ColumnLookup with truncated column bounds
                 }
                 var s = ws.GetStyleInner(0, column.ColumnMin);
                 AddNewStyleColumn(sender, e, ws, styleCashe, column, s);
@@ -782,6 +783,7 @@ namespace OfficeOpenXml
                     if (isNew)
                     {
                         column._columnMax = address.End.Column;
+                        ws.ColumnLookup.UpdateColumn(column.ColumnMin, column); // Sync ColumnLookup when updating max column for new spans
                     }
                     else
                     {

--- a/src/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/ExcelWorksheet.cs
@@ -2111,6 +2111,7 @@ namespace OfficeOpenXml
                 {
                     int maxCol = column.ColumnMax;
                     column.ColumnMax = col;
+                    ColumnLookup.UpdateColumn(column.ColumnMin, column); // Sync ColumnLookup with shortened column bounds
                     ExcelColumn copy = CopyColumn(column, col + 1, maxCol);
                 }
             }
@@ -2124,6 +2125,7 @@ namespace OfficeOpenXml
                     if (maxCol >= col)
                     {
                         column.ColumnMax = col - 1;
+                        ColumnLookup.UpdateColumn(column.ColumnMin, column); // Sync ColumnLookup with truncated preceding span
                         if (maxCol > col)
                         {
                             ExcelColumn newC = CopyColumn(column, col + 1, maxCol);
@@ -3764,7 +3766,7 @@ namespace OfficeOpenXml
             }
             if(row == 0)
             {
-                var colValue = GetColumn(col);
+                var colValue = GetValueInner(0, col) as ExcelColumn; // Avoid calling GetColumn(col) which causes recursive span splitting
                 if (colValue != null)
                 {
                     ColumnLookup.UpdateColumn(col, colValue);

--- a/src/EPPlusTest/ExcelStyleTests.cs
+++ b/src/EPPlusTest/ExcelStyleTests.cs
@@ -54,5 +54,23 @@ namespace EPPlusTest
                 Assert.AreEqual("1", nodes[cell.StyleID].Attributes["quotePrefix"].Value);
             }
         }
+
+        [TestMethod]
+        public void MultiColumnStyle_WhenSplitBySubRange_ShouldInheritStyle()
+        {
+            using (var p = new ExcelPackage())
+            {
+                var ws = p.Workbook.Worksheets.Add("TestSheet");
+
+                // 1. Set font size 9 on columns A to J (Columns 1 to 10)
+                ws.Cells["A:J"].Style.Font.Size = 9;
+
+                // 2. Set Font.Bold = true on sub-range B:C (Columns 2 to 3)
+                ws.Cells["B:C"].Style.Font.Bold = true;
+
+                // 3. Check font size of E1 before value assignment
+                Assert.AreEqual(9f, ws.Cells["E1"].Style.Font.Size, "Cell E1 font size should be 9 before value assignment");
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #2471
    
### Summary
When applying style or format changes to a sub-range (e.g. `B:C`) inside a previously styled multi-column range (e.g. `A:J`), the truncated column span (e.g. `D:J`) updates `ColumnMax` in the column object, but `ColumnLookup` is not notified of the updated boundary key. Subsequent cell style lookups beyond column `C` fail `TryGetExcelColumn` boundary checks and incorrectly fall back to default style 0 (11pt font). Furthermore, calling `GetColumn` inside `SetStyleInner` caused recursive span fragmentation across adjacent columns.
    
### Changes
1. **Synchronize `ColumnLookup`**: Call `ColumnLookup.UpdateColumn(column.ColumnMin, column)` whenever `column.ColumnMax` or `column._columnMax` is modified during range splitting in `ExcelWorksheet.cs` and `ExcelStyles.cs`.
2. **Prevent Recursive Column Splitting**: Replace `GetColumn(col)` with `GetValueInner(0, col) as ExcelColumn` inside `SetStyleInner` in `ExcelWorksheet.cs`.
3. **Unit Test**: Added unit test `MultiColumnStyle_WhenSplitBySubRange_ShouldInheritStyle` in `ExcelStyleTests.cs`.