### PR TITLE
#2498 - Fix GPOS kerning: unwrap extension-wrapped PairPos, sort expanded pair sets, and scale TJ adjustments by units per em

### DIFF
--- a/src/EPPlus.Export.Pdf.Tests/KerningReproTests.cs
+++ b/src/EPPlus.Export.Pdf.Tests/KerningReproTests.cs
@@ -1,0 +1,170 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  09/07/2026         EPPlus Software AB           WP1 kerning repro sheet
+ *************************************************************************************************/
+using EPPlus.Export.Pdf.Tests;
+using OfficeOpenXml;
+using OfficeOpenXml.Style;
+using System;
+using System.IO;
+using System.Text;
+
+namespace EPPlusTest.PDF
+{
+    /// <summary>
+    /// Reproduces the reference sheet the WP1 kerning work was measured against.
+    ///
+    /// This is a VISUAL repro, not an automated regression test. It produces a PDF that has to be
+    /// opened and measured by hand, because the kerning adjustments live inside a Flate compressed
+    /// content stream and there is no decompression helper in the test project yet.
+    ///
+    /// What to measure in the output, at Calibri 48 pt and 3.3299 px/pt:
+    ///
+    ///   A2  "AVATAR Wa To"  The A to A pen step is the reference measurement. It was 184 px
+    ///                       before WP1 and should now be close to 170 px, which is 2358 font
+    ///                       units down to 2184. The pairs that carry kerning here are A+V, V+A,
+    ///                       A+T, T+A, W+a and T+o.
+    ///
+    ///   A4  "AVATAR Wa To"  Same string with kerning suppressed by putting every character in its
+    ///   A5                  own cell, as a side by side reference for the pen steps. Not affected
+    ///                       by WP1.
+    ///
+    ///   A7  "A" + U+0301    The accent cells are expected to be UNCHANGED by WP1. XOffset and
+    ///   A8  "a" + U+0301    YOffset are still not read by the renderer, so the accent over the
+    ///                       capital A should still sit about 7 px too far right and 23 px too low
+    ///                       and collide with the apex, while the accent over the lower case a
+    ///                       still looks correct by coincidence. Both moving is a sign that WP1
+    ///                       touched something it should not have. That is WP2.
+    ///
+    /// The decomposed sequences in A7 and A8 are the ones that exercise mark to base positioning.
+    /// The precomposed characters in B7 and B8 resolve to a single glyph in cmap and never reach
+    /// the mark positioning code, so they are included only as a visual baseline.
+    /// </summary>
+    [TestClass]
+    public class KerningReproTests : PdfTestBase
+    {
+        /// <summary>
+        /// Calibri is a system font, so this test is only meaningful on a machine that has it.
+        /// It is the font the original measurements were taken with, and its kern lookups are
+        /// extension wrapped, which is the failure mode WP1 fixes.
+        /// </summary>
+        private const string ReferenceFontName = "Calibri";
+
+        private const float ReferenceFontSize = 48f;
+
+        private const string KernedText = "AVATAR Wa To";
+
+        [TestMethod]
+        public void Avatar_Calibri48_KerningReproSheet()
+        {
+            using (var package = OpenPackage("WP1KerningRepro.xlsx", true))
+            {
+                var sheet = package.Workbook.Worksheets.Add("Kerning");
+
+                BuildReproSheet(sheet);
+
+                // Written to disk for visual inspection and for measuring against the reference
+                // image. SaveAsPdf on the worksheet exports that single sheet.
+                SaveAsPdf(sheet, "WP1KerningRepro");
+
+                // Also export to a stream so the test fails loudly if the export itself breaks,
+                // rather than silently writing an unreadable file.
+                using (var stream = new MemoryStream())
+                {
+                    sheet.SaveAsPdf(stream);
+                    AssertLooksLikePdf(stream.ToArray());
+                }
+
+                SaveWorkbook("WP1KerningRepro.xlsx", package);
+            }
+        }
+
+        private static void BuildReproSheet(ExcelWorksheet sheet)
+        {
+            sheet.Cells["A1"].Value = "Kerned pen steps";
+            StyleHeader(sheet.Cells["A1"]);
+
+            sheet.Cells["A2"].Value = KernedText;
+            StyleReference(sheet.Cells["A2"]);
+
+            sheet.Cells["A3"].Value = "Unkerned reference, one character per cell";
+            StyleHeader(sheet.Cells["A3"]);
+
+            // One character per cell removes every pair boundary, so these advances are the raw
+            // hmtx widths regardless of whether kerning works.
+            for (int i = 0; i < KernedText.Length; i++)
+            {
+                var cell = sheet.Cells[4, i + 1];
+                cell.Value = KernedText[i].ToString();
+                StyleReference(cell);
+            }
+
+            sheet.Cells["A6"].Value = "Mark to base, expected unchanged by WP1";
+            StyleHeader(sheet.Cells["A6"]);
+
+            // Decomposed: base glyph plus combining acute accent, U+0301.
+            sheet.Cells["A7"].Value = "A\u0301";
+            sheet.Cells["A8"].Value = "a\u0301";
+
+            // Precomposed, single glyph in cmap. Visual baseline only.
+            sheet.Cells["B7"].Value = "\u00C1";
+            sheet.Cells["B8"].Value = "\u00E1";
+
+            StyleReference(sheet.Cells["A7:B8"]);
+
+            // Wide enough that autofit or clipping never influences the measurement. Kerning that
+            // starts working narrows the measured text, so a fixed width keeps the pen steps the
+            // only thing that changes between runs.
+            for (int column = 1; column <= KernedText.Length; column++)
+            {
+                sheet.Column(column).Width = 20;
+            }
+
+            for (int row = 1; row <= 8; row++)
+            {
+                sheet.Row(row).CustomHeight = true;
+                sheet.Row(row).Height = 70;
+            }
+        }
+
+        private static void StyleReference(ExcelRange range)
+        {
+            range.Style.Font.Name = ReferenceFontName;
+            range.Style.Font.Size = ReferenceFontSize;
+            range.Style.HorizontalAlignment = ExcelHorizontalAlignment.Left;
+            range.Style.VerticalAlignment = ExcelVerticalAlignment.Bottom;
+
+            // Left aligned and unindented, so the first glyph starts at the cell edge and the
+            // A to A distance is a pure pen step with no left margin effects.
+            range.Style.Indent = 0;
+            range.Style.WrapText = false;
+        }
+
+        private static void StyleHeader(ExcelRange range)
+        {
+            range.Style.Font.Name = ReferenceFontName;
+            range.Style.Font.Size = 11f;
+            range.Style.Font.Bold = true;
+        }
+
+        private static void AssertLooksLikePdf(byte[] bytes)
+        {
+            Assert.IsTrue(bytes.Length > 0, "PDF output is empty.");
+
+            string head = Encoding.ASCII.GetString(bytes, 0, Math.Min(8, bytes.Length));
+            Assert.IsTrue(head.StartsWith("%PDF-"), $"Missing PDF header. Got: '{head}'");
+
+            int tailLength = Math.Min(8, bytes.Length);
+            string tail = Encoding.ASCII.GetString(bytes, bytes.Length - tailLength, tailLength);
+            Assert.IsTrue(tail.Contains("%%EOF"), "Missing %%EOF trailer marker.");
+        }
+    }
+}

