### PR TITLE
Mark-to-base positioning, script-aware feature lookup

### DIFF
--- a/src/EPPlus.Export.Pdf.Tests/KerningReproTests.cs
+++ b/src/EPPlus.Export.Pdf.Tests/KerningReproTests.cs
@@ -9,6 +9,7 @@
   Date               Author                       Change
  *************************************************************************************************
   09/07/2026         EPPlus Software AB           WP1 kerning repro sheet
+  09/07/2026         EPPlus Software AB           Removed the per-character reference row
  *************************************************************************************************/
 using EPPlus.Export.Pdf.Tests;
 using OfficeOpenXml;
@@ -20,41 +21,46 @@ using System.Text;
 namespace EPPlusTest.PDF
 {
     /// <summary>
-    /// Reproduces the reference sheet the WP1 kerning work was measured against.
+    /// Reproduces the reference sheet the kerning and mark-to-base work is measured against.
     ///
     /// This is a VISUAL repro, not an automated regression test. It produces a PDF that has to be
-    /// opened and measured by hand, because the kerning adjustments live inside a Flate compressed
+    /// opened and measured by hand, because the adjustments live inside a Flate compressed
     /// content stream and there is no decompression helper in the test project yet.
     ///
-    /// What to measure in the output, at Calibri 48 pt and 3.3299 px/pt:
+    /// What to measure in the output, at Calibri 48 pt:
     ///
-    ///   A2  "AVATAR Wa To"  The A to A pen step is the reference measurement. It was 184 px
-    ///                       before WP1 and should now be close to 170 px, which is 2358 font
-    ///                       units down to 2184. The pairs that carry kerning here are A+V, V+A,
-    ///                       A+T, T+A, W+a and T+o.
+    ///   A2  "AVATAR Wa To"  The kerned string. The pairs that carry kerning are A+V, V+A, A+T,
+    ///                       T+A, W+a and T+o. There are TWO A-to-A pen steps in this string,
+    ///                       over different pairs and with different values - measure the first
+    ///                       one (over A+V) or it will not match the reference numbers.
     ///
-    ///   A4  "AVATAR Wa To"  Same string with kerning suppressed by putting every character in its
-    ///   A5                  own cell, as a side by side reference for the pen steps. Not affected
-    ///                       by WP1.
+    ///                       Unkerned, the string's pen width is 12634 font units; kerned it is
+    ///                       11876. Those come from hmtx plus the kern values in the embedded
+    ///                       subset, not from this sheet - there is deliberately no unkerned
+    ///                       reference row. One character per cell does NOT give one: each cell
+    ///                       starts a new text run at the cell origin, so the spacing would be
+    ///                       the column width rather than the glyph advance.
     ///
-    ///   A7  "A" + U+0301    The accent cells are expected to be UNCHANGED by WP1. XOffset and
-    ///   A8  "a" + U+0301    YOffset are still not read by the renderer, so the accent over the
-    ///                       capital A should still sit about 7 px too far right and 23 px too low
-    ///                       and collide with the apex, while the accent over the lower case a
-    ///                       still looks correct by coincidence. Both moving is a sign that WP1
-    ///                       touched something it should not have. That is WP2.
+    ///   A4  "A" + U+0301    The mark-to-base cells. Column A is DECOMPOSED (base glyph plus
+    ///   A5  "a" + U+0301    combining acute) and goes through mark positioning. Column B is the
+    ///   B4  precomposed A   PRECOMPOSED single glyph, which resolves in cmap and never reaches
+    ///   B5  precomposed a   the mark code, so it carries the font's own accent placement.
     ///
-    /// The decomposed sequences in A7 and A8 are the ones that exercise mark to base positioning.
-    /// The precomposed characters in B7 and B8 resolve to a single glyph in cmap and never reach
-    /// the mark positioning code, so they are included only as a visual baseline.
+    ///                       Column B is therefore the control: once mark-to-base offsets reach
+    ///                       the renderer, the accent in A4 must line up with B4 to within a
+    ///                       pixel. Before that, A4's accent sits 287 font units lower.
+    ///
+    ///                       A5 is expected to end up roughly 44 font units HIGHER than B5. That
+    ///                       is not a defect - the anchor and the precomposed glyph disagree
+    ///                       slightly, and the anchor is what shaping must follow.
     /// </summary>
     [TestClass]
     public class KerningReproTests : PdfTestBase
     {
         /// <summary>
         /// Calibri is a system font, so this test is only meaningful on a machine that has it.
-        /// It is the font the original measurements were taken with, and its kern lookups are
-        /// extension wrapped, which is the failure mode WP1 fixes.
+        /// It is the font the original measurements were taken with; its kern lookups are
+        /// extension wrapped and it has a type 4 mark lookup for the combining acute.
         /// </summary>
         private const string ReferenceFontName = "Calibri";
 
@@ -89,46 +95,29 @@ namespace EPPlusTest.PDF
 
         private static void BuildReproSheet(ExcelWorksheet sheet)
         {
-            sheet.Cells["A1"].Value = "Kerned pen steps";
+            sheet.Cells["A1"].Value = "Kerned pen steps, measure the first A to A step";
             StyleHeader(sheet.Cells["A1"]);
 
             sheet.Cells["A2"].Value = KernedText;
             StyleReference(sheet.Cells["A2"]);
 
-            sheet.Cells["A3"].Value = "Unkerned reference, one character per cell";
+            sheet.Cells["A3"].Value = "Mark to base. Column A decomposed, column B precomposed control";
             StyleHeader(sheet.Cells["A3"]);
 
-            // One character per cell removes every pair boundary, so these advances are the raw
-            // hmtx widths regardless of whether kerning works.
-            for (int i = 0; i < KernedText.Length; i++)
-            {
-                var cell = sheet.Cells[4, i + 1];
-                cell.Value = KernedText[i].ToString();
-                StyleReference(cell);
-            }
+            // Decomposed: base glyph plus combining acute accent, U+0301. Goes through
+            // MarkToBaseProvider.
+            sheet.Cells["A4"].Value = "A\u0301";
+            sheet.Cells["A5"].Value = "a\u0301";
 
-            sheet.Cells["A6"].Value = "Mark to base, expected unchanged by WP1";
-            StyleHeader(sheet.Cells["A6"]);
+            // Precomposed, a single glyph in cmap. Carries the font's own accent placement and
+            // is the control the decomposed cells must line up with.
+            sheet.Cells["B4"].Value = "\u00C1";
+            sheet.Cells["B5"].Value = "\u00E1";
 
-            // Decomposed: base glyph plus combining acute accent, U+0301.
-            sheet.Cells["A7"].Value = "A\u0301";
-            sheet.Cells["A8"].Value = "a\u0301";
+            StyleReference(sheet.Cells["A4:B5"]);
+            sheet.Cells.AutoFitColumns();
 
-            // Precomposed, single glyph in cmap. Visual baseline only.
-            sheet.Cells["B7"].Value = "\u00C1";
-            sheet.Cells["B8"].Value = "\u00E1";
-
-            StyleReference(sheet.Cells["A7:B8"]);
-
-            // Wide enough that autofit or clipping never influences the measurement. Kerning that
-            // starts working narrows the measured text, so a fixed width keeps the pen steps the
-            // only thing that changes between runs.
-            for (int column = 1; column <= KernedText.Length; column++)
-            {
-                sheet.Column(column).Width = 20;
-            }
-
-            for (int row = 1; row <= 8; row++)
+            for (int row = 1; row <= 5; row++)
             {
                 sheet.Row(row).CustomHeight = true;
                 sheet.Row(row).Height = 70;

--- a/src/EPPlus.Export.Pdf/DocumentObjects/PdfContentStream.cs
+++ b/src/EPPlus.Export.Pdf/DocumentObjects/PdfContentStream.cs
@@ -10,6 +10,7 @@
  *************************************************************************************************
   10/07/2025         EPPlus Software AB           EPPlus.Fonts.OpenType 1.0
   09/07/2026         EPPlus Software AB           Scale TJ kerning adjustments with units per em
+  09/07/2026         EPPlus Software AB           Render glyph XOffset/YOffset (mark-to-base)
  *************************************************************************************************/
 using EPPlus.Graphics;
 using EPPlus.Graphics.Geometry;
@@ -233,6 +234,12 @@ namespace EPPlus.Export.Pdf.DocumentObjects
                     int charsRendered = 0;
                     var sb = new StringBuilder();
                     sb.Append("[");
+
+                    // Text rise currently in effect inside the TJ sequence below, in unscaled
+                    // text space units. Text rise is part of the text state and is NOT reset by
+                    // BT/ET, so it has to be put back to zero before leaving this block.
+                    double currentRise = 0.0;
+
                     for (int j = glyphStart; j < shapedText.ShapedText.Glyphs.Length; j++)
                     {
                         if (charsRendered >= fragmentCharCount)
@@ -246,19 +253,47 @@ namespace EPPlus.Export.Pdf.DocumentObjects
                             sb.Append("[");
                             currentFontId = glyph.FontId;
                         }
+
+                        // Glyph metrics are in font units, TJ numbers are in 1/1000 em, so
+                        // offsets and advances have to be scaled by 1000 / unitsPerEm. The em
+                        // square is resolved per glyph because a fallback font can use a
+                        // different one than the primary font. Same scaling as /W in PdfCIDFont.
+                        ushort unitsPerEm = GetUnitsPerEm(
+                            shapedText.ShapedText.FontUnitsPerEm,
+                            glyph.FontId,
+                            fontResource.fontData.HeadTable.UnitsPerEm);
+
+                        // A vertical offset cannot be expressed inside a TJ array, which only
+                        // adjusts horizontally. Ts (text rise) shifts the baseline without
+                        // touching the text matrix, so the horizontal position accumulated by
+                        // the preceding TJ advances is preserved. Ts is a text state operator
+                        // and must sit outside the array, hence the close and reopen.
+                        double rise = glyph.YOffset == 0 ? 0.0 : glyph.YOffset * size / unitsPerEm;
+                        if (rise != currentRise)
+                        {
+                            sb.Append($"] TJ\n{rise.ToPdfStringF4()} Ts\n[");
+                            currentRise = rise;
+                        }
+
+                        // A horizontal offset IS a pen displacement, so TJ can express it. It is
+                        // applied before the glyph and taken back after it, leaving the pen where
+                        // it would have been. Positive TJ numbers move left, hence the negation.
+                        double xOffset = glyph.XOffset == 0 ? 0.0 : glyph.XOffset * 1000.0 / unitsPerEm;
+                        if (xOffset != 0.0)
+                        {
+                            sb.Append($"{(-xOffset).ToPdfStringF0()} ");
+                        }
+
                         sb.Append($"<{glyph.GlyphId:X4}>");
+
+                        if (xOffset != 0.0)
+                        {
+                            sb.Append($" {xOffset.ToPdfStringF0()}");
+                        }
+
                         int kerning = glyph.XAdvance - glyph.BaseAdvance;
                         if (kerning != 0)
                         {
-                            // Glyph metrics are in font units, TJ numbers are in 1/1000 em, so
-                            // the adjustment has to be scaled by 1000 / unitsPerEm. The em square
-                            // is resolved per glyph because a fallback font can use a different
-                            // one than the primary font. Same scaling as /W in PdfCIDFont.
-                            ushort unitsPerEm = GetUnitsPerEm(
-                                shapedText.ShapedText.FontUnitsPerEm,
-                                glyph.FontId,
-                                fontResource.fontData.HeadTable.UnitsPerEm);
-
                             double adjustment = -(kerning * 1000.0 / unitsPerEm);
                             sb.Append($" {adjustment.ToPdfStringF0()}");
                         }
@@ -270,6 +305,10 @@ namespace EPPlus.Export.Pdf.DocumentObjects
                     }
                     advanceX += textLength;
                     commands.Add(sb.ToString() + "] TJ");
+                    if (currentRise != 0.0)
+                    {
+                        commands.Add("0 Ts");
+                    }
                     commands.Add("ET");
                 }
                 advanceY -= (line.LargestAscent + line.LargestDescent);

--- a/src/EPPlus.Fonts.OpenType.Tests/TextShaping/GposExtensionKerningTests.cs
+++ b/src/EPPlus.Fonts.OpenType.Tests/TextShaping/GposExtensionKerningTests.cs
@@ -69,12 +69,12 @@ namespace EPPlus.Fonts.OpenType.Tests.TextShaping
 
             Assert.AreEqual(
                 GaramondKerningAV,
-                (int)provider.GetKerning(font.CmapTable.GetGlyphId('A'), font.CmapTable.GetGlyphId('V')),
+                (int)provider.GetKerning(font.CmapTable.GetGlyphId('A'), font.CmapTable.GetGlyphId('V'), "latn", null),
                 "A+V kerning must be found even though the kern lookup is extension wrapped");
 
             Assert.AreEqual(
                 GaramondKerningTo,
-                (int)provider.GetKerning(font.CmapTable.GetGlyphId('T'), font.CmapTable.GetGlyphId('o')),
+                (int)provider.GetKerning(font.CmapTable.GetGlyphId('T'), font.CmapTable.GetGlyphId('o'), "latn", null),
                 "T+o kerning must be found even though the kern lookup is extension wrapped");
         }
 
@@ -90,12 +90,12 @@ namespace EPPlus.Fonts.OpenType.Tests.TextShaping
 
             Assert.AreEqual(
                 RobotoKerningAV,
-                (int)provider.GetKerning(font.CmapTable.GetGlyphId('A'), font.CmapTable.GetGlyphId('V')),
+                (int)provider.GetKerning(font.CmapTable.GetGlyphId('A'), font.CmapTable.GetGlyphId('V'), "latn", null),
                 "A+V comes from a class based subtable");
 
             Assert.AreEqual(
                 RobotoKerningFa,
-                (int)provider.GetKerning(font.CmapTable.GetGlyphId('F'), font.CmapTable.GetGlyphId('a')),
+                (int)provider.GetKerning(font.CmapTable.GetGlyphId('F'), font.CmapTable.GetGlyphId('a'), "latn", null),
                 "F+a comes from an individual pair subtable");
         }
 