--- a/src/EPPlus.Export.Pdf/DocumentObjects/PdfContentStream.cs
+++ b/src/EPPlus.Export.Pdf/DocumentObjects/PdfContentStream.cs
@@ -9,6 +9,7 @@
   Date               Author                       Change
  *************************************************************************************************
   10/07/2025         EPPlus Software AB           EPPlus.Fonts.OpenType 1.0
+  09/07/2026         EPPlus Software AB           Scale TJ kerning adjustments with units per em
  *************************************************************************************************/
 using EPPlus.Graphics;
 using EPPlus.Graphics.Geometry;
@@ -249,7 +250,16 @@ namespace EPPlus.Export.Pdf.DocumentObjects
                         int kerning = glyph.XAdvance - glyph.BaseAdvance;
                         if (kerning != 0)
                         {
-                            double adjustment = -(kerning * 1000.0 / 1000);
+                            // Glyph metrics are in font units, TJ numbers are in 1/1000 em, so
+                            // the adjustment has to be scaled by 1000 / unitsPerEm. The em square
+                            // is resolved per glyph because a fallback font can use a different
+                            // one than the primary font. Same scaling as /W in PdfCIDFont.
+                            ushort unitsPerEm = GetUnitsPerEm(
+                                shapedText.ShapedText.FontUnitsPerEm,
+                                glyph.FontId,
+                                fontResource.fontData.HeadTable.UnitsPerEm);
+
+                            double adjustment = -(kerning * 1000.0 / unitsPerEm);
                             sb.Append($" {adjustment.ToPdfStringF0()}");
                         }
                         if (j < shapedText.ShapedText.Glyphs.Length - 1)
@@ -264,6 +274,32 @@ namespace EPPlus.Export.Pdf.DocumentObjects
                 }
                 advanceY -= (line.LargestAscent + line.LargestDescent);
             }
+        }
+
+        /// <summary>
+        /// Resolves the em square to use when converting font units to text space units for a
+        /// single glyph. Fallback fonts are allowed to have a different units per em than the
+        /// primary font, which is why the value is indexed by the font id of the glyph.
+        /// </summary>
+        /// <param name="fontUnitsPerEm">Units per em indexed by font id, from the shaping result.</param>
+        /// <param name="fontId">The font id of the glyph being written.</param>
+        /// <param name="defaultUnitsPerEm">Units per em of the primary font, used as a fallback.</param>
+        private static ushort GetUnitsPerEm(ushort[] fontUnitsPerEm, byte fontId, ushort defaultUnitsPerEm)
+        {
+            if (fontUnitsPerEm != null && fontUnitsPerEm.Length > 0)
+            {
+                if (fontId < fontUnitsPerEm.Length && fontUnitsPerEm[fontId] > 0)
+                {
+                    return fontUnitsPerEm[fontId];
+                }
+
+                if (fontUnitsPerEm[0] > 0)
+                {
+                    return fontUnitsPerEm[0];
+                }
+            }
+
+            return defaultUnitsPerEm > 0 ? defaultUnitsPerEm : (ushort)1000;
         }
 
         public void AddCellContentLayout(PdfCellContentLayout cell, PdfDictionaries dictionaries, PdfPageSettings pageSettings)