@@ -169,12 +169,12 @@ namespace EPPlus.Fonts.OpenType.Tests.TextShaping
             // Glyph ids are the subset ones here, which is exactly what the PDF path shapes with.
             Assert.AreEqual(
                 GaramondKerningAV,
-                (int)provider.GetKerning(subset.CmapTable.GetGlyphId('A'), subset.CmapTable.GetGlyphId('V')),
+                (int)provider.GetKerning(subset.CmapTable.GetGlyphId('A'), subset.CmapTable.GetGlyphId('V'), "latn", null),
                 "A+V kerning must survive subsetting and glyph id remapping");
 
             Assert.AreEqual(
                 GaramondKerningTo,
-                (int)provider.GetKerning(subset.CmapTable.GetGlyphId('T'), subset.CmapTable.GetGlyphId('o')),
+                (int)provider.GetKerning(subset.CmapTable.GetGlyphId('T'), subset.CmapTable.GetGlyphId('o'), "latn", null),
                 "T+o kerning must survive subsetting and glyph id remapping");
         }
 

--- a/src/EPPlus.Fonts.OpenType.Tests/TextShaping/MarkToBasePositioningTests.cs
+++ b/src/EPPlus.Fonts.OpenType.Tests/TextShaping/MarkToBasePositioningTests.cs
@@ -1,0 +1,225 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  09/07/2026         EPPlus Software AB           Mark-to-base offset convention
+ *************************************************************************************************/
+using EPPlus.Fonts.OpenType.TextShaping;
+using EPPlus.Fonts.OpenType.TextShaping.Positioning;
+using OfficeOpenXml.Interfaces.Fonts;
+using System.Collections.Generic;
+
+namespace EPPlus.Fonts.OpenType.Tests.TextShaping
+{
+    /// <summary>
+    /// Tests the offset convention for mark-to-base positioning (GPOS type 4).
+    ///
+    /// The offsets written by <c>MarkToBaseProvider</c> are relative to the base glyph's ORIGIN
+    /// today. A renderer draws the mark at the pen, which has already moved by the base glyph's
+    /// advance, so a base-relative offset is unusable without the renderer knowing the advance.
+    /// The offsets are therefore being changed to PEN-RELATIVE, following the HarfBuzz convention.
+    ///
+    /// Every expected value below is taken straight from the anchors in the shipped test fonts:
+    ///   pen-relative XOffset = baseAnchor.X - markAnchor.X - baseAdvance
+    ///   YOffset              = baseAnchor.Y - markAnchor.Y
+    ///
+    /// The X assertions FAIL before the change and pass after it. The Y assertions pass both
+    /// before and after - vertical position is unaffected by the pen convention, and they are
+    /// here as guards against the change going too far.
+    /// </summary>
+    [TestClass]
+    public class MarkToBasePositioningTests : FontTestBase
+    {
+        public override TestContext? TestContext { get; set; }
+
+        /// <summary>
+        /// Noto Sans Math has mark as lookup type 4 only, so nothing is silently skipped by the
+        /// missing type 5 loader. Units per em is 1000.
+        /// </summary>
+        private const string NotoSansMathFamily = "Noto Sans Math";
+
+        /// <summary>
+        /// Mulish has both type 4 and type 5 mark lookups. Only type 4 is loaded, which makes it
+        /// a useful second font: the expected values must come from the type 4 anchors alone.
+        /// </summary>
+        private const string MulishFamily = "Mulish";
+
+        private const char CombiningAcute = '\u0301';
+
+        // Noto Sans Math: A advance 639, base anchor (318, 714); a advance 561, base anchor
+        // (281, 536); mark anchor (93, 536).
+        private const int NotoMathBaseRelativeX_A = 225;
+        private const int NotoMathPenRelativeX_A = -414;
+        private const int NotoMathYOffset_A = 178;
+        private const int NotoMathPenRelativeX_a = -373;
+        private const int NotoMathYOffset_a = 0;
+
+        // Mulish: A advance 735, base anchor (366, 705); a advance 600, base anchor (294, 484);
+        // mark anchor (0, 484).
+        private const int MulishPenRelativeX_A = -369;
+        private const int MulishYOffset_A = 221;
+        private const int MulishPenRelativeX_a = -306;
+        private const int MulishYOffset_a = 0;
+
+        #region Offsets are pen-relative
+
+        [TestMethod]
+        public void MarkOffset_OverCapital_IsPenRelative_NotoSansMath()
+        {
+            var glyphs = ShapeBaseAndMark(NotoSansMathFamily, 'A');
+
+            Assert.AreEqual(
+                NotoMathPenRelativeX_A,
+                (int)glyphs[1].XOffset,
+                $"XOffset must be pen-relative. {NotoMathBaseRelativeX_A} means it is still "
+                + "relative to the base glyph's origin.");
+
+            Assert.AreEqual(NotoMathYOffset_A, (int)glyphs[1].YOffset, "YOffset must be unchanged");
+        }
+
+        [TestMethod]
+        public void MarkOffset_OverLowercase_IsPenRelative_NotoSansMath()
+        {
+            var glyphs = ShapeBaseAndMark(NotoSansMathFamily, 'a');
+
+            Assert.AreEqual(NotoMathPenRelativeX_a, (int)glyphs[1].XOffset, "XOffset must be pen-relative");
+            Assert.AreEqual(NotoMathYOffset_a, (int)glyphs[1].YOffset, "YOffset must be unchanged");
+        }
+
+        [TestMethod]
+        public void MarkOffset_OverCapital_IsPenRelative_Mulish()
+        {
+            var glyphs = ShapeBaseAndMark(MulishFamily, 'A');
+
+            Assert.AreEqual(MulishPenRelativeX_A, (int)glyphs[1].XOffset, "XOffset must be pen-relative");
+            Assert.AreEqual(MulishYOffset_A, (int)glyphs[1].YOffset, "YOffset must be unchanged");
+        }
+
+        [TestMethod]
+        public void MarkOffset_OverLowercase_IsPenRelative_Mulish()
+        {
+            var glyphs = ShapeBaseAndMark(MulishFamily, 'a');
+
+            Assert.AreEqual(MulishPenRelativeX_a, (int)glyphs[1].XOffset, "XOffset must be pen-relative");
+            Assert.AreEqual(MulishYOffset_a, (int)glyphs[1].YOffset, "YOffset must be unchanged");
+        }
+
+        #endregion
+
+        #region Offsets accumulate
+
+        [TestMethod]
+        public void MarkOffset_DoesNotOverwriteExistingPlacement()
+        {
+            // SinglePos writes XPlacement/YPlacement into the same fields before mark positioning
+            // runs (TextShaper.ApplyValueRecord uses +=). MarkToBaseProvider must accumulate, not
+            // assign, or that contribution is silently discarded.
+            var font = TestFolderEngine.LoadFont(NotoSansMathFamily, FontSubFamily.Regular);
+            Assert.IsNotNull(font, $"{NotoSansMathFamily} must be present in the test font folder");
+
+            const short seededX = 25;
+            const short seededY = -40;
+
+            var glyphs = BuildGlyphPair(font!, 'A', seededX, seededY);
+
+            new MarkToBaseProvider(font!).ApplyMarkPositioning(glyphs, "latn", null);
+
+            Assert.AreEqual(
+                NotoMathPenRelativeX_A + seededX,
+                (int)glyphs[1].XOffset,
+                "an XOffset already present must be added to, not replaced");
+
+            Assert.AreEqual(
+                NotoMathYOffset_A + seededY,
+                (int)glyphs[1].YOffset,
+                "a YOffset already present must be added to, not replaced");
+        }
+
+        [TestMethod]
+        public void MarkOffset_UsesKernedAdvance_NotRawAdvance()
+        {
+            // Mark positioning runs after kerning, so the base glyph's XAdvance may already have
+            // been reduced. The pen is where XAdvance says it is, so that is the value the offset
+            // must be taken from - not the raw hmtx advance.
+            var font = TestFolderEngine.LoadFont(NotoSansMathFamily, FontSubFamily.Regular);
+            Assert.IsNotNull(font);
+
+            var glyphs = BuildGlyphPair(font!, 'A', 0, 0);
+
+            // Simulate a kern pair having tightened the base advance by 30 font units.
+            const short kerning = -30;
+            glyphs[0].XAdvance = (short)(glyphs[0].XAdvance + kerning);
+
+            new MarkToBaseProvider(font!).ApplyMarkPositioning(glyphs, "latn", null);
+
+            Assert.AreEqual(
+                NotoMathPenRelativeX_A - kerning,
+                (int)glyphs[1].XOffset,
+                "the offset must follow the kerned advance, since that is where the pen ends up");
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// Shapes a base character followed by a combining acute and returns the two glyphs.
+        /// </summary>
+        private static List<ShapedGlyph> ShapeBaseAndMark(string family, char baseChar)
+        {
+            var font = TestFolderEngine.LoadFont(family, FontSubFamily.Regular);
+            Assert.IsNotNull(font, $"{family} must be present in the test font folder");
+
+            var shaped = new TextShaper(TestFolderEngine, font!).Shape($"{baseChar}{CombiningAcute}");
+
+            Assert.AreEqual(
+                2,
+                shaped.Glyphs.Length,
+                "the sequence must stay decomposed - a ccmp/liga substitution would defeat the test");
+
+            return new List<ShapedGlyph>(shaped.Glyphs);
+        }
+
+        /// <summary>
+        /// Builds a base glyph plus combining acute directly, so the test controls XAdvance and any
+        /// offset already present. Advances come from hmtx, matching what TextShaper would set.
+        /// </summary>
+        private static List<ShapedGlyph> BuildGlyphPair(OpenTypeFont font, char baseChar, short seededX, short seededY)
+        {
+            ushort baseGlyphId = font.CmapTable.GetGlyphId(baseChar);
+            ushort markGlyphId = font.CmapTable.GetGlyphId(CombiningAcute);
+
+            Assert.AreNotEqual(0, (int)baseGlyphId, $"'{baseChar}' must be in the font");
+            Assert.AreNotEqual(0, (int)markGlyphId, "the combining acute must be in the font");
+
+            short baseAdvance = (short)font.HmtxTable.GetAdvanceWidth(baseGlyphId);
+            short markAdvance = (short)font.HmtxTable.GetAdvanceWidth(markGlyphId);
+
+            return new List<ShapedGlyph>
+            {
+                new ShapedGlyph
+                {
+                    GlyphId = baseGlyphId,
+                    XAdvance = baseAdvance,
+                    BaseAdvance = baseAdvance
+                },
+                new ShapedGlyph
+                {
+                    GlyphId = markGlyphId,
+                    XAdvance = markAdvance,
+                    BaseAdvance = markAdvance,
+                    XOffset = seededX,
+                    YOffset = seededY
+                }
+            };
+        }
+
+        #endregion
+    }
+}

--- a/src/EPPlus.Fonts.OpenType.Tests/TextShaping/ScriptAwareFeatureLookupTests.cs
+++ b/src/EPPlus.Fonts.OpenType.Tests/TextShaping/ScriptAwareFeatureLookupTests.cs
@@ -1,0 +1,182 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  09/07/2026         EPPlus Software AB           Script-aware feature lookup
+ *************************************************************************************************/
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Coverage;
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Features;
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Lookups;
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Scripts;
+using EPPlus.Fonts.OpenType.Tables.Gpos;
+using EPPlus.Fonts.OpenType.Tables.Gpos.Data.Lookups;
+using EPPlus.Fonts.OpenType.Tables.Gpos.Data.Lookups.LookupType1;
+using EPPlus.Fonts.OpenType.TextShaping.Positioning;
+using OfficeOpenXml.Interfaces.Fonts;
+using System.Collections.Generic;
+
+namespace EPPlus.Fonts.OpenType.Tests.TextShaping
+{
+    /// <summary>
+    /// SingleAdjustmentProvider.BuildFeatureMap maps a feature TAG (e.g. "kern") straight to
+    /// a list of subtables, with no notion of script. When several FeatureRecords share the same
+    /// tag but are reachable through different scripts in ScriptList, the map keeps only the last
+    /// one it iterates - so a lookup that should only ever fire for one script (here 'arab') can
+    /// silently answer for another (here 'latn').
+    ///
+    /// This is the exact shape of a real defect found in Calibri Bold, where a SinglePos
+    /// tagged "kern" and reachable only via 'arab' gave 'period' a YPlacement of 168 in Latin
+    /// text. Reproducing it against the real Calibri Bold font is not reliable: subsetting
+    /// collapses FeatureList down to only what was referenced, so the full, unsubsetted font has
+    /// a different FeatureList shape and the same tag ends up resolving to different data. This
+    /// test instead builds the minimal GposTable structure directly, so the defect is demonstrated
+    /// against the mapping logic itself rather than against a specific font file.
+    /// </summary>
+    [TestClass]
+    public class ScriptAwareFeatureLookupTests : FontTestBase
+    {
+        public override TestContext? TestContext { get; set; }
+
+        private const ushort PeriodGlyphId = 5;
+
+        [TestMethod]
+        public void SingleAdjustment_ForLatinScript_DoesNotPickUpArabicOnlyLookup()
+        {
+            // BIZUDGothic has no GPOS table at all, so OpenTypeFont's internal GposTableLoader is
+            // null and the GposTable getter falls through to the local table cache below. Any
+            // font that already HAS a GPOS table would ignore the injected table: the getter
+            // checks its loader first and only falls back to the cache when there is none.
+            //
+            // ignoreCache: true is required. The normal cached path marks the font read-only
+            // (FontStore.LoadFont) so it can be shared safely across tests; AddOrReplaceTable
+            // throws on a read-only instance.
+            var font = TestFolderEngine.LoadFont("BIZUDGothic", FontSubFamily.Regular, ignoreCache: true);
+            Assert.IsNotNull(font, "BIZUDGothic must be present in the test font folder");
+
+            font.AddOrReplaceTable(BuildSyntheticGposTable());
+
+            var provider = new SingleAdjustmentProvider(font);
+
+            // "latn" is what ShapingOptions.Default/.Fast/.Full all pass. Previously,
+            // TryGetAdjustment had no script parameter at all and always searched every
+            // FeatureRecord tagged "kern"; now it must restrict to the script given here.
+            bool found = provider.TryGetAdjustment(
+                PeriodGlyphId,
+                new List<string> { "kern" },
+                script: "latn",
+                language: null,
+                out var value);
+
+            if (found)
+            {
+                Assert.AreEqual(
+                    0,
+                    (int)(value?.YPlacement ?? 0),
+                    "'period' must not receive YPlacement from the lookup that is only reachable "
+                    + "through the 'arab' script's LangSys - SingleAdjustmentProvider has no "
+                    + "script filter yet, so the tag-only map picks it up regardless of script.");
+            }
+        }
+
+        /// <summary>
+        /// Builds a GposTable with two "kern" FeatureRecords sharing the tag but reachable
+        /// through different scripts:
+        ///   - lookup 0 (SinglePos, YPlacement 168 on PeriodGlyphId) reachable only via 'arab'
+        ///   - lookup 1 (SinglePos, no adjustment relevant to PeriodGlyphId) reachable via 'latn'
+        /// FeatureRecords are ordered so the 'arab' record comes LAST, which is what makes it win
+        /// the tag-keyed dictionary in BuildFeatureMap regardless of which script is active.
+        /// </summary>
+        private static GposTable BuildSyntheticGposTable()
+        {
+            var arabSubtable = new SinglePosSubTableFormat1
+            {
+                SubtableFormat = 1,
+                ValueFormat = 0x0002, // YPlacement only
+                Coverage = new CoverageTableFormat1 { GlyphArray = new ushort[] { PeriodGlyphId } },
+                Value = new ValueRecord { YPlacement = 168 }
+            };
+
+            var latinSubtable = new SinglePosSubTableFormat1
+            {
+                SubtableFormat = 1,
+                ValueFormat = 0x0004, // XAdvance only - a plausible, unrelated latn kern adjustment
+                Coverage = new CoverageTableFormat1 { GlyphArray = new ushort[] { 42 } }, // not 'period'
+                Value = new ValueRecord { XAdvance = -30 }
+            };
+
+            var lookupList = new LookupListTable
+            {
+                Lookups = new List<LookupTable>
+                {
+                    new LookupTable { LookupType = 1, SubTables = new List<Tables.FontTableElement> { arabSubtable } },
+                    new LookupTable { LookupType = 1, SubTables = new List<Tables.FontTableElement> { latinSubtable } }
+                }
+            };
+
+            var featureList = new FeatureListTable
+            {
+                FeatureRecords = new List<FeatureRecord>
+                {
+                    // Index 0: 'latn' record -> lookup 1 (does not cover 'period').
+                    new FeatureRecord
+                    {
+                        FeatureTag = new Tag("kern"),
+                        FeatureTable = new FeatureTable { LookupListIndices = new ushort[] { 1 } }
+                    },
+                    // Index 1: 'arab' record -> lookup 0 (covers 'period', YPlacement 168).
+                    // Placed last so it is the one that wins the OLD, tag-only dictionary,
+                    // regardless of which script is actually active - that overwrite is the bug.
+                    new FeatureRecord
+                    {
+                        FeatureTag = new Tag("kern"),
+                        FeatureTable = new FeatureTable { LookupListIndices = new ushort[] { 0 } }
+                    }
+                }
+            };
+
+            var scriptList = new ScriptListTable
+            {
+                ScriptRecords = new List<ScriptRecord>
+                {
+                    new ScriptRecord
+                    {
+                        ScriptTag = new Tag("latn"),
+                        ScriptTable = new ScriptTable
+                        {
+                            DefaultLangSys = new LangSysTable
+                            {
+                                RequiredFeatureIndex = 0xFFFF,
+                                FeatureIndices = new ushort[] { 0 } // only the latn record
+                            }
+                        }
+                    },
+                    new ScriptRecord
+                    {
+                        ScriptTag = new Tag("arab"),
+                        ScriptTable = new ScriptTable
+                        {
+                            DefaultLangSys = new LangSysTable
+                            {
+                                RequiredFeatureIndex = 0xFFFF,
+                                FeatureIndices = new ushort[] { 1 } // only the arab record
+                            }
+                        }
+                    }
+                }
+            };
+
+            return new GposTable
+            {
+                ScriptList = scriptList,
+                FeatureList = featureList,
+                LookupList = lookupList
+            };
+        }
+    }
+}

--- a/src/EPPlus.Fonts.OpenType.Tests/TextShaping/ScriptAwareGsubTests.cs
+++ b/src/EPPlus.Fonts.OpenType.Tests/TextShaping/ScriptAwareGsubTests.cs
@@ -1,0 +1,308 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  09/07/2026         EPPlus Software AB           Script-aware feature lookup
+ *************************************************************************************************/
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Coverage;
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Features;
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Lookups;
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Scripts;
+using EPPlus.Fonts.OpenType.Tables.Gsub;
+using EPPlus.Fonts.OpenType.Tables.Gsub.Data.Lookups;
+using EPPlus.Fonts.OpenType.TextShaping.Contextual;
+using EPPlus.Fonts.OpenType.TextShaping.Ligatures;
+using EPPlus.Fonts.OpenType.TextShaping.Substitutions;
+using OfficeOpenXml.Interfaces.Fonts;
+using System.Collections.Generic;
+
+namespace EPPlus.Fonts.OpenType.Tests.TextShaping
+{
+    /// <summary>
+    /// Same synthetic-GsubTable technique as ScriptAwareFeatureLookupTests and
+    /// ScriptAwareKerningAndMarkTests, applied to the three remaining GSUB processors:
+    /// LigatureProcessor, ChainingContextualProcessor and SingleSubstitutionProcessor.
+    ///
+    /// Each test builds two FeatureRecords sharing a tag ("liga" / "smcp") but reachable through
+    /// different scripts, with the 'arab'-only record placed last so it would win any tag-only
+    /// (script-unaware) map regardless of which script is actually active.
+    /// </summary>
+    [TestClass]
+    public class ScriptAwareGsubTests : FontTestBase
+    {
+        public override TestContext? TestContext { get; set; }
+
+        private const ushort GlyphA = 5;
+        private const ushort GlyphB = 6;
+        private const ushort LigatureGlyph = 7;
+        private const ushort SubstituteGlyph = 8;
+
+        private static OpenTypeFont LoadHostFont()
+        {
+            var font = TestFolderEngine.LoadFont("BIZUDGothic", FontSubFamily.Regular, ignoreCache: true);
+            Assert.IsNotNull(font, "BIZUDGothic must be present in the test font folder");
+            return font;
+        }
+
+        [TestMethod]
+        public void Ligatures_ForLatinScript_DoNotPickUpArabicOnlyLigature()
+        {
+            var font = LoadHostFont();
+            font.AddOrReplaceTable(BuildLigatureGsubTable());
+
+            var processor = new LigatureProcessor(font);
+
+            var glyphs = new List<ShapedGlyph>
+            {
+                new ShapedGlyph { GlyphId = GlyphA },
+                new ShapedGlyph { GlyphId = GlyphB }
+            };
+
+            processor.ApplyLigaturesInPlace(glyphs, "latn", null);
+
+            Assert.AreEqual(
+                2,
+                glyphs.Count,
+                "A+B must not be merged into the ligature that is only reachable through the "
+                + "'arab' script's LangSys");
+        }
+
+        [TestMethod]
+        public void ChainingContextual_ForLatinScript_DoesNotPickUpArabicOnlyRule()
+        {
+            var font = LoadHostFont();
+            font.AddOrReplaceTable(BuildChainingContextualGsubTable());
+
+            var processor = new ChainingContextualProcessor(
+                font,
+                new SingleSubstitutionProcessor(font),
+                new LigatureProcessor(font));
+
+            var glyphs = new List<ShapedGlyph>
+            {
+                new ShapedGlyph { GlyphId = GlyphA }
+            };
+
+            var result = processor.ApplyContextualSubstitutions(glyphs, "liga", "latn", null);
+
+            Assert.AreEqual(
+                GlyphA,
+                result[0].GlyphId,
+                "the glyph must not be substituted by the contextual rule that is only reachable "
+                + "through the 'arab' script's LangSys");
+        }
+
+        [TestMethod]
+        public void SingleSubstitution_ForLatinScript_DoesNotPickUpArabicOnlySubstitution()
+        {
+            var font = LoadHostFont();
+            font.AddOrReplaceTable(BuildSingleSubstGsubTable());
+
+            var processor = new SingleSubstitutionProcessor(font);
+
+            var glyphs = new List<ShapedGlyph>
+            {
+                new ShapedGlyph { GlyphId = GlyphA, BaseAdvance = 500, XAdvance = 500 }
+            };
+
+            var result = processor.ApplySubstitutions(
+                glyphs, new List<string> { "smcp" }, "latn", null);
+
+            Assert.AreEqual(
+                GlyphA,
+                result[0].GlyphId,
+                "the glyph must not be substituted by the 'smcp' record that is only reachable "
+                + "through the 'arab' script's LangSys");
+        }
+
+        /// <summary>
+        /// Two "liga" FeatureRecords: index 0 -> 'latn', a lookup with no subtables (matches
+        /// nothing). Index 1 -> 'arab', a LigatureSubstSubTable merging GlyphA+GlyphB into
+        /// LigatureGlyph. Index 1 is last, so it wins a tag-only map regardless of active script.
+        /// </summary>
+        private static GsubTable BuildLigatureGsubTable()
+        {
+            var arabLigature = new LigatureSubstSubTable
+            {
+                Coverage = new CoverageTableFormat1 { GlyphArray = new ushort[] { GlyphA } },
+                LigatureSets = new Dictionary<ushort, LigatureSetTable>
+                {
+                    [GlyphA] = new LigatureSetTable
+                    {
+                        Ligatures = new List<LigatureTable>
+                        {
+                            new LigatureTable { LigatureGlyph = LigatureGlyph, Components = new ushort[] { GlyphB } }
+                        }
+                    }
+                }
+            };
+
+            var latinLookup = new LookupTable { LookupType = 4, SubTables = new List<Tables.FontTableElement>() };
+            var arabLookup = new LookupTable
+            {
+                LookupType = 4,
+                SubTables = new List<Tables.FontTableElement> { arabLigature }
+            };
+
+            return new GsubTable
+            {
+                ScriptList = BuildTwoScriptList(),
+                FeatureList = BuildTwoFeatureList("liga"),
+                LookupList = new LookupListTable { Lookups = new List<LookupTable> { latinLookup, arabLookup } }
+            };
+        }
+
+        /// <summary>
+        /// Two "liga" FeatureRecords (ChainingContextualProcessor is hardcoded to look for
+        /// "liga", per LigatureProcessor's own hardcoding pre-WP3/WP4). Index 0 -> 'latn', a Type
+        /// 6 lookup with no subtables. Index 1 -> 'arab', a Type 6 lookup whose
+        /// ChainingContextualSubstFormat3 matches GlyphA and substitutes it via a nested Type 1
+        /// lookup. Index 1 is last, so it wins a tag-only map regardless of active script.
+        /// </summary>
+        private static GsubTable BuildChainingContextualGsubTable()
+        {
+            var singleSubst = new SingleSubstSubTableFormat2
+            {
+                Coverage = new CoverageTableFormat1 { GlyphArray = new ushort[] { GlyphA } },
+                SubstituteGlyphIDs = new ushort[] { SubstituteGlyph }
+            };
+
+            var contextualRule = new ChainingContextualSubstFormat3
+            {
+                InputCoverages = new List<CoverageTable>
+                {
+                    new CoverageTableFormat1 { GlyphArray = new ushort[] { GlyphA } }
+                },
+                SubstLookupRecords = new List<SubstLookupRecord>
+                {
+                    new SubstLookupRecord { SequenceIndex = 0, LookupListIndex = 2 } // targets the Type 1 lookup at index 2
+                }
+            };
+
+            var latinLookup = new LookupTable { LookupType = 6, SubTables = new List<Tables.FontTableElement>() };
+            var arabLookup = new LookupTable
+            {
+                LookupType = 6,
+                SubTables = new List<Tables.FontTableElement> { contextualRule }
+            };
+            var singleSubstLookup = new LookupTable
+            {
+                LookupType = 1,
+                SubTables = new List<Tables.FontTableElement> { singleSubst }
+            };
+
+            return new GsubTable
+            {
+                ScriptList = BuildTwoScriptList(),
+                FeatureList = BuildTwoFeatureList("liga"),
+                LookupList = new LookupListTable
+                {
+                    // Index 0 = latinLookup (feature index 0 -> LookupListIndices [0]).
+                    // Index 1 = arabLookup (feature index 1 -> LookupListIndices [1], matches
+                    // BuildTwoFeatureList's fixed {0}/{1} pattern).
+                    // Index 2 = singleSubstLookup, referenced only by arabLookup's own
+                    // SubstLookupRecord.LookupListIndex, not by any FeatureRecord.
+                    Lookups = new List<LookupTable> { latinLookup, arabLookup, singleSubstLookup }
+                }
+            };
+        }
+
+        /// <summary>
+        /// Two "smcp" FeatureRecords: index 0 -> 'latn', a lookup with no subtables. Index 1 ->
+        /// 'arab', a SingleSubstSubTable substituting GlyphA -> SubstituteGlyph. Index 1 is last,
+        /// so it wins a tag-only map regardless of active script.
+        /// </summary>
+        private static GsubTable BuildSingleSubstGsubTable()
+        {
+            var arabSubst = new SingleSubstSubTableFormat2
+            {
+                Coverage = new CoverageTableFormat1 { GlyphArray = new ushort[] { GlyphA } },
+                SubstituteGlyphIDs = new ushort[] { SubstituteGlyph }
+            };
+
+            var latinLookup = new LookupTable { LookupType = 1, SubTables = new List<Tables.FontTableElement>() };
+            var arabLookup = new LookupTable
+            {
+                LookupType = 1,
+                SubTables = new List<Tables.FontTableElement> { arabSubst }
+            };
+
+            return new GsubTable
+            {
+                ScriptList = BuildTwoScriptList(),
+                FeatureList = BuildTwoFeatureList("smcp"),
+                LookupList = new LookupListTable { Lookups = new List<LookupTable> { latinLookup, arabLookup } }
+            };
+        }
+
+        /// <summary>
+        /// Two FeatureRecords sharing the given tag: index 0 references lookup 0, index 1
+        /// references lookup 1 (or, for the chaining-contextual table, lookup 2 - see
+        /// BuildChainingContextualGsubTable's own lookup list).
+        /// </summary>
+        private static FeatureListTable BuildTwoFeatureList(string tag)
+        {
+            return new FeatureListTable
+            {
+                FeatureRecords = new List<FeatureRecord>
+                {
+                    new FeatureRecord
+                    {
+                        FeatureTag = new Tag(tag),
+                        FeatureTable = new FeatureTable { LookupListIndices = new ushort[] { 0 } }
+                    },
+                    new FeatureRecord
+                    {
+                        FeatureTag = new Tag(tag),
+                        FeatureTable = new FeatureTable { LookupListIndices = new ushort[] { 1 } }
+                    }
+                }
+            };
+        }
+
+        /// <summary>
+        /// 'latn' -> feature index 0 only. 'arab' -> feature index 1 only. Shared by all three
+        /// synthetic tables in this file; each table's own LookupList is ordered so that feature
+        /// index 1 always resolves to LookupListIndices [1], per BuildTwoFeatureList.
+        /// </summary>
+        private static ScriptListTable BuildTwoScriptList()
+        {
+            return new ScriptListTable
+            {
+                ScriptRecords = new List<ScriptRecord>
+                {
+                    new ScriptRecord
+                    {
+                        ScriptTag = new Tag("latn"),
+                        ScriptTable = new ScriptTable
+                        {
+                            DefaultLangSys = new LangSysTable
+                            {
+                                RequiredFeatureIndex = 0xFFFF,
+                                FeatureIndices = new ushort[] { 0 }
+                            }
+                        }
+                    },
+                    new ScriptRecord
+                    {
+                        ScriptTag = new Tag("arab"),
+                        ScriptTable = new ScriptTable
+                        {
+                            DefaultLangSys = new LangSysTable
+                            {
+                                RequiredFeatureIndex = 0xFFFF,
+                                FeatureIndices = new ushort[] { 1 }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/src/EPPlus.Fonts.OpenType.Tests/TextShaping/ScriptAwareKerningAndMarkTests.cs
+++ b/src/EPPlus.Fonts.OpenType.Tests/TextShaping/ScriptAwareKerningAndMarkTests.cs
@@ -1,0 +1,296 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  09/07/2026         EPPlus Software AB           Script-aware feature lookup
+ *************************************************************************************************/
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Coverage;
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Features;
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Lookups;
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Scripts;
+using EPPlus.Fonts.OpenType.Tables.Gpos;
+using EPPlus.Fonts.OpenType.Tables.Gpos.Data.Lookups;
+using EPPlus.Fonts.OpenType.Tables.Gpos.Data.Lookups.LookupType2;
+using EPPlus.Fonts.OpenType.Tables.Gpos.Data.Lookups.LookupType4;
+using EPPlus.Fonts.OpenType.TextShaping.Kerning;
+using EPPlus.Fonts.OpenType.TextShaping.Positioning;
+using OfficeOpenXml.Interfaces.Fonts;
+using System.Collections.Generic;
+
+namespace EPPlus.Fonts.OpenType.Tests.TextShaping
+{
+    /// <summary>
+    /// Same synthetic-GposTable technique as ScriptAwareFeatureLookupTests, applied to
+    /// GposKerningProvider and MarkToBaseProvider: two FeatureRecords share a tag ("kern" /
+    /// "mark") but are reachable through different scripts, and the 'arab'-only record is placed
+    /// last so it wins any tag-only mapping regardless of which script is actually active.
+    /// </summary>
+    [TestClass]
+    public class ScriptAwareKerningAndMarkTests : FontTestBase
+    {
+        public override TestContext? TestContext { get; set; }
+
+        private const ushort GlyphA = 5;
+        private const ushort GlyphB = 6;
+        private const ushort MarkGlyph = 7;
+
+        [TestMethod]
+        public void Kerning_ForLatinScript_DoesNotPickUpArabicOnlyPair()
+        {
+            var font = TestFolderEngine.LoadFont("BIZUDGothic", FontSubFamily.Regular, ignoreCache: true);
+            Assert.IsNotNull(font, "BIZUDGothic must be present in the test font folder");
+
+            font.AddOrReplaceTable(BuildKerningGposTable());
+
+            var provider = new GposKerningProvider(font.GposTable);
+
+            short kerning = provider.GetKerning(GlyphA, GlyphB, "latn", null);
+
+            Assert.AreEqual(
+                0,
+                (int)kerning,
+                "A+B must not receive kerning from the pair that is only reachable through the "
+                + "'arab' script's LangSys");
+        }
+
+        [TestMethod]
+        public void MarkPositioning_ForLatinScript_DoesNotPickUpArabicOnlyOffset()
+        {
+            var font = TestFolderEngine.LoadFont("BIZUDGothic", FontSubFamily.Regular, ignoreCache: true);
+            Assert.IsNotNull(font, "BIZUDGothic must be present in the test font folder");
+
+            font.AddOrReplaceTable(BuildMarkGposTable());
+
+            var provider = new MarkToBaseProvider(font);
+
+            var glyphs = new List<ShapedGlyph>
+            {
+                new ShapedGlyph { GlyphId = GlyphA, XAdvance = 500, BaseAdvance = 500 },
+                new ShapedGlyph { GlyphId = MarkGlyph, XAdvance = 0, BaseAdvance = 0 }
+            };
+
+            provider.ApplyMarkPositioning(glyphs, "latn", null);
+
+            Assert.AreEqual(
+                0,
+                (int)glyphs[1].YOffset,
+                "the mark must not receive an offset from the MarkToBase subtable that is only "
+                + "reachable through the 'arab' script's LangSys");
+        }
+
+        /// <summary>
+        /// Two "kern" FeatureRecords: index 0 -> 'latn', covers a pair NOT involving A/B.
+        /// Index 1 -> 'arab', covers A+B with a large adjustment. Index 1 is last, so it is the
+        /// one that would win a tag-only (script-unaware) map regardless of active script.
+        /// </summary>
+        private static GposTable BuildKerningGposTable()
+        {
+            var arabPair = new PairPosSubTableFormat1
+            {
+                Coverage = new CoverageTableFormat1 { GlyphArray = new ushort[] { GlyphA } },
+                PairSets = new List<PairSet>
+                {
+                    new PairSet
+                    {
+                        PairValueRecords = new List<PairValueRecord>
+                        {
+                            new PairValueRecord
+                            {
+                                SecondGlyph = GlyphB,
+                                Value1 = new ValueRecord { XAdvance = -200 }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var latinPair = new PairPosSubTableFormat1
+            {
+                Coverage = new CoverageTableFormat1 { GlyphArray = new ushort[] { 42 } },
+                PairSets = new List<PairSet>
+                {
+                    new PairSet
+                    {
+                        PairValueRecords = new List<PairValueRecord>
+                        {
+                            new PairValueRecord
+                            {
+                                SecondGlyph = 43,
+                                Value1 = new ValueRecord { XAdvance = -10 }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var lookupList = new LookupListTable
+            {
+                Lookups = new List<LookupTable>
+                {
+                    new LookupTable { LookupType = 2, SubTables = new List<Tables.FontTableElement> { latinPair } },
+                    new LookupTable { LookupType = 2, SubTables = new List<Tables.FontTableElement> { arabPair } }
+                }
+            };
+
+            var featureList = new FeatureListTable
+            {
+                FeatureRecords = new List<FeatureRecord>
+                {
+                    new FeatureRecord
+                    {
+                        FeatureTag = new Tag("kern"),
+                        FeatureTable = new FeatureTable { LookupListIndices = new ushort[] { 0 } }
+                    },
+                    new FeatureRecord
+                    {
+                        FeatureTag = new Tag("kern"),
+                        FeatureTable = new FeatureTable { LookupListIndices = new ushort[] { 1 } }
+                    }
+                }
+            };
+
+            return new GposTable
+            {
+                ScriptList = BuildTwoScriptList(),
+                FeatureList = featureList,
+                LookupList = lookupList
+            };
+        }
+
+        /// <summary>
+        /// Two "mark" FeatureRecords: index 0 -> 'latn', covers a base/mark pair that never
+        /// appears in the test glyph sequence. Index 1 -> 'arab', covers GlyphA/MarkGlyph with a
+        /// large YOffset. Index 1 is last, so it is the one that would win a tag-only map.
+        /// </summary>
+        private static GposTable BuildMarkGposTable()
+        {
+            var arabMark = new MarkToBaseSubTableFormat1
+            {
+                MarkClassCount = 1,
+                MarkCoverage = new CoverageTableFormat1 { GlyphArray = new ushort[] { MarkGlyph } },
+                BaseCoverage = new CoverageTableFormat1 { GlyphArray = new ushort[] { GlyphA } },
+                MarkArray = new MarkArray
+                {
+                    MarkCount = 1,
+                    Records = new[]
+                    {
+                        new MarkRecord { MarkClass = 0, MarkAnchor = new AnchorTable { XCoordinate = 0, YCoordinate = 0 } }
+                    }
+                },
+                BaseArray = new BaseArray
+                {
+                    BaseCount = 1,
+                    Records = new[]
+                    {
+                        new BaseRecord
+                        {
+                            BaseAnchors = new[] { new AnchorTable { XCoordinate = 0, YCoordinate = 500 } }
+                        }
+                    }
+                }
+            };
+
+            var latinMark = new MarkToBaseSubTableFormat1
+            {
+                MarkClassCount = 1,
+                MarkCoverage = new CoverageTableFormat1 { GlyphArray = new ushort[] { 44 } },
+                BaseCoverage = new CoverageTableFormat1 { GlyphArray = new ushort[] { 45 } },
+                MarkArray = new MarkArray
+                {
+                    MarkCount = 1,
+                    Records = new[]
+                    {
+                        new MarkRecord { MarkClass = 0, MarkAnchor = new AnchorTable { XCoordinate = 0, YCoordinate = 0 } }
+                    }
+                },
+                BaseArray = new BaseArray
+                {
+                    BaseCount = 1,
+                    Records = new[]
+                    {
+                        new BaseRecord
+                        {
+                            BaseAnchors = new[] { new AnchorTable { XCoordinate = 0, YCoordinate = 10 } }
+                        }
+                    }
+                }
+            };
+
+            var lookupList = new LookupListTable
+            {
+                Lookups = new List<LookupTable>
+                {
+                    new LookupTable { LookupType = 4, SubTables = new List<Tables.FontTableElement> { latinMark } },
+                    new LookupTable { LookupType = 4, SubTables = new List<Tables.FontTableElement> { arabMark } }
+                }
+            };
+
+            var featureList = new FeatureListTable
+            {
+                FeatureRecords = new List<FeatureRecord>
+                {
+                    new FeatureRecord
+                    {
+                        FeatureTag = new Tag("mark"),
+                        FeatureTable = new FeatureTable { LookupListIndices = new ushort[] { 0 } }
+                    },
+                    new FeatureRecord
+                    {
+                        FeatureTag = new Tag("mark"),
+                        FeatureTable = new FeatureTable { LookupListIndices = new ushort[] { 1 } }
+                    }
+                }
+            };
+
+            return new GposTable
+            {
+                ScriptList = BuildTwoScriptList(),
+                FeatureList = featureList,
+                LookupList = lookupList
+            };
+        }
+
+        /// <summary>
+        /// 'latn' -> feature index 0 only. 'arab' -> feature index 1 only.
+        /// </summary>
+        private static ScriptListTable BuildTwoScriptList()
+        {
+            return new ScriptListTable
+            {
+                ScriptRecords = new List<ScriptRecord>
+                {
+                    new ScriptRecord
+                    {
+                        ScriptTag = new Tag("latn"),
+                        ScriptTable = new ScriptTable
+                        {
+                            DefaultLangSys = new LangSysTable
+                            {
+                                RequiredFeatureIndex = 0xFFFF,
+                                FeatureIndices = new ushort[] { 0 }
+                            }
+                        }
+                    },
+                    new ScriptRecord
+                    {
+                        ScriptTag = new Tag("arab"),
+                        ScriptTable = new ScriptTable
+                        {
+                            DefaultLangSys = new LangSysTable
+                            {
+                                RequiredFeatureIndex = 0xFFFF,
+                                FeatureIndices = new ushort[] { 1 }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/src/EPPlus.Fonts.OpenType/Tables/Common/Layout/Scripts/ScriptFeatureResolver.cs
+++ b/src/EPPlus.Fonts.OpenType/Tables/Common/Layout/Scripts/ScriptFeatureResolver.cs
@@ -1,0 +1,147 @@
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  09/07/2026         EPPlus Software AB           Script-aware feature resolution
+ *************************************************************************************************/
+using System;
+using System.Collections.Generic;
+
+namespace EPPlus.Fonts.OpenType.Tables.Common.Layout.Scripts
+{
+    /// <summary>
+    /// Resolves which entries in a FeatureList a given script/language may use, per the
+    /// ScriptList/LangSys structure in the OpenType spec.
+    ///
+    /// Every GSUB/GPOS processor used to iterate FeatureList.FeatureRecords directly and
+    /// applied every record whose tag matched, regardless of script. That let a lookup reachable
+    /// only through one script's LangSys (e.g. an Arabic-only "kern" adjustment) apply to text in
+    /// a completely different script. Real-world example: a SinglePos reachable only via 'arab'
+    /// gave the Latin 'period' glyph an unwanted YPlacement in one font's GPOS table.
+    /// </summary>
+    internal static class ScriptFeatureResolver
+    {
+        private const string DefaultScriptTag = "DFLT";
+
+        /// <summary>
+        /// Returns the set of FeatureList indices reachable from the given script and language.
+        ///
+        /// Returns null - meaning "no filter, keep every FeatureRecord" - when scriptList is null
+        /// or the requested script is not null but neither the exact script nor 'DFLT' is present.
+        /// Returning null instead of an empty set is deliberate: it preserves the previous behavior
+        /// (apply every matching-tag record) for callers that have no way to resolve a script,
+        /// rather than silently discarding all features. Every current caller passes "latn" from
+        /// ShapingOptions.Default, so this fallback should not be reachable in practice today.
+        /// </summary>
+        /// <param name="scriptList">The font's ScriptList table, or null if unavailable.</param>
+        /// <param name="script">
+        /// OpenType script tag (e.g. "latn"). Case-insensitive; padded/truncated to 4 characters
+        /// as OpenType tags require. Null means "use the font's default script".
+        /// </param>
+        /// <param name="language">
+        /// OpenType language-system tag (e.g. "SWE "), or null for the script's default LangSys.
+        /// </param>
+        public static HashSet<int> GetActiveFeatureIndices(ScriptListTable scriptList, string script, string language)
+        {
+            if (scriptList == null)
+            {
+                return null;
+            }
+
+            var scriptTable = FindScriptTable(scriptList, script) ?? FindScriptTable(scriptList, DefaultScriptTag);
+            if (scriptTable == null)
+            {
+                // Requested script (and DFLT) both absent from this font. No safe default exists,
+                // so fall back to unfiltered rather than silently dropping every feature.
+                return null;
+            }
+
+            var langSys = FindLangSys(scriptTable, language) ?? scriptTable.DefaultLangSys;
+            if (langSys == null)
+            {
+                return new HashSet<int>();
+            }
+
+            var indices = new HashSet<int>();
+            if (langSys.RequiredFeatureIndex != 0xFFFF)
+            {
+                indices.Add(langSys.RequiredFeatureIndex);
+            }
+
+            if (langSys.FeatureIndices != null)
+            {
+                foreach (var index in langSys.FeatureIndices)
+                {
+                    indices.Add(index);
+                }
+            }
+
+            return indices;
+        }
+
+        private static ScriptTable FindScriptTable(ScriptListTable scriptList, string scriptTag)
+        {
+            if (string.IsNullOrEmpty(scriptTag))
+            {
+                return null;
+            }
+
+            foreach (var record in scriptList.ScriptRecords)
+            {
+                if (TagsMatch(record.ScriptTag?.Value, scriptTag))
+                {
+                    return record.ScriptTable;
+                }
+            }
+
+            return null;
+        }
+
+        private static LangSysTable FindLangSys(ScriptTable scriptTable, string languageTag)
+        {
+            if (string.IsNullOrEmpty(languageTag) || scriptTable.LangSysRecords == null)
+            {
+                return null;
+            }
+
+            foreach (var record in scriptTable.LangSysRecords)
+            {
+                if (TagsMatch(LangSysTagToString(record.LangSysTag), languageTag))
+                {
+                    return record.LangSysTable;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// OpenType tags are compared case-insensitively here despite the spec's binary
+        /// comparison, because callers pass human-typed strings (ShapingOptions.Script/.Language)
+        /// rather than tags read verbatim from a font file.
+        /// </summary>
+        private static bool TagsMatch(string a, string b)
+        {
+            return a != null && b != null
+                && string.Equals(a.TrimEnd(), b.TrimEnd(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string LangSysTagToString(uint tag)
+        {
+            var bytes = new[]
+            {
+                (char)((tag >> 24) & 0xFF),
+                (char)((tag >> 16) & 0xFF),
+                (char)((tag >> 8) & 0xFF),
+                (char)(tag & 0xFF)
+            };
+            return new string(bytes);
+        }
+    }
+}

--- a/src/EPPlus.Fonts.OpenType/TextShaping/Contextual/ChainingContextualProcessor.cs
+++ b/src/EPPlus.Fonts.OpenType/TextShaping/Contextual/ChainingContextualProcessor.cs
@@ -11,6 +11,7 @@
  *************************************************************************************************/
 using EPPlus.Fonts.OpenType.Tables;
 using EPPlus.Fonts.OpenType.Tables.Common.Layout.Lookups;
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Scripts;
 using EPPlus.Fonts.OpenType.Tables.Gsub;
 using EPPlus.Fonts.OpenType.Tables.Gsub.Data.Lookups;
 using EPPlus.Fonts.OpenType.TextShaping.Ligatures;
@@ -37,18 +38,26 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Contextual
         }
 
         /// <summary>
-        /// Applies chaining contextual substitutions for a specific feature.
+        /// Applies chaining contextual substitutions for a specific feature, restricted to the
+        /// FeatureRecords reachable from the given script and language.
         /// </summary>
+        /// <param name="script">
+        /// OpenType script tag (e.g. "latn"). Pass null to fall back to unfiltered lookup, which
+        /// reproduces the previous behavior for callers that have no script to give.
+        /// </param>
+        /// <param name="language">OpenType language-system tag, or null for the script's default.</param>
         internal List<ShapedGlyph> ApplyContextualSubstitutions(
             List<ShapedGlyph> glyphs,
-            string featureTag)
+            string featureTag,
+            string script,
+            string language)
         {
             var gsub = _font.GsubTable;
             if (gsub == null)
                 return glyphs;
 
             // Find all Type 6 lookups for this feature
-            var contextualLookups = FindContextualLookupsForFeature(gsub, featureTag);
+            var contextualLookups = FindContextualLookupsForFeature(gsub, featureTag, script, language);
             if (contextualLookups.Count == 0)
                 return glyphs;
 
@@ -62,40 +71,54 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Contextual
         }
 
         /// <summary>
-        /// Finds all Type 6 lookups associated with a feature tag.
+        /// Finds all Type 6 lookups associated with a feature tag, restricted to the
+        /// FeatureRecords reachable from the given script and language. Two FeatureRecords can
+        /// legitimately share a tag (one per script); the ScriptList/LangSys lookup is what tells
+        /// them apart, since the tag alone does not.
         /// </summary>
-        private List<LookupTable> FindContextualLookupsForFeature(GsubTable gsub, string featureTag)
+        private List<LookupTable> FindContextualLookupsForFeature(
+            GsubTable gsub, string featureTag, string script, string language)
         {
             var lookups = new List<LookupTable>();
 
-            foreach (var featureRecord in gsub.FeatureList.FeatureRecords)
+            var activeIndices = ScriptFeatureResolver.GetActiveFeatureIndices(gsub.ScriptList, script, language);
+            var featureRecords = gsub.FeatureList.FeatureRecords;
+
+            for (int featureIndex = 0; featureIndex < featureRecords.Count; featureIndex++)
             {
-                if (featureRecord.FeatureTag.Value == featureTag)
+                var featureRecord = featureRecords[featureIndex];
+
+                if (featureRecord.FeatureTag.Value != featureTag)
+                    continue;
+
+                // null activeIndices means "no ScriptList to filter by" - keep every entry,
+                // matching the previous behavior rather than discarding features we cannot resolve.
+                if (activeIndices != null && !activeIndices.Contains(featureIndex))
+                    continue;
+
+                var feature = featureRecord.FeatureTable;
+
+                foreach (var lookupIndex in feature.LookupListIndices)
                 {
-                    var feature = featureRecord.FeatureTable;
-
-                    foreach (var lookupIndex in feature.LookupListIndices)
+                    if (lookupIndex < gsub.LookupList.Lookups.Count)
                     {
-                        if (lookupIndex < gsub.LookupList.Lookups.Count)
-                        {
-                            var lookup = gsub.LookupList.Lookups[lookupIndex];
+                        var lookup = gsub.LookupList.Lookups[lookupIndex];
 
-                            // Only Type 6 (Chaining Contextual) or Type 7 (Extension wrapping Type 6)
-                            if (lookup.LookupType == 6)
+                        // Only Type 6 (Chaining Contextual) or Type 7 (Extension wrapping Type 6)
+                        if (lookup.LookupType == 6)
+                        {
+                            lookups.Add(lookup);
+                        }
+                        else if (lookup.LookupType == 7)
+                        {
+                            // Check if extension wraps a Type 6
+                            foreach (var subtable in lookup.SubTables)
                             {
-                                lookups.Add(lookup);
-                            }
-                            else if (lookup.LookupType == 7)
-                            {
-                                // Check if extension wraps a Type 6
-                                foreach (var subtable in lookup.SubTables)
+                                if (subtable is ExtensionSubstSubTable ext &&
+                                    ext.ExtensionLookupType == 6)
                                 {
-                                    if (subtable is ExtensionSubstSubTable ext &&
-                                        ext.ExtensionLookupType == 6)
-                                    {
-                                        lookups.Add(lookup);
-                                        break;
-                                    }
+                                    lookups.Add(lookup);
+                                    break;
                                 }
                             }
                         }

--- a/src/EPPlus.Fonts.OpenType/TextShaping/Kerning/GposKerningProvider.cs
+++ b/src/EPPlus.Fonts.OpenType/TextShaping/Kerning/GposKerningProvider.cs
@@ -1,4 +1,18 @@
-﻿using EPPlus.Fonts.OpenType.Tables.Gpos;
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  09/07/2026         EPPlus Software AB           Extension-wrapped kerning support
+  09/07/2026         EPPlus Software AB           Filter by ScriptList/LangSys, not just tag
+ *************************************************************************************************/
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Scripts;
+using EPPlus.Fonts.OpenType.Tables.Gpos;
 using EPPlus.Fonts.OpenType.Tables.Gpos.Data.Lookups.LookupType2;
 using System.Collections.Generic;
 
@@ -13,26 +27,51 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Kerning
     /// </summary>
     internal class GposKerningProvider
     {
-        private readonly List<PairPosSubTable> _subtables;
+        private readonly struct IndexedSubtable
+        {
+            public readonly int FeatureIndex;
+            public readonly PairPosSubTable Subtable;
+
+            public IndexedSubtable(int featureIndex, PairPosSubTable subtable)
+            {
+                FeatureIndex = featureIndex;
+                Subtable = subtable;
+            }
+        }
+
+        private readonly GposTable _gpos;
+        private readonly List<IndexedSubtable> _subtables;
+        private readonly Dictionary<string, HashSet<int>> _activeIndexCache = new Dictionary<string, HashSet<int>>();
 
         public GposKerningProvider(GposTable gposTable)
         {
+            _gpos = gposTable;
             _subtables = FindAllKerningSubtables(gposTable);
         }
 
         /// <summary>
-        /// Gets kerning adjustment for a glyph pair.
-        /// Delegates to PairPosSubTable.TryGetPairAdjustment which does:
-        ///   Format 1: coverage lookup + binary search in PairSet — O(log n)
-        ///   Format 2: coverage lookup + class lookup + matrix index — O(1)
-        /// Combined with KerningCache in KerningProvider, each unique pair
-        /// is looked up at most once.
+        /// Gets kerning adjustment for a glyph pair, restricted to the "kern" feature records
+        /// reachable from the given script and language.
         /// </summary>
-        public short GetKerning(ushort leftGlyph, ushort rightGlyph)
+        /// <param name="script">
+        /// OpenType script tag (e.g. "latn"). Pass null to fall back to unfiltered lookup, which
+        /// reproduces the previous behavior for callers that have no script to give.
+        /// </param>
+        /// <param name="language">OpenType language-system tag, or null for the script's default.</param>
+        public short GetKerning(ushort leftGlyph, ushort rightGlyph, string script, string language)
         {
+            HashSet<int> activeIndices = GetActiveIndices(script, language);
+
             for (int i = 0; i < _subtables.Count; i++)
             {
-                if (_subtables[i].TryGetPairAdjustment(leftGlyph, rightGlyph,
+                // null activeIndices means "no ScriptList to filter by" - keep every entry,
+                // matching the previous behavior rather than discarding kerning we cannot resolve.
+                if (activeIndices != null && !activeIndices.Contains(_subtables[i].FeatureIndex))
+                {
+                    continue;
+                }
+
+                if (_subtables[i].Subtable.TryGetPairAdjustment(leftGlyph, rightGlyph,
                     out var value1, out var value2))
                 {
                     if (value1 != null && value1.XAdvance != 0)
@@ -43,37 +82,59 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Kerning
             return 0;
         }
 
-        private List<PairPosSubTable> FindAllKerningSubtables(GposTable gpos)
+        private HashSet<int> GetActiveIndices(string script, string language)
         {
-            var subtables = new List<PairPosSubTable>();
+            string cacheKey = (script ?? string.Empty) + "|" + (language ?? string.Empty);
 
-            if (gpos == null)
+            if (!_activeIndexCache.TryGetValue(cacheKey, out var indices))
+            {
+                indices = ScriptFeatureResolver.GetActiveFeatureIndices(_gpos?.ScriptList, script, language);
+                _activeIndexCache[cacheKey] = indices;
+            }
+
+            return indices;
+        }
+
+        /// <summary>
+        /// Collects every "kern"-tagged PairPos subtable together with its original FeatureList
+        /// index, across all scripts, so GetKerning can filter by script later. Two FeatureRecords
+        /// can legitimately share the "kern" tag (one per script); both are kept.
+        /// </summary>
+        private List<IndexedSubtable> FindAllKerningSubtables(GposTable gpos)
+        {
+            var subtables = new List<IndexedSubtable>();
+
+            if (gpos?.FeatureList == null)
                 return subtables;
 
-            foreach (var featureRecord in gpos.FeatureList.FeatureRecords)
+            var featureRecords = gpos.FeatureList.FeatureRecords;
+
+            for (int featureIndex = 0; featureIndex < featureRecords.Count; featureIndex++)
             {
-                if (featureRecord.FeatureTag.Value == "kern")
+                var featureRecord = featureRecords[featureIndex];
+
+                if (featureRecord.FeatureTag.Value != "kern")
+                    continue;
+
+                var feature = featureRecord.FeatureTable;
+
+                foreach (var lookupIndex in feature.LookupListIndices)
                 {
-                    var feature = featureRecord.FeatureTable;
+                    if (lookupIndex >= gpos.LookupList.Lookups.Count)
+                        continue;
 
-                    foreach (var lookupIndex in feature.LookupListIndices)
+                    var lookup = gpos.LookupList.Lookups[lookupIndex];
+
+                    // No lookup type check here. Extension positioning (type 9) is resolved
+                    // by GposTableLoader, which stores the wrapped subtable directly in the
+                    // lookup while leaving LookupType at 9. Requiring LookupType == 2 would
+                    // therefore discard all extension wrapped kerning. The subtable type
+                    // test below is what actually identifies pair positioning data.
+                    foreach (var subtable in lookup.SubTables)
                     {
-                        if (lookupIndex >= gpos.LookupList.Lookups.Count)
-                            continue;
-
-                        var lookup = gpos.LookupList.Lookups[lookupIndex];
-
-                        // No lookup type check here. Extension positioning (type 9) is resolved
-                        // by GposTableLoader, which stores the wrapped subtable directly in the
-                        // lookup while leaving LookupType at 9. Requiring LookupType == 2 would
-                        // therefore discard all extension wrapped kerning. The subtable type
-                        // test below is what actually identifies pair positioning data.
-                        foreach (var subtable in lookup.SubTables)
+                        if (subtable is PairPosSubTable pairPos)
                         {
-                            if (subtable is PairPosSubTable pairPos)
-                            {
-                                subtables.Add(pairPos);
-                            }
+                            subtables.Add(new IndexedSubtable(featureIndex, pairPos));
                         }
                     }
                 }

--- a/src/EPPlus.Fonts.OpenType/TextShaping/Kerning/KerningCache.cs
+++ b/src/EPPlus.Fonts.OpenType/TextShaping/Kerning/KerningCache.cs
@@ -9,6 +9,7 @@
   Date               Author                       Change
  *************************************************************************************************
   01/15/2025         EPPlus Software AB           Initial implementation
+  09/07/2026         EPPlus Software AB           Fold script/language into the cache key
  *************************************************************************************************/
 using System.Collections.Generic;
 
@@ -16,31 +17,37 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Kerning
 {
     /// <summary>
     /// Caches kerning values for glyph pairs to avoid repeated lookups.
+    ///
+    /// Keyed by (leftGlyph, rightGlyph, script, language) rather than just the glyph pair: the
+    /// same pair can kern differently depending on which script's GPOS features are active, and a
+    /// single cache instance is reused across many Shape() calls that may each specify a different
+    /// script. Keying on the glyph pair alone would let a value computed for one script leak into
+    /// a lookup for another.
     /// </summary>
     internal class KerningCache
     {
-        private readonly Dictionary<ulong, short> _cache;
+        private readonly Dictionary<string, short> _cache;
 
         public KerningCache()
         {
-            _cache = new Dictionary<ulong, short>();
+            _cache = new Dictionary<string, short>();
         }
 
         /// <summary>
         /// Tries to get a cached kerning value.
         /// </summary>
-        public bool TryGet(ushort leftGlyph, ushort rightGlyph, out short value)
+        public bool TryGet(ushort leftGlyph, ushort rightGlyph, string script, string language, out short value)
         {
-            ulong key = MakeKey(leftGlyph, rightGlyph);
+            string key = MakeKey(leftGlyph, rightGlyph, script, language);
             return _cache.TryGetValue(key, out value);
         }
 
         /// <summary>
         /// Caches a kerning value.
         /// </summary>
-        public void Set(ushort leftGlyph, ushort rightGlyph, short value)
+        public void Set(ushort leftGlyph, ushort rightGlyph, string script, string language, short value)
         {
-            ulong key = MakeKey(leftGlyph, rightGlyph);
+            string key = MakeKey(leftGlyph, rightGlyph, script, language);
             _cache[key] = value;
         }
 
@@ -52,10 +59,12 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Kerning
             _cache.Clear();
         }
 
-        private static ulong MakeKey(ushort leftGlyph, ushort rightGlyph)
+        private static string MakeKey(ushort leftGlyph, ushort rightGlyph, string script, string language)
         {
-            // Combine two ushorts into one ulong for fast dictionary lookup
-            return ((ulong)leftGlyph << 16) | rightGlyph;
+            // A string key trades a little speed for simplicity over the previous packed-ulong
+            // key, which had no room left for script/language without a second dictionary layer.
+            return leftGlyph.ToString() + "_" + rightGlyph.ToString() + "_"
+                + (script ?? string.Empty) + "_" + (language ?? string.Empty);
         }
     }
 }

--- a/src/EPPlus.Fonts.OpenType/TextShaping/Kerning/KerningProvider.cs
+++ b/src/EPPlus.Fonts.OpenType/TextShaping/Kerning/KerningProvider.cs
@@ -9,6 +9,7 @@
   Date               Author                       Change
  *************************************************************************************************
   01/15/2025         EPPlus Software AB           Initial implementation
+  09/07/2026         EPPlus Software AB           Pass script/language through to GposKerningProvider
  *************************************************************************************************/
 using System;
 using System.Runtime.CompilerServices;
@@ -40,32 +41,38 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Kerning
         }
 
         /// <summary>
-        /// Gets kerning value for a glyph pair.
+        /// Gets kerning value for a glyph pair, restricted to the given script/language.
         /// Returns 0 if no kerning is defined.
         /// </summary>
-        public short GetKerning(ushort leftGlyph, ushort rightGlyph)
+        /// <param name="script">
+        /// OpenType script tag (e.g. "latn"). Pass null to fall back to unfiltered GPOS lookup.
+        /// The legacy kern table has no script concept and is unaffected either way.
+        /// </param>
+        /// <param name="language">OpenType language-system tag, or null for the script's default.</param>
+        public short GetKerning(ushort leftGlyph, ushort rightGlyph, string script, string language)
         {
-            // Check cache first
-            if (_cache.TryGet(leftGlyph, rightGlyph, out short cachedValue))
+            // Cache key must include script: the same glyph pair can legitimately kern
+            // differently (or not at all) depending on which script's GPOS features are active,
+            // and a single KerningProvider instance is reused across many Shape() calls that may
+            // each request a different script.
+            if (_cache.TryGet(leftGlyph, rightGlyph, script, language, out short cachedValue))
                 return cachedValue;
 
-            // Lookup kerning value
-            short kernValue = LookupKerning(leftGlyph, rightGlyph);
+            short kernValue = LookupKerning(leftGlyph, rightGlyph, script, language);
 
-            // Cache result
-            _cache.Set(leftGlyph, rightGlyph, kernValue);
+            _cache.Set(leftGlyph, rightGlyph, script, language, kernValue);
 
             return kernValue;
         }
 
         public void ClearCache() => _cache.Clear();
 
-        private short LookupKerning(ushort leftGlyph, ushort rightGlyph)
+        private short LookupKerning(ushort leftGlyph, ushort rightGlyph, string script, string language)
         {
             // Try GPOS first (modern, preferred)
             if (_gposProvider != null)
             {
-                short gposKern = _gposProvider.GetKerning(leftGlyph, rightGlyph);
+                short gposKern = _gposProvider.GetKerning(leftGlyph, rightGlyph, script, language);
                 if (gposKern != 0)
                     return gposKern;
             }

--- a/src/EPPlus.Fonts.OpenType/TextShaping/Ligatures/LigatureProcessor.cs
+++ b/src/EPPlus.Fonts.OpenType/TextShaping/Ligatures/LigatureProcessor.cs
@@ -9,8 +9,10 @@
   Date               Author                       Change
  *************************************************************************************************
   01/15/2025         EPPlus Software AB           Initial implementation
+  09/07/2026         EPPlus Software AB           Filter by ScriptList/LangSys, not just tag
  *************************************************************************************************/
 using EPPlus.Fonts.OpenType.Tables.Common.Layout.Lookups;
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Scripts;
 using EPPlus.Fonts.OpenType.Tables.Gsub;
 using EPPlus.Fonts.OpenType.Tables.Gsub.Data.Lookups;
 using OfficeOpenXml.Interfaces.Fonts;
@@ -21,7 +23,21 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Ligatures
 {
     internal class LigatureProcessor
     {
-        private readonly List<LookupTable> _ligaLookups;
+        private readonly struct IndexedLookup
+        {
+            public readonly int FeatureIndex;
+            public readonly LookupTable Lookup;
+
+            public IndexedLookup(int featureIndex, LookupTable lookup)
+            {
+                FeatureIndex = featureIndex;
+                Lookup = lookup;
+            }
+        }
+
+        private readonly OpenTypeFont _font;
+        private readonly List<IndexedLookup> _ligaLookups;
+        private readonly Dictionary<string, HashSet<int>> _activeIndexCache = new Dictionary<string, HashSet<int>>();
 
         public LigatureProcessor(OpenTypeFont font)
         {
@@ -32,42 +48,44 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Ligatures
             }
             else
             {
-                _ligaLookups = new List<LookupTable>();
+                _ligaLookups = new List<IndexedLookup>();
             }
         }
-
-        private readonly OpenTypeFont _font;
 
         /// <summary>
         /// Applies standard ligature substitutions (fi, ff, ffi, ffl, etc.).
         /// Processes glyphs left-to-right, replacing sequences with ligature glyphs.
         /// </summary>
-        internal List<ShapedGlyph> ApplyLigatures(List<ShapedGlyph> glyphs)
+        internal List<ShapedGlyph> ApplyLigatures(List<ShapedGlyph> glyphs, string script, string language)
         {
             var gsub = _font.GsubTable;
             if (gsub == null)
                 return glyphs;
 
-            // Find "liga" feature
-            var ligaLookups = FindLookupsForFeature(gsub, "liga");
-            if (ligaLookups.Count == 0)
+            if (_ligaLookups.Count == 0)
                 return glyphs;
 
-            // Apply each lookup in order
-            foreach (var lookup in ligaLookups)
-            {
-                ApplyLigaturesInPlace(glyphs);
-            }
+            ApplyLigaturesInPlace(glyphs, script, language);
 
             return glyphs;
         }
 
-        internal void ApplyLigaturesInPlace(List<ShapedGlyph> glyphs)
+        internal void ApplyLigaturesInPlace(List<ShapedGlyph> glyphs, string script, string language)
         {
             if (_ligaLookups.Count == 0) return;
 
-            foreach (var lookup in _ligaLookups)
+            HashSet<int> activeIndices = GetActiveIndices(script, language);
+
+            foreach (var entry in _ligaLookups)
             {
+                // null activeIndices means "no ScriptList to filter by" - keep every entry,
+                // matching the previous behavior rather than discarding ligatures we cannot resolve.
+                if (activeIndices != null && !activeIndices.Contains(entry.FeatureIndex))
+                {
+                    continue;
+                }
+
+                var lookup = entry.Lookup;
                 if (lookup.LookupType != 4) continue;
 
                 int i = 0;
@@ -82,14 +100,27 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Ligatures
                         if (TryApplyLigatureInPlace(glyphs, i, subtable, out int consumed))
                         {
                             substituted = true;
-                            i += consumed; // Oftast 1 efter ersättning
-                            break;         // Första match vinner – hoppa ur
+                            i += consumed; // Usually 1 after a substitution
+                            break;         // First match wins - break out
                         }
                     }
 
                     if (!substituted) i++;
                 }
             }
+        }
+
+        private HashSet<int> GetActiveIndices(string script, string language)
+        {
+            string cacheKey = (script ?? string.Empty) + "|" + (language ?? string.Empty);
+
+            if (!_activeIndexCache.TryGetValue(cacheKey, out var indices))
+            {
+                indices = ScriptFeatureResolver.GetActiveFeatureIndices(_font.GsubTable?.ScriptList, script, language);
+                _activeIndexCache[cacheKey] = indices;
+            }
+
+            return indices;
         }
 
         private bool TryApplyLigatureInPlace(
@@ -109,7 +140,7 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Ligatures
             if (!subtable.LigatureSets.TryGetValue(first, out var ligSet) || ligSet?.Ligatures.Count == 0)
                 return false;
 
-            // Försök längre ligaturer först (rekommenderas av OpenType-spec)
+            // Try longer ligatures first, as recommended by the OpenType spec
             var sortedLigs = ligSet.Ligatures
                 .OrderByDescending(l => 1 + (l.Components?.Length ?? 0))
                 .ToList();
@@ -133,11 +164,11 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Ligatures
                 {
                     var ligGlyph = CreateLigatureGlyph(glyphs, startIndex, (byte)compCount, lig.LigatureGlyph);
 
-                    // MUTERA DIREKT
+                    // MUTATE IN PLACE
                     glyphs.RemoveRange(startIndex, compCount);
                     glyphs.Insert(startIndex, ligGlyph);
 
-                    componentsConsumed = 1; // ligatur tar platsen → nästa steg flyttar förbi den
+                    componentsConsumed = 1; // the ligature takes its place - the next step moves past it
                     return true;
                 }
             }
@@ -147,27 +178,35 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Ligatures
 
 
         /// <summary>
-        /// Finds all lookups associated with a feature tag.
+        /// Finds all lookups associated with a feature tag, together with each one's original
+        /// FeatureList index, across all scripts. Two FeatureRecords can legitimately share a
+        /// tag (one per script); both are kept so ApplyLigaturesInPlace can filter by script at
+        /// call time instead of the constructor baking in whichever script happened to be active
+        /// when this processor was built.
         /// </summary>
-        private List<LookupTable> FindLookupsForFeature(GsubTable gsub, string featureTag)
+        private List<IndexedLookup> FindLookupsForFeature(GsubTable gsub, string featureTag)
         {
-            var lookups = new List<LookupTable>();
+            var lookups = new List<IndexedLookup>();
 
             if (gsub?.FeatureList?.FeatureRecords == null)
                 return lookups;
 
-            foreach (var featureRecord in gsub.FeatureList.FeatureRecords)
-            {
-                if (featureRecord.FeatureTag.Value == featureTag)
-                {
-                    var feature = featureRecord.FeatureTable;
+            var featureRecords = gsub.FeatureList.FeatureRecords;
 
-                    foreach (var lookupIndex in feature.LookupListIndices)
+            for (int featureIndex = 0; featureIndex < featureRecords.Count; featureIndex++)
+            {
+                var featureRecord = featureRecords[featureIndex];
+
+                if (featureRecord.FeatureTag.Value != featureTag)
+                    continue;
+
+                var feature = featureRecord.FeatureTable;
+
+                foreach (var lookupIndex in feature.LookupListIndices)
+                {
+                    if (lookupIndex < gsub.LookupList.Lookups.Count)
                     {
-                        if (lookupIndex < gsub.LookupList.Lookups.Count)
-                        {
-                            lookups.Add(gsub.LookupList.Lookups[lookupIndex]);
-                        }
+                        lookups.Add(new IndexedLookup(featureIndex, gsub.LookupList.Lookups[lookupIndex]));
                     }
                 }
             }
@@ -191,8 +230,8 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Ligatures
             return new ShapedGlyph
             {
                 GlyphId = ligatureGlyphId,
-                BaseAdvance = baseAdvance,      // ← Base advance for ligature
-                XAdvance = baseAdvance,         // ← Will be adjusted by positioning
+                BaseAdvance = baseAdvance,      // Base advance for ligature
+                XAdvance = baseAdvance,         // Will be adjusted by positioning
                 YAdvance = 0,
                 XOffset = 0,
                 YOffset = 0,

--- a/src/EPPlus.Fonts.OpenType/TextShaping/Positioning/MarkToBaseProvider.cs
+++ b/src/EPPlus.Fonts.OpenType/TextShaping/Positioning/MarkToBaseProvider.cs
@@ -9,7 +9,10 @@
   Date               Author                       Change
  *************************************************************************************************
   01/20/2025         EPPlus Software AB           Mark-to-Base positioning
+  09/07/2026         EPPlus Software AB           Pen-relative, additive mark offsets
+  09/07/2026         EPPlus Software AB           Filter by ScriptList/LangSys, not just tag
  *************************************************************************************************/
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Scripts;
 using EPPlus.Fonts.OpenType.Tables.Gpos;
 using EPPlus.Fonts.OpenType.Tables.Gpos.Data.Lookups.LookupType4;
 using OfficeOpenXml.Interfaces.Fonts;
@@ -24,17 +27,33 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Positioning
     /// </summary>
     internal class MarkToBaseProvider
     {
-        private readonly List<MarkToBaseSubTableFormat1> _subtables;
+        private readonly struct IndexedSubtable
+        {
+            public readonly int FeatureIndex;
+            public readonly MarkToBaseSubTableFormat1 Subtable;
+
+            public IndexedSubtable(int featureIndex, MarkToBaseSubTableFormat1 subtable)
+            {
+                FeatureIndex = featureIndex;
+                Subtable = subtable;
+            }
+        }
+
+        private readonly GposTable _gpos;
+        private readonly List<IndexedSubtable> _subtables;
+        private readonly Dictionary<string, HashSet<int>> _activeIndexCache = new Dictionary<string, HashSet<int>>();
 
         public MarkToBaseProvider(OpenTypeFont font)
         {
-            if (font.GposTable != null)
+            _gpos = font.GposTable;
+
+            if (_gpos != null)
             {
-                _subtables = FindAllMarkToBaseSubtables(font.GposTable);
+                _subtables = FindAllMarkToBaseSubtables(_gpos);
             }
             else
             {
-                _subtables = new List<MarkToBaseSubTableFormat1>();
+                _subtables = new List<IndexedSubtable>();
             }
         }
 
@@ -43,10 +62,17 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Positioning
         /// Marks are positioned relative to the preceding base glyph.
         /// </summary>
         /// <param name="glyphs">List of shaped glyphs to process</param>
-        public void ApplyMarkPositioning(List<ShapedGlyph> glyphs)
+        /// <param name="script">
+        /// OpenType script tag (e.g. "latn"). Pass null to fall back to unfiltered lookup, which
+        /// reproduces the previous behavior for callers that have no script to give.
+        /// </param>
+        /// <param name="language">OpenType language-system tag, or null for the script's default.</param>
+        public void ApplyMarkPositioning(List<ShapedGlyph> glyphs, string script, string language)
         {
             if (_subtables.Count == 0 || glyphs.Count < 2)
                 return;
+
+            HashSet<int> activeIndices = GetActiveIndices(script, language);
 
             // Process glyphs left-to-right
             for (int i = 1; i < glyphs.Count; i++)
@@ -54,18 +80,35 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Positioning
                 var baseGlyph = glyphs[i - 1];
                 var markGlyph = glyphs[i];
 
-                bool positioned = false;
-
-                // Try each subtable until we find positioning
-                foreach (var subtable in _subtables)
+                // Try each subtable reachable from the active script until we find positioning
+                foreach (var entry in _subtables)
                 {
-                    if (TryPositionMark(subtable, baseGlyph, markGlyph))
+                    // null activeIndices means "no ScriptList to filter by" - keep every entry,
+                    // matching the previous behavior rather than discarding marks we cannot resolve.
+                    if (activeIndices != null && !activeIndices.Contains(entry.FeatureIndex))
                     {
-                        positioned = true;
+                        continue;
+                    }
+
+                    if (TryPositionMark(entry.Subtable, baseGlyph, markGlyph))
+                    {
                         break;
                     }
                 }
             }
+        }
+
+        private HashSet<int> GetActiveIndices(string script, string language)
+        {
+            string cacheKey = (script ?? string.Empty) + "|" + (language ?? string.Empty);
+
+            if (!_activeIndexCache.TryGetValue(cacheKey, out var indices))
+            {
+                indices = ScriptFeatureResolver.GetActiveFeatureIndices(_gpos?.ScriptList, script, language);
+                _activeIndexCache[cacheKey] = indices;
+            }
+
+            return indices;
         }
 
         /// <summary>
@@ -105,14 +148,19 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Positioning
             if (baseAnchor == null || markAnchor == null)
                 return false;
 
-            // Calculate mark position relative to base
-            // Mark is positioned so its anchor aligns with base anchor
-            var xOffset = baseAnchor.XCoordinate - markAnchor.XCoordinate;
+            // Calculate mark position relative to the PEN, not to the base glyph's origin
+            // (HarfBuzz convention). The pen has already moved by the base glyph's advance when
+            // the mark is drawn, so that advance has to be taken back out of the offset.
+            // baseGlyph.XAdvance is used rather than the raw hmtx advance because kerning has
+            // already been applied at this point - ApplyPositioning orders SinglePos, then
+            // kerning, then mark positioning.
+            var xOffset = baseAnchor.XCoordinate - markAnchor.XCoordinate - baseGlyph.XAdvance;
             var yOffset = baseAnchor.YCoordinate - markAnchor.YCoordinate;
 
-            // Apply positioning to mark glyph
-            markGlyph.XOffset = (short)xOffset;
-            markGlyph.YOffset = (short)yOffset;
+            // Accumulate rather than assign, so an XPlacement/YPlacement already written by
+            // SinglePos (TextShaper, ApplyValueRecord) is not discarded.
+            markGlyph.XOffset += (short)xOffset;
+            markGlyph.YOffset += (short)yOffset;
 
             // Mark should not advance (it's positioned over base)
             markGlyph.XAdvance = 0;
@@ -122,34 +170,43 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Positioning
         }
 
         /// <summary>
-        /// Finds all Mark-to-Base subtables in the "mark" feature.
+        /// Finds all Mark-to-Base subtables in "mark"-tagged FeatureRecords, together with each
+        /// one's original FeatureList index, across all scripts. Two FeatureRecords can
+        /// legitimately share the "mark" tag (one per script); both are kept so
+        /// ApplyMarkPositioning can filter by script at call time.
         /// </summary>
-        private List<MarkToBaseSubTableFormat1> FindAllMarkToBaseSubtables(GposTable gpos)
+        private List<IndexedSubtable> FindAllMarkToBaseSubtables(GposTable gpos)
         {
-            var subtables = new List<MarkToBaseSubTableFormat1>();
-            if (gpos == null)
+            var subtables = new List<IndexedSubtable>();
+
+            if (gpos?.FeatureList == null)
                 return subtables;
 
-            foreach (var featureRecord in gpos.FeatureList.FeatureRecords)
+            var featureRecords = gpos.FeatureList.FeatureRecords;
+
+            for (int featureIndex = 0; featureIndex < featureRecords.Count; featureIndex++)
             {
-                if (featureRecord.FeatureTag.Value == "mark")
+                var featureRecord = featureRecords[featureIndex];
+
+                if (featureRecord.FeatureTag.Value != "mark")
+                    continue;
+
+                var feature = featureRecord.FeatureTable;
+
+                foreach (var lookupIndex in feature.LookupListIndices)
                 {
-                    var feature = featureRecord.FeatureTable;
+                    if (lookupIndex >= gpos.LookupList.Lookups.Count)
+                        continue;
 
-                    foreach (var lookupIndex in feature.LookupListIndices)
+                    var lookup = gpos.LookupList.Lookups[lookupIndex];
+
+                    // Only the subtable content is checked, not LookupType - extension wrapped
+                    // (type 9) mark lookups are unwrapped by GposTableLoader but keep LookupType 9.
+                    foreach (var subtable in lookup.SubTables)
                     {
-                        if (lookupIndex >= gpos.LookupList.Lookups.Count)
-                            continue;
-
-                        var lookup = gpos.LookupList.Lookups[lookupIndex];
-
-                        // ✅ Kolla bara innehållet, ignorera LookupType
-                        foreach (var subtable in lookup.SubTables)
+                        if (subtable is MarkToBaseSubTableFormat1 markToBase)
                         {
-                            if (subtable is MarkToBaseSubTableFormat1 markToBase)
-                            {
-                                subtables.Add(markToBase);
-                            }
+                            subtables.Add(new IndexedSubtable(featureIndex, markToBase));
                         }
                     }
                 }

--- a/src/EPPlus.Fonts.OpenType/TextShaping/Positioning/SingleAdjustmentProvider.cs
+++ b/src/EPPlus.Fonts.OpenType/TextShaping/Positioning/SingleAdjustmentProvider.cs
@@ -1,4 +1,17 @@
-﻿using EPPlus.Fonts.OpenType.Tables.Gpos;
+﻿/*************************************************************************************************
+  Required Notice: Copyright (C) EPPlus Software AB. 
+  This software is licensed under PolyForm Noncommercial License 1.0.0 
+  and may only be used for noncommercial purposes 
+  https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+  A commercial license to use this software can be purchased at https://epplussoftware.com
+ *************************************************************************************************
+  Date               Author                       Change
+ *************************************************************************************************
+  09/07/2026         EPPlus Software AB           Filter by ScriptList/LangSys, not just tag
+ *************************************************************************************************/
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Scripts;
+using EPPlus.Fonts.OpenType.Tables.Gpos;
 using EPPlus.Fonts.OpenType.Tables.Gpos.Data.Lookups;
 using EPPlus.Fonts.OpenType.Tables.Gpos.Data.Lookups.LookupType1;
 using System.Collections.Generic;
@@ -11,28 +24,63 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Positioning
     /// </summary>
     internal class SingleAdjustmentProvider
     {
+        /// <summary>
+        /// A subtable together with the FeatureList index it was recorded under. A plain struct
+        /// is used instead of ValueTuple to avoid depending on the System.ValueTuple package on
+        /// net462, which is not confirmed to be referenced by this project.
+        /// </summary>
+        private readonly struct IndexedSubtable
+        {
+            public readonly int FeatureIndex;
+            public readonly GposSubTableBase Subtable;
+
+            public IndexedSubtable(int featureIndex, GposSubTableBase subtable)
+            {
+                FeatureIndex = featureIndex;
+                Subtable = subtable;
+            }
+        }
+
         private readonly OpenTypeFont _font;
-        private readonly Dictionary<string, List<GposSubTableBase>> _subtablesByFeature;
+        private readonly GposTable _gpos;
+
+        // Feature tag -> every (FeatureList index, subtable) pair recorded under that tag, across
+        // ALL scripts. The FeatureList index is what lets TryGetAdjustment filter down to the
+        // ones the requested script can actually reach - unlike the tag alone, which collapses
+        // every script's data for the same tag into one bucket.
+        private readonly Dictionary<string, List<IndexedSubtable>> _subtablesByFeature;
+
+        // Active-index sets are per (script, language), not per font, so they are cached
+        // separately rather than recomputed on every call - a TextShaper instance is reused
+        // across many Shape() calls that may each specify a different script.
+        private readonly Dictionary<string, HashSet<int>> _activeIndexCache = new Dictionary<string, HashSet<int>>();
 
         public SingleAdjustmentProvider(OpenTypeFont font)
         {
             _font = font;
-            _subtablesByFeature = new Dictionary<string, List<GposSubTableBase>>();
+            _gpos = font?.GposTable;
+            _subtablesByFeature = new Dictionary<string, List<IndexedSubtable>>();
 
-            if (font?.GposTable != null)
+            if (_gpos != null)
             {
-                BuildFeatureMap(font.GposTable);
+                BuildFeatureMap(_gpos);
             }
         }
 
         /// <summary>
-        /// Tries to get positioning adjustment for a single glyph using specified features.
+        /// Tries to get positioning adjustment for a single glyph using specified features,
+        /// restricted to the features reachable from the given script and language.
         /// </summary>
         /// <param name="glyphId">The glyph ID to look up</param>
-        /// <param name="features">List of feature tags to search (e.g., ["kern"])</param>
+        /// <param name="features">List of feature tags to search (e.g., [\"kern\"])</param>
+        /// <param name="script">
+        /// OpenType script tag (e.g. "latn"). Pass null to fall back to unfiltered lookup, which
+        /// reproduces the previous behavior for callers that have no script to give.
+        /// </param>
+        /// <param name="language">OpenType language-system tag, or null for the script's default.</param>
         /// <param name="value">The ValueRecord if found</param>
         /// <returns>True if an adjustment was found</returns>
-        public bool TryGetAdjustment(ushort glyphId, List<string> features, out ValueRecord value)
+        public bool TryGetAdjustment(ushort glyphId, List<string> features, string script, string language, out ValueRecord value)
         {
             if (features == null || features.Count == 0)
             {
@@ -41,23 +89,46 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Positioning
                 return false;
             }
 
-            // Search in specified features
+            HashSet<int> activeIndices = GetActiveIndices(script, language);
+
             foreach (var feature in features)
             {
-                if (_subtablesByFeature.TryGetValue(feature, out var subtables))
+                if (!_subtablesByFeature.TryGetValue(feature, out var entries))
                 {
-                    foreach (var subtable in subtables)
+                    continue;
+                }
+
+                foreach (var entry in entries)
+                {
+                    // null activeIndices means "no ScriptList to filter by" - keep every entry,
+                    // matching the previous behavior rather than discarding features we cannot resolve.
+                    if (activeIndices != null && !activeIndices.Contains(entry.FeatureIndex))
                     {
-                        if (TryGetAdjustmentFromSubtable(subtable, glyphId, out value))
-                        {
-                            return true;
-                        }
+                        continue;
+                    }
+
+                    if (TryGetAdjustmentFromSubtable(entry.Subtable, glyphId, out value))
+                    {
+                        return true;
                     }
                 }
             }
 
             value = null;
             return false;
+        }
+
+        private HashSet<int> GetActiveIndices(string script, string language)
+        {
+            string cacheKey = (script ?? string.Empty) + "|" + (language ?? string.Empty);
+
+            if (!_activeIndexCache.TryGetValue(cacheKey, out var indices))
+            {
+                indices = ScriptFeatureResolver.GetActiveFeatureIndices(_gpos?.ScriptList, script, language);
+                _activeIndexCache[cacheKey] = indices;
+            }
+
+            return indices;
         }
 
         private bool TryGetAdjustmentFromSubtable(GposSubTableBase subtable, ushort glyphId, out ValueRecord value)
@@ -78,22 +149,27 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Positioning
         }
 
         /// <summary>
-        /// Builds a map of feature tags to their Single Adjustment subtables.
+        /// Builds a map of feature tags to their Single Adjustment subtables, keeping each
+        /// subtable's original FeatureList index so TryGetAdjustment can filter by script later.
+        /// Unlike the previous version, entries are APPENDED rather than overwritten per tag: two
+        /// FeatureRecords can legitimately share a tag (one per script), and both must survive so
+        /// the script filter has something to choose between at lookup time.
         /// </summary>
         private void BuildFeatureMap(GposTable gpos)
         {
             if (gpos?.FeatureList == null || gpos.LookupList == null)
                 return;
 
-            foreach (var featureRecord in gpos.FeatureList.FeatureRecords)
+            var featureRecords = gpos.FeatureList.FeatureRecords;
+
+            for (int featureIndex = 0; featureIndex < featureRecords.Count; featureIndex++)
             {
+                var featureRecord = featureRecords[featureIndex];
                 string featureTag = featureRecord.FeatureTag.Value;
                 var feature = featureRecord.FeatureTable;
 
                 if (feature?.LookupListIndices == null)
                     continue;
-
-                var subtables = new List<GposSubTableBase>();
 
                 foreach (var lookupIndex in feature.LookupListIndices)
                 {
@@ -109,15 +185,16 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Positioning
                         {
                             if (subtable is SinglePosSubTableFormat1 || subtable is SinglePosSubTableFormat2)
                             {
-                                subtables.Add((GposSubTableBase)subtable);
+                                if (!_subtablesByFeature.TryGetValue(featureTag, out var list))
+                                {
+                                    list = new List<IndexedSubtable>();
+                                    _subtablesByFeature[featureTag] = list;
+                                }
+
+                                list.Add(new IndexedSubtable(featureIndex, (GposSubTableBase)subtable));
                             }
                         }
                     }
-                }
-
-                if (subtables.Count > 0)
-                {
-                    _subtablesByFeature[featureTag] = subtables;
                 }
             }
         }

--- a/src/EPPlus.Fonts.OpenType/TextShaping/Substitutions/SingleSubstitutionProcessor.cs
+++ b/src/EPPlus.Fonts.OpenType/TextShaping/Substitutions/SingleSubstitutionProcessor.cs
@@ -9,7 +9,9 @@
   Date               Author                       Change
  *************************************************************************************************
   01/19/2026         EPPlus Software AB           GSUB Single Substitution support
+  09/07/2026         EPPlus Software AB           Filter by ScriptList/LangSys, not just tag
  *************************************************************************************************/
+using EPPlus.Fonts.OpenType.Tables.Common.Layout.Scripts;
 using EPPlus.Fonts.OpenType.Tables.Gsub;
 using EPPlus.Fonts.OpenType.Tables.Gsub.Data.Lookups;
 using OfficeOpenXml.Interfaces.Fonts;
@@ -23,15 +25,33 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Substitutions
     /// </summary>
     internal class SingleSubstitutionProcessor
     {
+        private readonly struct IndexedSubtable
+        {
+            public readonly int FeatureIndex;
+            public readonly SingleSubstSubTable Subtable;
+
+            public IndexedSubtable(int featureIndex, SingleSubstSubTable subtable)
+            {
+                FeatureIndex = featureIndex;
+                Subtable = subtable;
+            }
+        }
+
         private readonly OpenTypeFont _font;
         private readonly GsubTable _gsubTable;
-        private readonly Dictionary<string, List<SingleSubstSubTable>> _featureSubtables;
+
+        // Feature tag -> every (FeatureList index, subtable) pair recorded under that tag, across
+        // ALL scripts. The FeatureList index lets ApplySubstitutions filter down to the ones the
+        // requested script can actually reach - unlike the tag alone, which collapses every
+        // script's data for the same tag into one bucket.
+        private readonly Dictionary<string, List<IndexedSubtable>> _featureSubtables;
+        private readonly Dictionary<string, HashSet<int>> _activeIndexCache = new Dictionary<string, HashSet<int>>();
 
         public SingleSubstitutionProcessor(OpenTypeFont font)
         {
             _font = font;
             _gsubTable = font?.GsubTable;
-            _featureSubtables = new Dictionary<string, List<SingleSubstSubTable>>();
+            _featureSubtables = new Dictionary<string, List<IndexedSubtable>>();
 
             if (_gsubTable != null)
             {
@@ -40,13 +60,19 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Substitutions
         }
 
         /// <summary>
-        /// Applies single substitution to the glyph list.
+        /// Applies single substitution to the glyph list, restricted to the features reachable
+        /// from the given script and language.
         /// This processes all glyphs and replaces them according to the active features.
         /// </summary>
         /// <param name="glyphs">List of shaped glyphs to process</param>
         /// <param name="activeFeatures">List of feature tags to apply (e.g., "smcp", "onum")</param>
+        /// <param name="script">
+        /// OpenType script tag (e.g. "latn"). Pass null to fall back to unfiltered lookup, which
+        /// reproduces the previous behavior for callers that have no script to give.
+        /// </param>
+        /// <param name="language">OpenType language-system tag, or null for the script's default.</param>
         /// <returns>Modified glyph list with substitutions applied</returns>
-        public List<ShapedGlyph> ApplySubstitutions(List<ShapedGlyph> glyphs, List<string> activeFeatures)
+        public List<ShapedGlyph> ApplySubstitutions(List<ShapedGlyph> glyphs, List<string> activeFeatures, string script, string language)
         {
             if (glyphs == null || glyphs.Count == 0)
                 return glyphs;
@@ -54,13 +80,28 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Substitutions
             if (activeFeatures == null || activeFeatures.Count == 0)
                 return glyphs;
 
+            HashSet<int> activeIndices = GetActiveIndices(script, language);
+
             // Collect all subtables for the active features
             var subtablesToApply = new List<SingleSubstSubTable>();
             foreach (var feature in activeFeatures)
             {
-                if (_featureSubtables.TryGetValue(feature, out var subtables))
+                if (!_featureSubtables.TryGetValue(feature, out var entries))
                 {
-                    subtablesToApply.AddRange(subtables);
+                    continue;
+                }
+
+                foreach (var entry in entries)
+                {
+                    // null activeIndices means "no ScriptList to filter by" - keep every entry,
+                    // matching the previous behavior rather than discarding features we cannot
+                    // resolve.
+                    if (activeIndices != null && !activeIndices.Contains(entry.FeatureIndex))
+                    {
+                        continue;
+                    }
+
+                    subtablesToApply.Add(entry.Subtable);
                 }
             }
 
@@ -75,20 +116,33 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Substitutions
                 // Try to find a substitution for this glyph in the active subtables
                 if (TryGetSubstitution(originalGlyphId, subtablesToApply, out ushort newGlyphId))
                 {
-                    // ✅ FIX: Update both GlyphId AND BaseAdvance for the new glyph
+                    // Update both GlyphId and BaseAdvance for the new glyph
                     var glyph = glyphs[i];
                     glyph.GlyphId = newGlyphId;
 
                     // Get the new glyph's advance width from hmtx
                     var newAdvance = (short)_font.HmtxTable.GetAdvanceWidth(newGlyphId);
-                    glyph.BaseAdvance = newAdvance;  // ✅ Update base advance
-                    glyph.XAdvance = newAdvance;     // ✅ Reset to base (kerning will be reapplied)
+                    glyph.BaseAdvance = newAdvance;  // Update base advance
+                    glyph.XAdvance = newAdvance;     // Reset to base (kerning will be reapplied)
 
                     glyphs[i] = glyph;
                 }
             }
 
             return glyphs;
+        }
+
+        private HashSet<int> GetActiveIndices(string script, string language)
+        {
+            string cacheKey = (script ?? string.Empty) + "|" + (language ?? string.Empty);
+
+            if (!_activeIndexCache.TryGetValue(cacheKey, out var indices))
+            {
+                indices = ScriptFeatureResolver.GetActiveFeatureIndices(_gsubTable?.ScriptList, script, language);
+                _activeIndexCache[cacheKey] = indices;
+            }
+
+            return indices;
         }
 
         /// <summary>
@@ -122,22 +176,23 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Substitutions
         }
 
         /// <summary>
-        /// Builds a map of feature tags to their Single Substitution subtables.
-        /// This allows us to only apply substitutions for active features.
+        /// Builds a map of feature tags to their Single Substitution subtables, keeping each
+        /// subtable's original FeatureList index so ApplySubstitutions can filter by script later.
+        /// Entries are APPENDED rather than overwritten per tag: two FeatureRecords can
+        /// legitimately share a tag (one per script), and both must survive so the script filter
+        /// has something to choose between at lookup time.
         /// </summary>
         private void BuildFeatureSubtableMap()
         {
             if (_gsubTable?.FeatureList?.FeatureRecords == null)
                 return;
 
-            foreach (var featureRecord in _gsubTable.FeatureList.FeatureRecords)
-            {
-                string featureTag = featureRecord.FeatureTag.Value;
+            var featureRecords = _gsubTable.FeatureList.FeatureRecords;
 
-                if (!_featureSubtables.ContainsKey(featureTag))
-                {
-                    _featureSubtables[featureTag] = new List<SingleSubstSubTable>();
-                }
+            for (int featureIndex = 0; featureIndex < featureRecords.Count; featureIndex++)
+            {
+                var featureRecord = featureRecords[featureIndex];
+                string featureTag = featureRecord.FeatureTag.Value;
 
                 var feature = featureRecord.FeatureTable;
 
@@ -154,7 +209,13 @@ namespace EPPlus.Fonts.OpenType.TextShaping.Substitutions
                             {
                                 if (subtable is SingleSubstSubTable singleSubst)
                                 {
-                                    _featureSubtables[featureTag].Add(singleSubst);
+                                    if (!_featureSubtables.TryGetValue(featureTag, out var list))
+                                    {
+                                        list = new List<IndexedSubtable>();
+                                        _featureSubtables[featureTag] = list;
+                                    }
+
+                                    list.Add(new IndexedSubtable(featureIndex, singleSubst));
                                 }
                             }
                         }

--- a/src/EPPlus.Fonts.OpenType/TextShaping/TextShaper.cs
+++ b/src/EPPlus.Fonts.OpenType/TextShaping/TextShaper.cs
@@ -457,19 +457,19 @@ namespace EPPlus.Fonts.OpenType.TextShaping
             // Phase 1: Single Substitution (Type 1)
             if (options.GsubFeatures != null && options.GsubFeatures.Count > 0)
             {
-                glyphs = _singleSubstitutionProcessor.ApplySubstitutions(glyphs, options.GsubFeatures);
+                glyphs = _singleSubstitutionProcessor.ApplySubstitutions(glyphs, options.GsubFeatures, options.Script, options.Language);
             }
 
             // Phase 2: Chaining Contextual Substitution (Type 6)
             if (options.GsubFeatures != null && options.GsubFeatures.Contains("liga"))
             {
-                glyphs = _chainingContextualProcessor.ApplyContextualSubstitutions(glyphs, "liga");
+                glyphs = _chainingContextualProcessor.ApplyContextualSubstitutions(glyphs, "liga", options.Script, options.Language);
             }
 
             // Phase 3: Simple Ligatures (Type 4)
             if (options.GsubFeatures != null && options.GsubFeatures.Contains("liga"))
             {
-                _ligatureProcessor.ApplyLigaturesInPlace(glyphs);
+                _ligatureProcessor.ApplyLigaturesInPlace(glyphs, options.Script, options.Language);
             }
 
             return glyphs;
@@ -499,11 +499,11 @@ namespace EPPlus.Fonts.OpenType.TextShaping
             // Phase 2: Kerning (GPOS Type 2 / kern table) - primary font only
             if (applyAllFeatures || (options.GposFeatures != null && options.GposFeatures.Contains("kern")))
             {
-                ApplyKerning(glyphs);
+                ApplyKerning(glyphs, options);
             }
 
             // Phase 3: Mark-to-Base positioning (GPOS Type 4) - primary font only
-            _markToBaseProvider.ApplyMarkPositioning(glyphs);
+            _markToBaseProvider.ApplyMarkPositioning(glyphs, options.Script, options.Language);
         }
 
         /// <summary>
@@ -522,7 +522,7 @@ namespace EPPlus.Fonts.OpenType.TextShaping
 
                 ushort glyphId = glyphs[i].GlyphId;
 
-                if (_singleAdjustmentProvider.TryGetAdjustment(glyphId, features, out var valueRecord))
+                if (_singleAdjustmentProvider.TryGetAdjustment(glyphId, features, options.Script, options.Language, out var valueRecord))
                 {
                     var glyph = glyphs[i];
 
@@ -544,7 +544,7 @@ namespace EPPlus.Fonts.OpenType.TextShaping
         /// Applies kerning adjustments to glyph pairs.
         /// Only kerns between primary font glyphs (FontId == 0).
         /// </summary>
-        private void ApplyKerning(List<ShapedGlyph> glyphs)
+        private void ApplyKerning(List<ShapedGlyph> glyphs, ShapingOptions options)
         {
             for (int i = 1; i < glyphs.Count; i++)
             {
@@ -555,7 +555,7 @@ namespace EPPlus.Fonts.OpenType.TextShaping
                 ushort leftGlyph = glyphs[i - 1].GlyphId;
                 ushort rightGlyph = glyphs[i].GlyphId;
 
-                short kernValue = _kerningProvider.GetKerning(leftGlyph, rightGlyph);
+                short kernValue = _kerningProvider.GetKerning(leftGlyph, rightGlyph, options.Script, options.Language);
 
                 if (kernValue != 0)
                 {
@@ -674,7 +674,7 @@ namespace EPPlus.Fonts.OpenType.TextShaping
 
             if (options.ApplyPositioning)
             {
-                ApplyKerningOnly(glyphs);
+                ApplyKerningOnly(glyphs, options);
             }
 
             return new ShapedLightText
@@ -693,7 +693,7 @@ namespace EPPlus.Fonts.OpenType.TextShaping
             return BuildFontUnitsPerEm();
         }
 
-        private void ApplyKerningOnly(List<ShapedGlyph> glyphs)
+        private void ApplyKerningOnly(List<ShapedGlyph> glyphs, ShapingOptions options)
         {
             for (int i = 1; i < glyphs.Count; i++)
             {
@@ -704,7 +704,7 @@ namespace EPPlus.Fonts.OpenType.TextShaping
                 ushort leftGlyph = glyphs[i - 1].GlyphId;
                 ushort rightGlyph = glyphs[i].GlyphId;
 
-                short kernValue = _kerningProvider.GetKerning(leftGlyph, rightGlyph);
+                short kernValue = _kerningProvider.GetKerning(leftGlyph, rightGlyph, options.Script, options.Language);
 
                 if (kernValue != 0)
                 {


### PR DESCRIPTION
## Summary

Renders mark-to-base positioning (`XOffset`/`YOffset`) in the PDF output,
and makes GPOS/GSUB feature lookup respect `ScriptList`/`LangSys` instead
of matching feature tags across all scripts.

## Problem

`MarkToBaseProvider` computed offsets that no renderer read, so
decomposed diacritics (e.g. `A` + U+0301) rendered on the pen with no
offset. Separately, every GSUB/GSUB processor iterated
`FeatureList.FeatureRecords` directly, so a feature reachable only
through one script's `LangSys` could apply to text in a different
script. Verified in Calibri Bold: a `kern`-tagged `SinglePos` reachable
only via `arab` gave the Latin `period` glyph an unwanted `YPlacement`
of 168 font units. This was invisible until offsets were rendered,
which is why the two fixes ship together.

## Changes

- `MarkToBaseProvider`: pen-relative, additive offsets (HarfBuzz
  convention).
- `PdfContentStream`: reads `XOffset`/`YOffset` via `Ts` (vertical) and
  paired `TJ` adjustments (horizontal).
- New `ScriptFeatureResolver` resolves active `FeatureList` indices per
  script/language.
- All six GPOS/GSUB feature-lookup call sites (kerning, single
  adjustment, mark-to-base, ligatures, chaining contextual, single
  substitution) now filter by script.

## Verification

Confirmed in an exported PDF (`WP1KerningRepro.pdf`): decomposed `Á`
now aligns with its precomposed control glyph, and the previously
leaking `period` no longer receives a `Ts` offset. Unit tests cover the
script-leak defect directly for three of the six providers via a
synthetic `GposTable`.

## Known gaps

- Measurement-path/render-path parity (WP1's last acceptance
  criterion) is still unverified.