--- a/src/EPPlus.Fonts.OpenType.Tests/TextShaping/GposExtensionKerningTests.cs
+++ b/src/EPPlus.Fonts.OpenType.Tests/TextShaping/GposExtensionKerningTests.cs
@@ -1,0 +1,311 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  09/07/2026         EPPlus Software AB           Kerning from extension wrapped GPOS lookups
+ *************************************************************************************************/
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Coverage;
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Lookups;
+using EPPlus.Fonts.OpenType.Tables.Gpos;
+using EPPlus.Fonts.OpenType.Tables.Gpos.Data.Lookups.LookupType2;
+using EPPlus.Fonts.OpenType.Tests.Helpers;
+using EPPlus.Fonts.OpenType.TextShaping;
+using EPPlus.Fonts.OpenType.TextShaping.Kerning;
+using OfficeOpenXml.Interfaces.Fonts;
+
+namespace EPPlus.Fonts.OpenType.Tests.TextShaping
+{
+    /// <summary>
+    /// Tests that pair positioning is actually FOUND for a given font, both in the full font and
+    /// in a serialized subset.
+    ///
+    /// These tests exist because every bug they cover was silent. GposKerningProvider required
+    /// LookupType == 2 and ExtensionPosHandler only handled MarkToBase, so a font whose kern
+    /// lookups are extension wrapped simply came out unkerned with no error anywhere. Asserting
+    /// that shaping does not throw is not enough - the assertion has to be that a specific
+    /// adjustment for a specific pair is retrieved.
+    /// </summary>
+    [TestClass]
+    public class GposExtensionKerningTests : FontTestBase
+    {
+        public override TestContext? TestContext { get; set; }
+
+        /// <summary>
+        /// EB Garamond has its kern feature as lookup type 9 (Extension) wrapping PairPos type 2,
+        /// with both format 1 and format 2 subtables. This is the same failure mode as Calibri,
+        /// without needing a system font. Units per em is 1000.
+        /// </summary>
+        private const string GaramondFamily = "EB Garamond";
+
+        /// <summary>
+        /// Roboto has its kern feature as PairPos type 2 directly, and 2048 units per em.
+        /// Used as the guard that unwrapped lookups still work, and as the font that exposes
+        /// units per em scaling errors as a factor of roughly two.
+        /// </summary>
+        private const string RobotoFamily = "Roboto";
+
+        // Adjustments read from the kern feature of the shipped test fonts, in font units.
+        private const int GaramondKerningAV = -140;   // class based (format 2) subtable
+        private const int GaramondKerningTo = -105;   // class based (format 2) subtable
+        private const int RobotoKerningAV = -87;      // class based (format 2) subtable
+        private const int RobotoKerningFa = -34;      // individual pair (format 1) subtable
+
+        #region Full font
+
+        [TestMethod]
+        public void FullFont_ExtensionWrappedKernLookup_IsFoundByKerningProvider()
+        {
+            var font = TestFolderEngine.LoadFont(GaramondFamily, FontSubFamily.Regular);
+            Assert.IsNotNull(font, $"{GaramondFamily} must be present in the test font folder");
+            Assert.IsNotNull(font.GposTable, $"{GaramondFamily} must have a GPOS table");
+
+            var provider = new GposKerningProvider(font.GposTable);
+
+            Assert.AreEqual(
+                GaramondKerningAV,
+                (int)provider.GetKerning(font.CmapTable.GetGlyphId('A'), font.CmapTable.GetGlyphId('V')),
+                "A+V kerning must be found even though the kern lookup is extension wrapped");
+
+            Assert.AreEqual(
+                GaramondKerningTo,
+                (int)provider.GetKerning(font.CmapTable.GetGlyphId('T'), font.CmapTable.GetGlyphId('o')),
+                "T+o kerning must be found even though the kern lookup is extension wrapped");
+        }
+
+        [TestMethod]
+        public void FullFont_DirectKernLookup_IsStillFoundByKerningProvider()
+        {
+            // Guards the removal of the LookupType == 2 filter in GposKerningProvider:
+            // lookups that are not extension wrapped must keep working.
+            var font = TestFolderEngine.LoadFont(RobotoFamily, FontSubFamily.Regular);
+            Assert.IsNotNull(font.GposTable);
+
+            var provider = new GposKerningProvider(font.GposTable);
+
+            Assert.AreEqual(
+                RobotoKerningAV,
+                (int)provider.GetKerning(font.CmapTable.GetGlyphId('A'), font.CmapTable.GetGlyphId('V')),
+                "A+V comes from a class based subtable");
+
+            Assert.AreEqual(
+                RobotoKerningFa,
+                (int)provider.GetKerning(font.CmapTable.GetGlyphId('F'), font.CmapTable.GetGlyphId('a')),
+                "F+a comes from an individual pair subtable");
+        }
+
+        [TestMethod]
+        public void Shape_ExtensionWrappedKerning_IsAppliedToLeftGlyphAdvance()
+        {
+            var font = TestFolderEngine.LoadFont(GaramondFamily, FontSubFamily.Regular);
+            var shaper = new TextShaper(TestFolderEngine, font);
+
+            var shaped = shaper.Shape("AV");
+
+            Assert.AreEqual(2, shaped.Glyphs.Length);
+
+            // TextShaper.ApplyKerning adjusts the advance of the LEFT glyph of the pair.
+            int kerning = shaped.Glyphs[0].XAdvance - shaped.Glyphs[0].BaseAdvance;
+            Assert.AreEqual(GaramondKerningAV, kerning, "kerning must reach the shaped advance");
+
+            Assert.AreEqual(
+                0,
+                shaped.Glyphs[1].XAdvance - shaped.Glyphs[1].BaseAdvance,
+                "the right glyph of the pair must not be adjusted");
+        }
+
+        #endregion
+
+        #region Subset
+
+        [TestMethod]
+        public void Subset_ExtensionWrappedKernLookup_SurvivesWithInnerLookupType()
+        {
+            var subset = FontTestHelper.RoundtripSubset(TestFolderEngine, GaramondFamily, "AVATAR Wa To");
+
+            Assert.IsNotNull(subset.GposTable, "GPOS must survive subsetting");
+
+            var kernLookups = GetKernLookups(subset.GposTable);
+            Assert.AreNotEqual(0, kernLookups.Count, "the kern feature must still reference lookups");
+
+            int pairPosSubtables = 0;
+            foreach (var lookup in kernLookups)
+            {
+                foreach (var subtable in lookup.SubTables)
+                {
+                    if (subtable is PairPosSubTable)
+                    {
+                        pairPosSubtables++;
+
+                        // The subset must carry the inner lookup type, not the extension type.
+                        // Re-wrapping as type 9 without a real ExtensionPosFormat1 record is what
+                        // made the embedded GPOS table unreadable to external parsers.
+                        Assert.AreEqual(
+                            2,
+                            (int)lookup.LookupType,
+                            "a lookup holding PairPos subtables must be declared as type 2");
+                    }
+                }
+            }
+
+            Assert.AreNotEqual(
+                0,
+                pairPosSubtables,
+                "extension wrapped PairPos must not be dropped during subsetting");
+        }
+
+        [TestMethod]
+        public void Subset_ExtensionWrappedKerning_IsStillFoundAfterRoundtrip()
+        {
+            var subset = FontTestHelper.RoundtripSubset(TestFolderEngine, GaramondFamily, "AVATAR Wa To");
+
+            var provider = new GposKerningProvider(subset.GposTable);
+
+            // Glyph ids are the subset ones here, which is exactly what the PDF path shapes with.
+            Assert.AreEqual(
+                GaramondKerningAV,
+                (int)provider.GetKerning(subset.CmapTable.GetGlyphId('A'), subset.CmapTable.GetGlyphId('V')),
+                "A+V kerning must survive subsetting and glyph id remapping");
+
+            Assert.AreEqual(
+                GaramondKerningTo,
+                (int)provider.GetKerning(subset.CmapTable.GetGlyphId('T'), subset.CmapTable.GetGlyphId('o')),
+                "T+o kerning must survive subsetting and glyph id remapping");
+        }
+
+        [TestMethod]
+        public void Subset_ExpandedPairSets_AreSortedBySecondGlyph()
+        {
+            // PairPosHandler.RewriteFormat2 expands the class matrix by iterating
+            // FontSubsettingContext.IncludedGlyphs, which is a HashSet with no defined
+            // enumeration order. Unsorted records break the binary search in
+            // PairPosSubTableFormat1.TryGetPairAdjustment and silently lose pairs.
+            var subset = FontTestHelper.RoundtripSubset(
+                TestFolderEngine, GaramondFamily, "AVATAR Wa To vwxyz .,-");
+
+            int checkedPairSets = 0;
+
+            foreach (var subtable in GetPairPosFormat1Subtables(subset.GposTable))
+            {
+                foreach (var pairSet in subtable.PairSets)
+                {
+                    if (pairSet?.PairValueRecords == null)
+                    {
+                        continue;
+                    }
+
+                    checkedPairSets++;
+
+                    for (int i = 1; i < pairSet.PairValueRecords.Count; i++)
+                    {
+                        Assert.IsTrue(
+                            pairSet.PairValueRecords[i - 1].SecondGlyph < pairSet.PairValueRecords[i].SecondGlyph,
+                            "PairValueRecords must be strictly ascending by SecondGlyph, but "
+                            + $"{pairSet.PairValueRecords[i - 1].SecondGlyph} came before "
+                            + $"{pairSet.PairValueRecords[i].SecondGlyph}");
+                    }
+                }
+            }
+
+            Assert.AreNotEqual(0, checkedPairSets, "the test must actually have pair sets to check");
+        }
+
+        [TestMethod]
+        public void Subset_EveryPairInExpandedPairSet_IsFoundByBinarySearch()
+        {
+            // The observable symptom of unsorted records: a pair is present in the table but
+            // cannot be retrieved.
+            var subset = FontTestHelper.RoundtripSubset(
+                TestFolderEngine, GaramondFamily, "AVATAR Wa To vwxyz .,-");
+
+            int checkedPairs = 0;
+
+            foreach (var subtable in GetPairPosFormat1Subtables(subset.GposTable))
+            {
+                var coverage = subtable.Coverage as CoverageTableFormat1;
+                Assert.IsNotNull(coverage, "subsetted coverage is always written as format 1");
+
+                for (int i = 0; i < coverage!.GlyphArray.Length && i < subtable.PairSets.Count; i++)
+                {
+                    var firstGlyph = coverage.GlyphArray[i];
+                    var pairSet = subtable.PairSets[i];
+
+                    if (pairSet?.PairValueRecords == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var record in pairSet.PairValueRecords)
+                    {
+                        checkedPairs++;
+
+                        Assert.IsTrue(
+                            subtable.TryGetPairAdjustment(firstGlyph, record.SecondGlyph, out _, out _),
+                            $"pair {firstGlyph}+{record.SecondGlyph} is in the table but was not found");
+                    }
+                }
+            }
+
+            Assert.AreNotEqual(0, checkedPairs, "the test must actually have pairs to check");
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// Returns the lookups referenced by the kern feature, resolved through the feature list.
+        /// </summary>
+        private static List<LookupTable> GetKernLookups(GposTable gpos)
+        {
+            var result = new List<LookupTable>();
+
+            foreach (var featureRecord in gpos.FeatureList.FeatureRecords)
+            {
+                if (featureRecord.FeatureTag.Value != "kern")
+                {
+                    continue;
+                }
+
+                foreach (var lookupIndex in featureRecord.FeatureTable.LookupListIndices)
+                {
+                    if (lookupIndex < gpos.LookupList.Lookups.Count)
+                    {
+                        result.Add(gpos.LookupList.Lookups[lookupIndex]);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns every PairPos format 1 subtable in the kern feature. After subsetting both
+        /// original formats are written as format 1, since RewriteFormat2 expands the class matrix.
+        /// </summary>
+        private static List<PairPosSubTableFormat1> GetPairPosFormat1Subtables(GposTable gpos)
+        {
+            var result = new List<PairPosSubTableFormat1>();
+
+            foreach (var lookup in GetKernLookups(gpos))
+            {
+                foreach (var subtable in lookup.SubTables)
+                {
+                    if (subtable is PairPosSubTableFormat1 format1 && format1.PairSets != null)
+                    {
+                        result.Add(format1);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        #endregion
+    }
+}

--- a/src/EPPlus.Fonts.OpenType/Tables/Gpos/Handlers/ExtensionPosHandler.cs
+++ b/src/EPPlus.Fonts.OpenType/Tables/Gpos/Handlers/ExtensionPosHandler.cs
@@ -9,77 +9,154 @@
   Date               Author                       Change
  *************************************************************************************************
   01/12/2026         EPPlus Software AB           GPOS lookup handler interface
+  09/07/2026         EPPlus Software AB           Support all wrapped lookup types with a handler,
+                                                  and emit the inner lookup type instead of type 9
  *************************************************************************************************/
 using EPPlus.Fonts.OpenType.Subsetting;
-using EPPlus.Fonts.OpenType.Tables;
 using EPPlus.Fonts.OpenType.Tables.Common.Layout.Lookups;
+using EPPlus.Fonts.OpenType.Tables.Gpos.Data.Lookups.LookupType1;
+using EPPlus.Fonts.OpenType.Tables.Gpos.Data.Lookups.LookupType2;
 using EPPlus.Fonts.OpenType.Tables.Gpos.Data.Lookups.LookupType4;
-using EPPlus.Fonts.OpenType.Tables.Gpos.Handlers;
 using System.Collections.Generic;
 
-internal class ExtensionPosHandler : IGposLookupHandler
+namespace EPPlus.Fonts.OpenType.Tables.Gpos.Handlers
 {
-    public ushort LookupType => 9;
-
-    public void Discover(FontSubsettingContext context, LookupTable lookup, GposSubsetProcessor processor)
+    /// <summary>
+    /// Handler for GPOS Lookup Type 9: Extension Positioning.
+    /// <para>
+    /// The loader (<c>GposTableLoader.ReadExtensionPosSubTable</c>) already resolves the
+    /// extension offset and stores the wrapped subtable directly in the lookup, while
+    /// <see cref="LookupTable.LookupType"/> is left at 9. This handler therefore only has to
+    /// determine the inner lookup type from the subtables and delegate to the handler for
+    /// that type.
+    /// </para>
+    /// <para>
+    /// The rewritten lookup is returned with the inner lookup type, not re-wrapped as type 9.
+    /// Re-wrapping would require writing a real ExtensionPosFormat1 record (format, inner
+    /// lookup type and a 32 bit offset) around every subtable. Since the subset is written
+    /// from scratch and is small, there is no 16 bit offset overflow to avoid, so the
+    /// wrapper serves no purpose.
+    /// </para>
+    /// </summary>
+    internal class ExtensionPosHandler : IGposLookupHandler
     {
-        // Extension wraps another lookup - unwrap and delegate
-        foreach (var subtable in lookup.SubTables)
-        {
-            if (subtable is MarkToBaseSubTableFormat1)
-            {
-                // It's a wrapped MarkToBase - delegate to MarkToBase handler
-                var wrappedLookup = new LookupTable
-                {
-                    LookupType = 4,
-                    SubTables = new List<FontTableElement> { subtable }
-                };
+        public ushort LookupType => 9;
 
-                var handler = processor.GetHandler(4);
-                if (handler != null)
-                {
-                    handler.Discover(context, wrappedLookup, processor);
-                }
+        public void Discover(FontSubsettingContext context, LookupTable lookup, GposSubsetProcessor processor)
+        {
+            var unwrapped = Unwrap(lookup);
+            if (unwrapped == null)
+            {
+                return;
             }
-            // Add cases for other wrapped types as needed
-        }
-    }
 
-    public LookupTable Rewrite(FontSubsettingContext context, LookupTable lookup)
-    {
-        // Unwrap and delegate to the actual handler
-        if (lookup.SubTables.Count == 0)
-            return null;
-
-        var firstSubtable = lookup.SubTables[0];
-
-        if (firstSubtable is MarkToBaseSubTableFormat1)
-        {
-            // Create a temporary Type 4 lookup
-            var wrappedLookup = new LookupTable
-            {
-                LookupType = 4,
-                LookupFlag = lookup.LookupFlag,
-                SubTables = lookup.SubTables
-            };
-
-            var handler = context.GposProcessor.GetHandler(4);
+            var handler = processor.GetHandler(unwrapped.LookupType);
             if (handler != null)
             {
-                var rewritten = handler.Rewrite(context, wrappedLookup);
-                if (rewritten != null && rewritten.SubTables.Count > 0)
-                {
-                    // Wrap back in Extension
-                    return new LookupTable
-                    {
-                        LookupType = 9,
-                        LookupFlag = lookup.LookupFlag,
-                        SubTables = rewritten.SubTables
-                    };
-                }
+                handler.Discover(context, unwrapped, processor);
             }
         }
 
-        return null;
+        public LookupTable Rewrite(FontSubsettingContext context, LookupTable lookup)
+        {
+            var unwrapped = Unwrap(lookup);
+            if (unwrapped == null)
+            {
+                return null;
+            }
+
+            var handler = context.GposProcessor.GetHandler(unwrapped.LookupType);
+            if (handler == null)
+            {
+                return null;
+            }
+
+            var rewritten = handler.Rewrite(context, unwrapped);
+            if (rewritten == null || rewritten.SubTables.Count == 0)
+            {
+                return null;
+            }
+
+            // The inner handlers all copy LookupType from the lookup they are given, so the
+            // rewritten lookup already carries the inner type. Return it as is.
+            return rewritten;
+        }
+
+        /// <summary>
+        /// Builds a lookup that represents the wrapped lookup, with the inner lookup type.
+        /// Returns null when the lookup wraps a type that has no loaded subtables, which is the
+        /// case for the positioning types the loader does not read yet (3, 5, 6, 7 and 8).
+        /// </summary>
+        private static LookupTable Unwrap(LookupTable lookup)
+        {
+            if (lookup.SubTables == null || lookup.SubTables.Count == 0)
+            {
+                return null;
+            }
+
+            ushort innerLookupType = 0;
+            var innerSubTables = new List<FontTableElement>();
+
+            foreach (var subTable in lookup.SubTables)
+            {
+                var subTableLookupType = GetLookupTypeOf(subTable);
+                if (subTableLookupType == 0)
+                {
+                    continue;
+                }
+
+                if (innerLookupType == 0)
+                {
+                    innerLookupType = subTableLookupType;
+                }
+                else if (subTableLookupType != innerLookupType)
+                {
+                    // All subtables of a lookup must be of the same type per the OpenType
+                    // specification. Ignore anything that does not match the first one rather
+                    // than emitting a lookup whose type does not describe its subtables.
+                    continue;
+                }
+
+                innerSubTables.Add(subTable);
+            }
+
+            if (innerLookupType == 0)
+            {
+                return null;
+            }
+
+            return new LookupTable
+            {
+                LookupType = innerLookupType,
+                LookupFlag = lookup.LookupFlag,
+                MarkFilteringSet = lookup.MarkFilteringSet,
+                SubTables = innerSubTables
+            };
+        }
+
+        /// <summary>
+        /// Maps a loaded GPOS subtable to the lookup type it belongs to.
+        /// Returns 0 for subtable types that cannot be mapped.
+        /// </summary>
+        private static ushort GetLookupTypeOf(FontTableElement subTable)
+        {
+            if (subTable is SinglePosSubTableFormat1 || subTable is SinglePosSubTableFormat2)
+            {
+                return 1;
+            }
+
+            if (subTable is PairPosSubTable)
+            {
+                // Covers both PairPosSubTableFormat1 and PairPosSubTableFormat2.
+                return 2;
+            }
+
+            if (subTable is MarkToBaseSubTableFormat1)
+            {
+                return 4;
+            }
+
+            return 0;
+        }
     }
 }

--- a/src/EPPlus.Fonts.OpenType/Tables/Gpos/Handlers/PairPosHandler.cs
+++ b/src/EPPlus.Fonts.OpenType/Tables/Gpos/Handlers/PairPosHandler.cs
@@ -9,6 +9,7 @@
   Date               Author                       Change
  *************************************************************************************************
   01/12/2026         EPPlus Software AB           GPOS Type 2 (PairPos) handler
+  09/07/2026         EPPlus Software AB           Sort expanded pair records by second glyph
  *************************************************************************************************/
 using EPPlus.Fonts.OpenType.Subsetting;
 using EPPlus.Fonts.OpenType.Tables.Common.Layout.Coverage;
@@ -244,6 +245,13 @@ namespace EPPlus.Fonts.OpenType.Tables.Gpos.Handlers
                 // Only include if we found pairs
                 if (pairRecords.Count > 0)
                 {
+                    // PairValueRecords must be ordered by SecondGlyph. Both the OpenType
+                    // specification and PairPosSubTableFormat1.TryGetPairAdjustment, which
+                    // binary searches the list, rely on it. The records are collected by
+                    // iterating context.IncludedGlyphs, which is a HashSet with no defined
+                    // enumeration order, so the list has to be sorted explicitly here.
+                    pairRecords.Sort(CompareBySecondGlyph);
+
                     newCoverageGlyphs.Add(firstMapping.NewGlyphId);
                     newPairSets.Add(new PairSet
                     {
@@ -275,8 +283,22 @@ namespace EPPlus.Fonts.OpenType.Tables.Gpos.Handlers
         }
 
         /// <summary>
+        /// Orders pair value records by second glyph id.
+        /// </summary>
+        private static int CompareBySecondGlyph(PairValueRecord a, PairValueRecord b)
+        {
+            return a.SecondGlyph.CompareTo(b.SecondGlyph);
+        }
+
+        /// <summary>
         /// Filters a PairSet to only include pairs where second glyph is in subset.
         /// Remaps second glyph IDs.
+        /// <para>
+        /// No re-sorting is needed here. The input is ordered by original glyph id, and
+        /// SubsetFontBuilder.BuildGlyphMapping assigns new ids in ascending order of the old
+        /// ones, so the remapping is monotonic and preserves the ordering the binary search in
+        /// PairPosSubTableFormat1.TryGetPairAdjustment depends on.
+        /// </para>
         /// </summary>
         private PairSet FilterPairSet(FontSubsettingContext context, PairSet original)
         {

--- a/src/EPPlus.Fonts.OpenType/TextShaping/Kerning/GposKerningProvider.cs
+++ b/src/EPPlus.Fonts.OpenType/TextShaping/Kerning/GposKerningProvider.cs
@@ -5,7 +5,8 @@ using System.Collections.Generic;
 namespace EPPlus.Fonts.OpenType.TextShaping.Kerning
 {
     /// <summary>
-    /// Provides kerning from GPOS PairPos lookups (Type 2).
+    /// Provides kerning from GPOS PairPos lookups (Type 2), including lookups that are
+    /// extension wrapped (Type 9) in the font file and unwrapped by GposTableLoader.
     /// Supports both Format 1 (individual pairs) and Format 2 (class-based).
     /// Uses lazy per-query lookup via TryGetPairAdjustment instead of
     /// pre-expanding all possible glyph pairs.
@@ -62,14 +63,16 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Kerning
 
                         var lookup = gpos.LookupList.Lookups[lookupIndex];
 
-                        if (lookup.LookupType == 2)
+                        // No lookup type check here. Extension positioning (type 9) is resolved
+                        // by GposTableLoader, which stores the wrapped subtable directly in the
+                        // lookup while leaving LookupType at 9. Requiring LookupType == 2 would
+                        // therefore discard all extension wrapped kerning. The subtable type
+                        // test below is what actually identifies pair positioning data.
+                        foreach (var subtable in lookup.SubTables)
                         {
-                            foreach (var subtable in lookup.SubTables)
+                            if (subtable is PairPosSubTable pairPos)
                             {
-                                if (subtable is PairPosSubTable pairPos)
-                                {
-                                    subtables.Add(pairPos);
-                                }
+                                subtables.Add(pairPos);
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

- `ExtensionPosHandler`: support all wrapped lookup types instead of
  only MarkToBase, in both Discover and Rewrite. Rewrite now returns
  the inner lookup type instead of re-wrapping as type 9, which
  fixes the unreadable embedded GPOS table as a side effect.
- [`GposKerningProvider`](url): removed the LookupType == 2 filter so
  extension-wrapped kern lookups are found. The subtable type check
  already does the real work.
- `PairPosHandler`: sort expanded PairValueRecords by second glyph in
  RewriteFormat2, so PairPosSubTableFormat1's binary search finds
  every pair instead of silently missing ones.
- `PdfContentStream`: scale TJ kerning adjustments by 1000 / unitsPerEm
  instead of a hardcoded 1000, resolved per glyph via FontUnitsPerEm.
  Fixes kerning being ~2x too strong for 2048-upem fonts.

Verified against WP1KerningRepro.pdf (Calibri 48pt): all six TJ
adjustments (A+V, V+A, A+T, T+A, W+a, T+o) match
-(kerning_fu * 1000 / 2048) within rounding, and the embedded GPOS
table parses cleanly with fontTools with kern lookups written as
type 2 instead of 9.

Adds `GposExtensionKerningTests `covering discovery, subsetting
survival, and pair-set ordering.

Does not address mark-to-base positioning (`XOffset`/`YOffset `still
unread by the renderer) or measurement/render path parity - both
remain open per the action plan.
